### PR TITLE
Added github/travis CI tests to repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,14 @@ env:
   global:
     - DOCKER_IMAGE="rootproject/root-ubuntu16"
     - DOCKER_CONTAINER="root-docker"
-    - DOCKER_CMD="docker exec -i $DOCKER_CONTAINER /bin/bash -c"
+    - LIBPATH_ORIG='\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}'
+    - LIBPATH_ROOT='\`root-config --libdir\`'
+    - LIBPATH_BAT='\${BATINSTALLDIR}\${BATINSTALLDIR:+/lib:}'
     - KLF_CMAKE_OPTS="-DBUILTIN_BAT=TRUE -DKLFITTER_INSTALL_TESTS=TRUE"
     - KLF_SOURCE_DIR=$TRAVIS_BUILD_DIR
     - KLF_BUILD_DIR=$TRAVIS_BUILD_DIR/build
+    - DOCKER_CMD="docker exec -i $DOCKER_CONTAINER /bin/bash -c"
+    - CMD_EXPORT_LIBPATH="export LD_LIBRARY_PATH=${LIBPATH_ORIG}${LIBPATH_ROOT}${LIBPATH_BAT}"
 
 before_install:
   - docker pull $DOCKER_IMAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ jobs:
         - mkdir -p $KLF_BUILD_DIR
         - $CMD_DOCKER "cd ${KLF_BUILD_DIR} && cmake ${KLF_CMAKE_OPTS} ${KLF_SOURCE_DIR}"
         - $CMD_DOCKER "cd ${KLF_BUILD_DIR} && make -j"
-        - $CMD_DOCKER "${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR}"
+        - $CMD_DOCKER "${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
+        - diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt
     - env:
         - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DKLFITTER_INSTALL_TESTS=TRUE"
         - KLF_SOURCE_DIR=$KLF_SOURCE_DIR/KLFitter
@@ -44,11 +45,13 @@ jobs:
         - $CMD_DOCKER "${KLF_SOURCE_DIR}/cmake/CompileBAT.sh \$PWD/BAT-0.9.4.1.tar.gz ${BATINSTALLDIR}"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && cmake ${KLF_CMAKE_OPTS} ${KLF_SOURCE_DIR}"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && cd ${KLF_BUILD_DIR} && make -j"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR}"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
+        - diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt
     - script:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $CMD_DOCKER "${KLF_SOURCE_DIR}/cmake/CompileBAT.sh \$PWD/BAT-0.9.4.1.tar.gz ${BATINSTALLDIR}"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j && make -j tests"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j install"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR}"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
+        - diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ jobs:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
-        - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake .."
-        - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && cmake .."
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && make -j"
     - env:
         - BATINSTALLDIR="$TRAVIS_BUILD_DIR/external/BAT"
       script:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
-        - $DOCKER_CMD "make -j"
-        - $DOCKER_CMD "make -j install"
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j"
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - BATINSTALLDIR="$TRAVIS_BUILD_DIR/external/BAT"
     - DOCKER_IMAGE="rootproject/root-ubuntu16"
     - DOCKER_CONTAINER="root-docker"
-    - KLF_CMAKE_OPTS="-DBUILTIN_BAT=TRUE -DKLFITTER_INSTALL_TESTS=TRUE"
+    - KLF_CMAKE_OPTS="-DBUILTIN_BAT=TRUE -DINSTALL_TESTS=TRUE"
     - KLF_SOURCE_DIR="$TRAVIS_BUILD_DIR"
     - KLF_BUILD_DIR="$TRAVIS_BUILD_DIR/build"
     - LIBPATH_ORIG="\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}"
@@ -36,7 +36,7 @@ jobs:
         - $CMD_DOCKER "${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
         - diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt
     - env:
-        - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DKLFITTER_INSTALL_TESTS=TRUE"
+        - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DINSTALL_TESTS=TRUE"
         - KLF_SOURCE_DIR=$KLF_SOURCE_DIR/KLFitter
       script:
         - mkdir -p $KLF_SOURCE_DIR $KLF_BUILD_DIR $BATINSTALLDIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - KLF_SOURCE_DIR=$KLF_SOURCE_DIR/KLFitter
       script:
         - mkdir -p $KLF_SOURCE_DIR $KLF_BUILD_DIR $BATINSTALLDIR
