### PR TITLE
Remove individual authors from class headers

### DIFF
--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -37,7 +37,6 @@ namespace KLFitter {
 /**
 * \class KLFitter::BoostedLikelihoodTopLeptonJets
 * \brief Add brief description here
-* \author Add author here
 *
 * Add detailed description here.
 */

--- a/include/KLFitter/DetectorAtlas_7TeV.h
+++ b/include/KLFitter/DetectorAtlas_7TeV.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::DetectorAtlas_7TeV
   * \brief A class for describing of the ATLAS detector.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class holds the description of the ATLAS detector.
   */

--- a/include/KLFitter/DetectorAtlas_8TeV.h
+++ b/include/KLFitter/DetectorAtlas_8TeV.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::DetectorAtlas_8TeV
   * \brief A class for describing of the ATLAS detector.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class holds the description of the ATLAS detector.
   */

--- a/include/KLFitter/DetectorBase.h
+++ b/include/KLFitter/DetectorBase.h
@@ -34,7 +34,6 @@ class ResolutionBase;
 /**
   * \class KLFitter::DetectorBase
   * \brief A base class for describing detectors.
-  * \author Kevin Kr&ouml;ninger
   *
   * This base class contains the energy resolution of different
   * objects. More information (angular resolutions, acceptance,

--- a/include/KLFitter/DetectorSnowmass.h
+++ b/include/KLFitter/DetectorSnowmass.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::DetectorSnowmass
   * \brief A class for describing of the Snowmass detector.
-  * \author Olaf Nackenhorst
   *
   * This class holds the description of the Snowmass detector.
   */

--- a/include/KLFitter/Fitter.h
+++ b/include/KLFitter/Fitter.h
@@ -37,7 +37,6 @@ class Permutations;
 /**
   * \class KLFitter::Fitter
   * \brief The fitter class.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class owns all particles, the detector description, the
   * likelihood, etc. This is the class seen by the user.

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -42,7 +42,6 @@ class DetectorBase;
 /**
   * \class KLFitter::LikelihoodBase
   * \brief A base class for likelihoods.
-  * \author Kevin Kr&ouml;ninger
   */
 class LikelihoodBase : public BCModel {
  public:

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -34,9 +34,11 @@
 namespace KLFitter {
 /**
   * \class KLFitter::LikelihoodSgTopWtLJ
-  * \brief A class implementing a likelihood for the SgTop Wt -> lepton+jets channel.
+  * \brief A class implementing a likelihood for the SgTop Wt -> lepton+jets
+  * channel.
   *
-  * This class represents a likelihood for the single top Wt channel into lepton+jets.
+  * This class represents a likelihood for the single top Wt channel into
+  * lepton+jets.
   */
 class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
  public:

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -35,7 +35,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::LikelihoodSgTopWtLJ
   * \brief A class implementing a likelihood for the SgTop Wt -> lepton+jets channel.
-  * \author Kevin Kr&ouml;ninger, Thomas Loddenk&ouml;tter
   *
   * This class represents a likelihood for the single top Wt channel into lepton+jets.
   */

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -37,11 +37,9 @@ namespace KLFitter {
 /**
   * \class KLFitter::LikelihoodTTHLeptonJets
   * \brief A class implementing a likelihood for the ttH lepton+jets channel.
-  * \author: Leonid Serkin
   *
   * This class represents a likelihood for the ttH in lepton+jets channel. It
-  * is largely based on the LikelihoodTopLeptonJets class authored by Kevin
-  * Kr&ouml;ninger.
+  * is largely based on the LikelihoodTopLeptonJets class.
   */
 class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
  public:

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -37,11 +37,9 @@ namespace KLFitter {
 /**
   * \class KLFitter::LikelihoodTTZTrilepton
   * \brief A class implementing a likelihood for the ttZ trilepton channel.
-  * \author: Knut Zoch
   *
   * This class represents a KLFitter likelihood for the ttZ trilepton
-  * channel. It is largely based on the LikelihoodTopLeptonJets class
-  * authored by Kevin Kr&ouml;ninger.
+  * channel. It is largely based on the LikelihoodTopLeptonJets class.
   */
 class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
  public:

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -37,7 +37,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::LikelihoodTopAllHadronic
   * \brief A class implementing a likelihood for the ttbar allhadronic channel.
-  * \author Stefanie Adomeit
   *
   * This class represents a likelihood for the ttbar allhadronic channel.
   */

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -52,7 +52,6 @@ class NuSolutions {
 /**
   * \class KLFitter::LikelihoodTopDilepton
   * \brief A class implementing a likelihood for the ttbar dilepton channel.
-  * \author Tamara Vazquez Schröder
   *
   * This class represents a likelihood for the ttbar dilepton channel.
   */

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -37,7 +37,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::LikelihoodTopLeptonJets
   * \brief A class implementing a likelihood for the ttbar lepton+jets channel.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class represents a likelihood for the ttbar into lepton+jets.
   */

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -38,7 +38,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::LikelihoodTopLeptonJetsUDSep
   * \brief A class implementing a likelihood for the ttbar lepton+jets channel.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class represents a likelihood for the ttbar into lepton+jets.
   */

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -37,7 +37,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::LikelihoodTopLeptonJets_Angular
   * \brief Add brief description here
-  * \author Add author here
   *
   * Add detailed description here.
   */

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -37,7 +37,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::LikelihoodTopLeptonJets_JetAngles
   * \brief Add brief description here
-  * \author Add author here
   *
   * Add a detailed description here.
   */

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -37,7 +37,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::Particles
   * \brief A class describing particles.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class contains sets of TLorentzVectors for quarks, leptons,
   * etc.

--- a/include/KLFitter/Permutations.h
+++ b/include/KLFitter/Permutations.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::Permutations
   * \brief A class permuting jets, electrons, muons and photons.
-  * \author Kevin Kr&ouml;ninger
   *
   * The class gets a pointer to the orignal set of particles and a
   * pointer to the currently used permutations. It can calculate all

--- a/include/KLFitter/PhysicsConstants.h
+++ b/include/KLFitter/PhysicsConstants.h
@@ -30,7 +30,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::PhysicsConstants
   * \brief A class containing physics constants.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class contains physics constants.
   */

--- a/include/KLFitter/ResDoubleGaussBase.h
+++ b/include/KLFitter/ResDoubleGaussBase.h
@@ -35,7 +35,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResDoubleGaussBase
   * \brief A class describing a resolution parameterized with a double Gaussian.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a double Gaussian with energy dependent

--- a/include/KLFitter/ResDoubleGaussE_1.h
+++ b/include/KLFitter/ResDoubleGaussE_1.h
@@ -35,7 +35,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResDoubleGaussE_1
   * \brief A class describing a resolution parameterized with a double Gaussian.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a double Gaussian with energy dependent

--- a/include/KLFitter/ResDoubleGaussE_2.h
+++ b/include/KLFitter/ResDoubleGaussE_2.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResDoubleGaussE_2
   * \brief A class describing a resolution parameterized with a double Gaussian.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a double Gaussian with energy dependent

--- a/include/KLFitter/ResDoubleGaussE_3.h
+++ b/include/KLFitter/ResDoubleGaussE_3.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResDoubleGaussE_3
   * \brief A class describing a resolution parameterized with a double Gaussian.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a double Gaussian with energy dependent

--- a/include/KLFitter/ResDoubleGaussE_4.h
+++ b/include/KLFitter/ResDoubleGaussE_4.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResDoubleGaussE_4
   * \brief A class describing a resolution parameterized with a double Gaussian.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a double Gaussian with energy dependent

--- a/include/KLFitter/ResDoubleGaussE_5.h
+++ b/include/KLFitter/ResDoubleGaussE_5.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResDoubleGaussE_5
   * \brief A class describing a resolution parameterized with a double Gaussian.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a double Gaussian with energy dependent

--- a/include/KLFitter/ResDoubleGaussPt.h
+++ b/include/KLFitter/ResDoubleGaussPt.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResDoubleGaussPt
   * \brief A class describing a resolution parameterized with a double Gaussian.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a double Gaussian with energy dependent

--- a/include/KLFitter/ResGauss.h
+++ b/include/KLFitter/ResGauss.h
@@ -32,7 +32,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResGauss
   * \brief A class describing a Gaussian resolution.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a Gaussian with a width of a constant times the

--- a/include/KLFitter/ResGaussE.h
+++ b/include/KLFitter/ResGaussE.h
@@ -33,7 +33,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResGaussE
   * \brief A class describing a Gaussian resolution.
-  * \author Olaf Nackenhorst
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a Gaussian with a width parametrized

--- a/include/KLFitter/ResGaussPt.h
+++ b/include/KLFitter/ResGaussPt.h
@@ -33,7 +33,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResGaussPt
   * \brief A class describing a Gaussian resolution.
-  * \author Olaf Nackenhorst
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a Gaussian with a width parametrized

--- a/include/KLFitter/ResGauss_MET.h
+++ b/include/KLFitter/ResGauss_MET.h
@@ -34,7 +34,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResGauss_MET
   * \brief A class describing a Gaussian resolution, parametrized for MET.
-  * \author Kevin Kr&ouml;ninger
   *
   * This class offers a simple parameterization of a resolution. The
   * parameterization is a Gaussian with a width of a constant times the

--- a/include/KLFitter/ResolutionBase.h
+++ b/include/KLFitter/ResolutionBase.h
@@ -32,7 +32,6 @@ namespace KLFitter {
 /**
   * \class KLFitter::ResolutionBase
   * \brief A base class for describing resolutions.
-  * \author Kevin Kr&ouml;ninger
   *
   * This base class can be used to decribe resolutions.
   */


### PR DESCRIPTION
As previously discussed in the group, we will remove individual author info from the class headers, as this information is stored in the central documentation anyways. Classes tend to have mixed authors/contributors over time anyways.