### PR TITLE
Switch to turn off build of example executable(s)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,11 @@ macro( KLFitter_add_executable name )
     RUNTIME DESTINATION bin )
 endmacro( KLFitter_add_executable )
 
-KLFitter_add_executable( example-top-ljets.exe util/example-top-ljets.cxx )
+# Build the example executable(s) of the project.
+option( INSTALL_EXAMPLES "Install the example executable(s) of KLFitter" ON )
+if( INSTALL_EXAMPLES )
+  KLFitter_add_executable( example-top-ljets.exe util/example-top-ljets.cxx )
+endif()
 
 # Install the CMake description of the project.
 install( EXPORT KLFitterTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ install( TARGETS KLFitter KLFitter-stat
 
 # Install the transfer functions.
 install( DIRECTORY data/transferfunctions/
-  DESTINATION share/KLFitter/TFs )
+  DESTINATION share/KLFitter/transferfunctions )
 
 # Helper macro for building the project's unit tests.
 macro( KLFitter_add_test name )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ macro( KLFitter_add_test name )
 endmacro( KLFitter_add_test )
 
 # Set up the test(s) of the project.
+option( INSTALL_TESTS "Install the unit tests to validate KLFitter installation" OFF )
 if( INSTALL_TESTS )
   KLFitter_add_test( test-ljets-lh.exe tests/test-ljets-lh.cxx )
 endif()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR introduces a switch in the cmake configuration to switch off the builds of the example executable(s). It also adds a few comments _and_ changes the destination path for the transfer functions installation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#12 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves the problem when including KLFitter into another software framework. The example builds can be turned off, so no linkage is necessary during the build (we ran into problems with that, but for the build of the final exectuables everything worked fine).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compilation tried with option switched on and off.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