-        - mv CMakeLists.txt cmake data include src tests $KLF_SOURCE_DIR
+        - mv CMakeLists.txt cmake data include src tests util $KLF_SOURCE_DIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $CMD_DOCKER "${KLF_SOURCE_DIR}/cmake/CompileBAT.sh \$PWD/BAT-0.9.4.1.tar.gz ${BATINSTALLDIR}"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && cmake ${KLF_CMAKE_OPTS} ${KLF_SOURCE_DIR}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       script:
         - mkdir -p $KLF_BUILD_DIR
         - $CMD_DOCKER "cd ${KLF_BUILD_DIR} && cmake ${KLF_CMAKE_OPTS} ${KLF_SOURCE_DIR}"
-        - $CMD_DOCKER "cd ${KLF_BUILD_DIR} && make -j"
+        - $CMD_DOCKER "cd ${KLF_BUILD_DIR} && make"
         - $CMD_DOCKER "${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
         - diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt
     - env:
@@ -44,14 +44,14 @@ jobs:
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $CMD_DOCKER "${KLF_SOURCE_DIR}/cmake/CompileBAT.sh \$PWD/BAT-0.9.4.1.tar.gz ${BATINSTALLDIR}"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && cmake ${KLF_CMAKE_OPTS} ${KLF_SOURCE_DIR}"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && cd ${KLF_BUILD_DIR} && make -j"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && cd ${KLF_BUILD_DIR} && make"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
         - diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt
     - script:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $CMD_DOCKER "${KLF_SOURCE_DIR}/cmake/CompileBAT.sh \$PWD/BAT-0.9.4.1.tar.gz ${BATINSTALLDIR}"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j && make -j tests"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j install"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make && make tests"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make install"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
         - diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ env:
     - KLF_CMAKE_OPTS="-DBUILTIN_BAT=TRUE -DKLFITTER_INSTALL_TESTS=TRUE"
     - KLF_SOURCE_DIR=$TRAVIS_BUILD_DIR
     - KLF_BUILD_DIR=$TRAVIS_BUILD_DIR/build
-    - DOCKER_CMD="docker exec -i $DOCKER_CONTAINER /bin/bash -c"
+    - CMD_DOCKER="docker exec -i $DOCKER_CONTAINER /bin/bash -c"
     - CMD_EXPORT_LIBPATH="export LD_LIBRARY_PATH=${LIBPATH_ORIG}${LIBPATH_ROOT}${LIBPATH_BAT}"
 
 before_install:
   - docker pull $DOCKER_IMAGE
   - docker run -i -d --name $DOCKER_CONTAINER -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR -w $TRAVIS_BUILD_DIR -u $(id -u) $DOCKER_IMAGE /bin/bash
   - docker ps -a
-  - $DOCKER_CMD "root -b -q"
+  - $CMD_DOCKER "root -b -q"
   - echo $KLF_SOURCE_DIR
   - echo $KLF_BUILD_DIR
 
@@ -26,9 +26,9 @@ jobs:
   include:
     - script:
         - mkdir -p $KLF_BUILD_DIR
-        - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
-        - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"
-        - $DOCKER_CMD "export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+:}${KLF_BUILD_DIR}/lib && cd $KLF_BUILD_DIR && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "cd $KLF_BUILD_DIR && make -j"
+        - $CMD_DOCKER "export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+:}${KLF_BUILD_DIR}/lib && cd $KLF_BUILD_DIR && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
     - env:
         - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
         - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DKLFITTER_INSTALL_TESTS=TRUE"
@@ -36,17 +36,17 @@ jobs:
       script:
         - mkdir -p $KLF_SOURCE_DIR $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
-        - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
+        - $CMD_DOCKER "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
         - mv CMakeLists.txt cmake data include src tests $KLF_SOURCE_DIR
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && make -j"
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && make -j"
+        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
     - env:
         - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
       script:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
