### PR TITLE
Addressed memory leaks in detector class and BAT

### DIFF
--- a/src/DetectorSnowmass.cxx
+++ b/src/DetectorSnowmass.cxx
@@ -86,6 +86,9 @@ KLFitter::DetectorSnowmass::~DetectorSnowmass() {
 
   if (fResEnergyJet_eta3)
     delete fResEnergyJet_eta3;
+
+  if (fResMissingET)
+    delete fResMissingET;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -47,6 +47,10 @@ KLFitter::LikelihoodBase::LikelihoodBase(Particles** particles) : BCModel(),
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodBase::~LikelihoodBase() {
+  // Clear the parameters container in the BCModel to circumvent
+  // BAT-internal memory leak (known issue in 0.9.4.1).
+  ClearParameters(true);
+
   if (fParticlesModel)
     delete fParticlesModel;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This addresses multiple memory leaks found with valgrind within the code:
- Missing `delete` of a Snowmass detector member
- Circumvention of BAT-internal memory leaks by calling the `ClearParameters` function manually.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#17 for the Snowmass issue
#18 for the BAT memory leaks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled and tested on SL6, works fine. Rerunning valgrind shows that the leaks are gone.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
