### PR TITLE
Reduce number of public library headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,19 +111,7 @@ set( lib_headers
   include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
   include/KLFitter/Particles.h
   include/KLFitter/Permutations.h
-  include/KLFitter/PhysicsConstants.h
-  include/KLFitter/ResDoubleGaussBase.h
-  include/KLFitter/ResDoubleGaussE_1.h
-  include/KLFitter/ResDoubleGaussE_2.h
-  include/KLFitter/ResDoubleGaussE_3.h
-  include/KLFitter/ResDoubleGaussE_4.h
-  include/KLFitter/ResDoubleGaussE_5.h
-  include/KLFitter/ResDoubleGaussPt.h
-  include/KLFitter/ResGauss.h
-  include/KLFitter/ResGaussE.h
-  include/KLFitter/ResGaussPt.h
-  include/KLFitter/ResGauss_MET.h
-  include/KLFitter/ResolutionBase.h )
+  include/KLFitter/PhysicsConstants.h )
 
 # Source files for the shared/static library.
 set( lib_sources

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -23,8 +23,11 @@
 #include <iostream>
 #include <vector>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "KLFitter/LikelihoodBase.h"
-#include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -22,8 +22,11 @@
 
 #include <vector>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "KLFitter/LikelihoodBase.h"
-#include "KLFitter/ResolutionBase.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -23,8 +23,11 @@
 #include <iostream>
 #include <vector>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "KLFitter/LikelihoodBase.h"
-#include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -23,8 +23,11 @@
 #include <iostream>
 #include <vector>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "KLFitter/LikelihoodBase.h"
-#include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -23,8 +23,11 @@
 #include <iostream>
 #include <vector>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "KLFitter/LikelihoodBase.h"
-#include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -27,10 +27,13 @@
 #include <utility>
 #include <vector>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "BAT/BCH1D.h"
 #include "BAT/BCModel.h"
 #include "KLFitter/LikelihoodBase.h"
-#include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -23,8 +23,11 @@
 #include <iostream>
 #include <vector>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "KLFitter/LikelihoodBase.h"
-#include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -22,8 +22,11 @@
 
 #include <iostream>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "KLFitter/LikelihoodTopLeptonJets.h"
-#include "KLFitter/ResolutionBase.h"
 #include "TH1F.h"
 #include "TH2F.h"
 #include "TLorentzVector.h"

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -23,8 +23,11 @@
 #include <iostream>
 #include <vector>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "KLFitter/LikelihoodBase.h"
-#include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -23,8 +23,11 @@
 #include <iostream>
 #include <vector>
 
+namespace KLFitter {
+  class ResolutionBase;
+}
+
 #include "KLFitter/LikelihoodBase.h"
-#include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This MR reduces the number of public library headers in the cmake configuration. All `Res*` header files are now library-internal, i.e. they don't get copied into the install directory anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#8 Reduce number of public library header files

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reduces confusion with many header files after installing KLFitter somewhere.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compilation has been tested, example file and unit tests run fine. We should, however, also do a full build of the inclusion of KLFitter in ATLAS software to make sure that nothing breaks there.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