-        - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j && make -j tests"
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j install"
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && echo \$LD_LIBRARY_PATH && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
+        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && make -j && make -j tests"
+        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && make -j install"
+        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && echo \$LD_LIBRARY_PATH && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
         - mkdir -p $KLF_BUILD_DIR
         - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
         - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"
+        - $DOCKER_CMD "cd $KLF_BUILD_DIR && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
     - env:
         - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
         - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DKLFITTER_INSTALL_TESTS=TRUE"
@@ -35,6 +36,7 @@ jobs:
         - mv CMakeLists.txt cmake include src tests $KLF_SOURCE_DIR
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && make -j"
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BATINSTALLDIR/lib && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
     - env:
         - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
       script:
@@ -43,3 +45,4 @@ jobs:
         - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j && make -j tests"
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j install"
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH:$LD_LIBRARY_PATH:$BATINSTALLDIR/lib && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,19 @@ sudo: required
 services: docker
 env:
   global:
+    - BATINSTALLDIR="\$TRAVIS_BUILD_DIR/external/BAT"
     - DOCKER_IMAGE="rootproject/root-ubuntu16"
     - DOCKER_CONTAINER="root-docker"
     - LIBPATH_ORIG='\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}'
-    - LIBPATH_ROOT='\`root-config --libdir\`'
+    - LIBPATH_LOCAL='\$KLF_BUILD_DIR/lib:'
+    - LIBPATH_ROOT='\`root-config --libdir\`:'
     - LIBPATH_BAT='\${BATINSTALLDIR}\${BATINSTALLDIR:+/lib:}'
     - KLF_CMAKE_OPTS="-DBUILTIN_BAT=TRUE -DKLFITTER_INSTALL_TESTS=TRUE"
     - KLF_SOURCE_DIR=$TRAVIS_BUILD_DIR
     - KLF_BUILD_DIR=$TRAVIS_BUILD_DIR/build
     - CMD_DOCKER="docker exec -i $DOCKER_CONTAINER /bin/bash -c"
-    - CMD_EXPORT_LIBPATH="export LD_LIBRARY_PATH=${LIBPATH_ORIG}${LIBPATH_ROOT}${LIBPATH_BAT}"
+    - CMD_EXPORT_BATINSTALL="export BATINSTALLDIR=\$BATINSTALLDIR"
+    - CMD_EXPORT_LIBPATH="export LD_LIBRARY_PATH=${LIBPATH_ORIG}${LIBPATH_ROOT}${LIBPATH_BAT}${LIBPATH_LOCAL}"
 
 before_install:
   - docker pull $DOCKER_IMAGE
@@ -24,13 +27,14 @@ before_install:
 
 jobs:
   include:
-    - script:
+    - env:
+        - BATINSTALLDIR=""
+      script:
         - mkdir -p $KLF_BUILD_DIR
         - $CMD_DOCKER "cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
         - $CMD_DOCKER "cd $KLF_BUILD_DIR && make -j"
-        - $CMD_DOCKER "export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+:}${KLF_BUILD_DIR}/lib && cd $KLF_BUILD_DIR && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "${CMD_EXPORT_LIBPATH} && cd $KLF_BUILD_DIR && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
     - env:
-        - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
         - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DKLFITTER_INSTALL_TESTS=TRUE"
         - KLF_SOURCE_DIR=$KLF_SOURCE_DIR/KLFitter
       script:
@@ -38,15 +42,13 @@ jobs:
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $CMD_DOCKER "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
         - mv CMakeLists.txt cmake data include src tests $KLF_SOURCE_DIR
-        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
-        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && make -j"
-        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
-    - env:
-        - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
-      script:
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && cd $KLF_BUILD_DIR && make -j"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+    - script:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $CMD_DOCKER "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
-        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && make -j && make -j tests"
-        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && make -j install"
-        - $CMD_DOCKER "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && echo \$LD_LIBRARY_PATH && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j && make -j tests"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j install"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - DOCKER_IMAGE="rootproject/root-ubuntu16"
     - DOCKER_CONTAINER="root-docker"
     - DOCKER_CMD="docker exec -i $DOCKER_CONTAINER /bin/bash -c"
+    - KLF_CMAKE_OPTS="-DBUILTIN_BAT=TRUE -DKLFITTER_INSTALL_TESTS=TRUE"
     - KLF_SOURCE_DIR=$TRAVIS_BUILD_DIR
     - KLF_BUILD_DIR=$TRAVIS_BUILD_DIR/build
 
@@ -21,17 +22,18 @@ jobs:
   include:
     - script:
         - mkdir -p $KLF_BUILD_DIR
-        - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake -DBUILTIN_BAT=TRUE $KLF_SOURCE_DIR"
+        - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
         - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"
     - env:
         - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
+        - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DKLFITTER_INSTALL_TESTS=TRUE"
         - KLF_SOURCE_DIR=$KLF_SOURCE_DIR/KLFitter
       script:
         - mkdir -p $KLF_SOURCE_DIR $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
         - mv CMakeLists.txt cmake include src tests $KLF_SOURCE_DIR
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && cmake $KLF_SOURCE_DIR"
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && make -j"
     - env:
         - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
@@ -39,5 +41,5 @@ jobs:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j"
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j && make -j tests"
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ sudo: required
 services: docker
 env:
   global:
-    - BATINSTALLDIR="\$TRAVIS_BUILD_DIR/external/BAT"
+    - BATINSTALLDIR="$TRAVIS_BUILD_DIR/external/BAT"
     - DOCKER_IMAGE="rootproject/root-ubuntu16"
     - DOCKER_CONTAINER="root-docker"
-    - LIBPATH_ORIG='\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}'
-    - LIBPATH_LOCAL='\$KLF_BUILD_DIR/lib:'
-    - LIBPATH_ROOT='\`root-config --libdir\`:'
-    - LIBPATH_BAT='\${BATINSTALLDIR}\${BATINSTALLDIR:+/lib:}'
     - KLF_CMAKE_OPTS="-DBUILTIN_BAT=TRUE -DKLFITTER_INSTALL_TESTS=TRUE"
-    - KLF_SOURCE_DIR=$TRAVIS_BUILD_DIR
-    - KLF_BUILD_DIR=$TRAVIS_BUILD_DIR/build
+    - KLF_SOURCE_DIR="$TRAVIS_BUILD_DIR"
+    - KLF_BUILD_DIR="$TRAVIS_BUILD_DIR/build"
+    - LIBPATH_ORIG="\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}"
+    - LIBPATH_LOCAL="$KLF_BUILD_DIR/lib:"
+    - LIBPATH_ROOT="\`root-config --libdir\`:"
+    - LIBPATH_BAT="${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}"
     - CMD_DOCKER="docker exec -i $DOCKER_CONTAINER /bin/bash -c"
-    - CMD_EXPORT_BATINSTALL="export BATINSTALLDIR=\$BATINSTALLDIR"
+    - CMD_EXPORT_BATINSTALL="export BATINSTALLDIR=${BATINSTALLDIR}"
     - CMD_EXPORT_LIBPATH="export LD_LIBRARY_PATH=${LIBPATH_ORIG}${LIBPATH_ROOT}${LIBPATH_BAT}${LIBPATH_LOCAL}"
 
 before_install:
@@ -31,24 +31,24 @@ jobs:
         - BATINSTALLDIR=""
       script:
         - mkdir -p $KLF_BUILD_DIR
-        - $CMD_DOCKER "cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
-        - $CMD_DOCKER "cd $KLF_BUILD_DIR && make -j"
-        - $CMD_DOCKER "${CMD_EXPORT_LIBPATH} && cd $KLF_BUILD_DIR && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "cd ${KLF_BUILD_DIR} && cmake ${KLF_CMAKE_OPTS} ${KLF_SOURCE_DIR}"
+        - $CMD_DOCKER "cd ${KLF_BUILD_DIR} && make -j"
+        - $CMD_DOCKER "${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR}"
     - env:
         - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DKLFITTER_INSTALL_TESTS=TRUE"
         - KLF_SOURCE_DIR=$KLF_SOURCE_DIR/KLFitter
       script:
         - mkdir -p $KLF_SOURCE_DIR $KLF_BUILD_DIR $BATINSTALLDIR
-        - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
-        - $CMD_DOCKER "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
         - mv CMakeLists.txt cmake data include src tests $KLF_SOURCE_DIR
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && cd $KLF_BUILD_DIR && make -j"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
+        - $CMD_DOCKER "${KLF_SOURCE_DIR}/cmake/CompileBAT.sh \$PWD/BAT-0.9.4.1.tar.gz ${BATINSTALLDIR}"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && cmake ${KLF_CMAKE_OPTS} ${KLF_SOURCE_DIR}"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && cd ${KLF_BUILD_DIR} && make -j"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR}"
     - script:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
-        - $CMD_DOCKER "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
+        - $CMD_DOCKER "${KLF_SOURCE_DIR}/cmake/CompileBAT.sh \$PWD/BAT-0.9.4.1.tar.gz ${BATINSTALLDIR}"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j && make -j tests"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j install"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,25 @@ before_install:
   - $DOCKER_CMD "root -b -q"
   - echo $KLF_BUILD_DIR
 
-script:
-  - mkdir -p $KLF_BUILD_DIR
-  - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake -DBUILTIN_BAT=TRUE .."
-  - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"
+jobs:
+  include:
+    - script:
+        - mkdir -p $KLF_BUILD_DIR
+        - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake -DBUILTIN_BAT=TRUE .."
+        - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"
+    - env:
+        - BATINSTALLDIR="$TRAVIS_BUILD_DIR/external/BAT"
+      script:
+        - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
+        - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
+        - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
+        - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake .."
+        - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"
+    - env:
+        - BATINSTALLDIR="$TRAVIS_BUILD_DIR/external/BAT"
+      script:
+        - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
+        - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
+        - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
+        - $DOCKER_CMD "make -j"
+        - $DOCKER_CMD "make -j install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
         - mkdir -p $KLF_BUILD_DIR
         - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
         - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"
-        - $DOCKER_CMD "cd $KLF_BUILD_DIR && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $DOCKER_CMD "export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+:}${KLF_BUILD_DIR}/lib && cd $KLF_BUILD_DIR && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
     - env:
         - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
         - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DKLFITTER_INSTALL_TESTS=TRUE"
@@ -33,10 +33,10 @@ jobs:
         - mkdir -p $KLF_SOURCE_DIR $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
-        - mv CMakeLists.txt cmake include src tests $KLF_SOURCE_DIR
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
+        - mv CMakeLists.txt cmake data include src tests $KLF_SOURCE_DIR
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && cd $KLF_BUILD_DIR && cmake $KLF_CMAKE_OPTS $KLF_SOURCE_DIR"
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && make -j"
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BATINSTALLDIR/lib && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
     - env:
         - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
       script:
@@ -45,4 +45,4 @@ jobs:
         - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j && make -j tests"
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && make -j install"
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH:$LD_LIBRARY_PATH:$BATINSTALLDIR/lib && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}\${LD_LIBRARY_PATH:+:}\`root-config --libdir\`:${BATINSTALLDIR}${BATINSTALLDIR:+/lib:}${KLF_BUILD_DIR}/lib && echo \$LD_LIBRARY_PATH && $KLF_BUILD_DIR/test-bin/test-ljets-lh.exe $KLF_SOURCE_DIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - DOCKER_IMAGE="rootproject/root-ubuntu16"
     - DOCKER_CONTAINER="root-docker"
     - DOCKER_CMD="docker exec -i $DOCKER_CONTAINER /bin/bash -c"
+    - KLF_SOURCE_DIR=$TRAVIS_BUILD_DIR
     - KLF_BUILD_DIR=$TRAVIS_BUILD_DIR/build
 
 before_install:
@@ -13,24 +14,27 @@ before_install:
   - docker run -i -d --name $DOCKER_CONTAINER -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR -w $TRAVIS_BUILD_DIR -u $(id -u) $DOCKER_IMAGE /bin/bash
   - docker ps -a
   - $DOCKER_CMD "root -b -q"
+  - echo $KLF_SOURCE_DIR
   - echo $KLF_BUILD_DIR
 
 jobs:
   include:
     - script:
         - mkdir -p $KLF_BUILD_DIR
-        - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake -DBUILTIN_BAT=TRUE .."
+        - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake -DBUILTIN_BAT=TRUE $KLF_SOURCE_DIR"
         - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"
     - env:
-        - BATINSTALLDIR="$TRAVIS_BUILD_DIR/external/BAT"
+        - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
+        - KLF_SOURCE_DIR=$KLF_SOURCE_DIR/KLFitter
       script:
-        - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
+        - mkdir -p $KLF_SOURCE_DIR $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz
         - $DOCKER_CMD "$TRAVIS_BUILD_DIR/cmake/CompileBAT.sh $PWD/BAT-0.9.4.1.tar.gz $BATINSTALLDIR"
-        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && cmake .."
+        - mv CMakeLists.txt cmake include src tests $KLF_SOURCE_DIR
+        - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && cmake $KLF_SOURCE_DIR"
         - $DOCKER_CMD "export BATINSTALLDIR=$BATINSTALLDIR && cd $KLF_BUILD_DIR && make -j"
     - env:
-        - BATINSTALLDIR="$TRAVIS_BUILD_DIR/external/BAT"
+        - BATINSTALLDIR=$TRAVIS_BUILD_DIR/external/BAT
       script:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
         - wget https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: cpp
+sudo: required
+services: docker
+env:
+  global:
+    - DOCKER_IMAGE="rootproject/root-ubuntu16"
+    - DOCKER_CONTAINER="root-docker"
+    - DOCKER_CMD="docker exec -i $DOCKER_CONTAINER /bin/bash -c"
+    - KLF_BUILD_DIR=$TRAVIS_BUILD_DIR/build
+
+before_install:
+  - docker pull $DOCKER_IMAGE
+  - docker run -i -d --name $DOCKER_CONTAINER -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR -w $TRAVIS_BUILD_DIR -u $(id -u) $DOCKER_IMAGE /bin/bash
+  - docker ps -a
+  - $DOCKER_CMD "root -b -q"
+  - echo $KLF_BUILD_DIR
+
+script:
+  - mkdir -p $KLF_BUILD_DIR
+  - $DOCKER_CMD "cd $KLF_BUILD_DIR && cmake -DBUILTIN_BAT=TRUE .."
+  - $DOCKER_CMD "cd $KLF_BUILD_DIR && make -j"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         - $CMD_DOCKER "${KLF_SOURCE_DIR}/cmake/CompileBAT.sh \$PWD/BAT-0.9.4.1.tar.gz ${BATINSTALLDIR}"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && cmake ${KLF_CMAKE_OPTS} ${KLF_SOURCE_DIR}"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && cd ${KLF_BUILD_DIR} && make -j"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
         - diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt
     - script:
         - mkdir -p $KLF_BUILD_DIR $BATINSTALLDIR
@@ -53,5 +53,5 @@ jobs:
         - $CMD_DOCKER "${KLF_SOURCE_DIR}/cmake/CompileBAT.sh \$PWD/BAT-0.9.4.1.tar.gz ${BATINSTALLDIR}"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j && make -j tests"
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make -j install"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
+        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && ${CMD_EXPORT_LIBPATH} && cd ${KLF_BUILD_DIR} && ${KLF_BUILD_DIR}/test-bin/test-ljets-lh.exe ${KLF_SOURCE_DIR} 2>&1 |tee test-output.txt"
         - diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt


### PR DESCRIPTION
The transition to github needs new CI tests for the repository. They are now based on travis and use slightly different steering, found [in this file](.travis.yml).