### PR TITLE
Documentation updates: typos & formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ License, respectively.
 ### Dependencies
 
 KLFitter depends on the ROOT and BAT libraries. For information about ROOT,
-please consult the [ROOT webpage](https://root.cern.ch/). Information about BAT,
-installation instructions and the latest BAT releases can be found on the
-[library's webpage](http://www.mppmu.mpg.de/bat/). The following versions have
+please consult the [ROOT web page](https://root.cern.ch/). Information about
+BAT, installation instructions and the latest BAT releases can be found on the
+[library's web page](http://www.mppmu.mpg.de/bat/). The following versions have
 been tested with KLFitter and are working:
 
 - ROOT v5.34.10 or later
@@ -38,9 +38,9 @@ been tested with KLFitter and are working:
 
 ### Obtaining KLFitter
 
-The KLFitter source code can be obtained from this repository 
-(https://github.com/KLFitter/KLFitter). A list of all releases of
-KLFitter can be found under 
+The KLFitter source code can be obtained from this repository
+(https://github.com/KLFitter/KLFitter). A list of all releases of KLFitter can
+be found under
 [KLFitter/releases](https://github.com/KLFitter/KLFitter/releases). To download
 the source code, you can use the git clone command:
 
@@ -63,10 +63,10 @@ and their associated commits in [this file](doc/SVN-tags.md).
 
 Before proceeding please make sure that you have a valid installation of ROOT on
 your system and that cmake is correctly configured (version 3.1 or higher is
-required). As cmake does fully automatised configuration, it is possible to
-build KLFitter and the BAT library simultaneously. BAT will be downloaded during
-the cmake build process. For doing so, change into the KLFitter directory and
-then do:
+required). As cmake does fully automated configuration, it is possible to build
+KLFitter and the BAT library simultaneously. BAT will be downloaded during the
+cmake build process. For doing so, change into the KLFitter directory and then
+do:
 
 ```
 mkdir build && cd build
@@ -74,7 +74,7 @@ cmake -DBUILTIN_BAT=TRUE ..
 make -j
 ```
 
-This will build both BAT and KLFitter in the _build_ subfolder of the KLFitter
+This will build both BAT and KLFitter in the _build_ sub-folder of the KLFitter
 directory. If you already have an existing installation of BAT, you can also
 link the KLFitter library against that version and not download BAT during the
 cmake build process. For that, make sure that the environment variable
@@ -96,9 +96,9 @@ Asked Questions](doc/FAQ.md).
 ### Installation via Makefile (deprecated)
 
 The repository also comes with a _Makefile_, although using cmake to build
-KLFitter is the recommended procedure. Compilation via Makefile assumes that
-you have a working installation of ROOT and BAT. The location of the BAT library
-is determined with the `$BATINSTALLDIR` variable, so make sure to set and export
+KLFitter is the recommended procedure. Compilation via Makefile assumes that you
+have a working installation of ROOT and BAT. The location of the BAT library is
+determined with the `$BATINSTALLDIR` variable, so make sure to set and export
 it. Then switch to the KLFitter repository directory and call
 
 ```

--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ be found under
 [KLFitter/releases](https://github.com/KLFitter/KLFitter/releases). To download
 the source code, you can use the git clone command:
 
+```sh
+> git clone https://github.com/KLFitter/KLFitter.git
 ```
-$ git clone https://github.com/KLFitter/KLFitter.git
 
-```
 and, for checking out a specific release, use the git checkout procedure:
-```
-$ cd KLFitter
-$ git checkout $VERSION_TAG
+
+```sh
+> cd KLFitter
+> git checkout $VERSION_TAG
 ```
 
 Before KLFitter was made public, it was maintained in non-public SVN
@@ -68,10 +69,10 @@ KLFitter and the BAT library simultaneously. BAT will be downloaded during the
 cmake build process. For doing so, change into the KLFitter directory and then
 do:
 
-```
-mkdir build && cd build
-cmake -DBUILTIN_BAT=TRUE ..
-make -j
+```sh
+> mkdir build && cd build
+> cmake -DBUILTIN_BAT=TRUE ..
+> make -j
 ```
 
 This will build both BAT and KLFitter in the _build_ sub-folder of the KLFitter
@@ -83,10 +84,10 @@ variable will be used by _FindBAT.cmake_, which locates the BAT library. With a
 local version of BAT, the `-DBUILTIN_BAT` flag of the cmake command can be
 omitted, i.e. the KLFitter build procedure becomes:
 
-```
-mkdir build && cd build
-cmake ..
-make -j
+```sh
+> mkdir build && cd build
+> cmake ..
+> make -j
 ```
 
 For problems with the cmake configuration, please also refer to the [Frequently
@@ -101,8 +102,8 @@ have a working installation of ROOT and BAT. The location of the BAT library is
 determined with the `$BATINSTALLDIR` variable, so make sure to set and export
 it. Then switch to the KLFitter repository directory and call
 
-```
-make -j && make -j install
+```sh
+> make -j all && make -j install
 ```
 
 to compile KLFitter. The latter command will create a subdirectory _build_ and

--- a/doc/Authors.md
+++ b/doc/Authors.md
@@ -5,19 +5,19 @@
 - Johannes Erdmann (TU Dortmund University): main author
 - Stefan Guindon (CERN): b-tagging methods
 - Kevin Kröninger (TU Dortmund University): main author
-- Boris Lemmer (previously University of Göttingen): transfer functions, `LikelihoodTopLeptonJetsUDSep`
+- Boris Lemmer (previously Univ. of Göttingen): transfer functions, `LikelihoodTopLeptonJetsUDSep`
 - Olaf Nackenhorst (TU Dortmund University): main author
-- Arnulf Quadt (University of Göttingen): initiator of KLFitter
-- Philipp Stolte (previously University of Göttingen): studies for the KLFitter paper
+- Arnulf Quadt (Univ. of Göttingen): initiator of KLFitter
+- Philipp Stolte (previously Univ. of Göttingen): studies for the KLFitter paper
 
 ### Current and previous contributors to KLFitter
 
 - Stefanie Adomeit (previously LMU Munich): `LikelihoodTopAllHadronic`
-- Tomas Dado (Comenius University in Bratislava & University of Göttingen): technical support
-- Andrea Knue (University of Freiburg): user support
-- Fabian Kohn (previously University of Göttingen): `LikelihoodTopLeptonJets_JetAngles`
-- Thomas Loddenkötter (previously Bonn University): `LikelihoodSgTopWtLJ`
+- Tomas Dado (Comenius University in Bratislava & Univ. of Göttingen): technical support
+- Andrea Knue (Univ. of Freiburg): user support
+- Fabian Kohn (previously Univ. of Göttingen): `LikelihoodTopLeptonJets_JetAngles`
+- Thomas Loddenkötter (previously Univ. of Bonn): `LikelihoodSgTopWtLJ`
 - Leonid Serkin (ICTP Trieste): `LikelihoodTTHLeptonJets`
 - Tamara Vazquez Schroeder (CERN): `LikelihoodTopDilepton`
 - Björn Wendland (TU Dortmund University): `BoostedLikelihoodTopLeptonJets`
-- Knut Zoch (University of Göttingen): technical support, `LikelihoodTTZTrilepton`
+- Knut Zoch (Univ. of Göttingen): technical support, `LikelihoodTTZTrilepton`

--- a/doc/Authors.md
+++ b/doc/Authors.md
@@ -8,12 +8,12 @@
 - Boris Lemmer (previously University of Göttingen): transfer functions, `LikelihoodTopLeptonJetsUDSep`
 - Olaf Nackenhorst (TU Dortmund University): main author
 - Arnulf Quadt (University of Göttingen): initiator of KLFitter
-- Philipp Stolte (University of Göttingen): studies for the KLFitter paper
+- Philipp Stolte (previously University of Göttingen): studies for the KLFitter paper
 
 ### Current and previous contributors to KLFitter
 
 - Stefanie Adomeit (previously LMU Munich): `LikelihoodTopAllHadronic`
-- Tomas Dado (Comenius University in Bratislava): technical support
+- Tomas Dado (Comenius University in Bratislava & University of Göttingen): technical support
 - Andrea Knue (University of Freiburg): user support
 - Fabian Kohn (previously University of Göttingen): `LikelihoodTopLeptonJets_JetAngles`
 - Thomas Loddenkötter (previously Bonn University): `LikelihoodSgTopWtLJ`

--- a/doc/Example.md
+++ b/doc/Example.md
@@ -4,13 +4,13 @@
 
 The purpose of the provided example is to demonstrate how to implement KLFitter
 in your analysis. The example code and the input files are designed to provide a
-minimalistic input and implementation. The example also shows how to retrieve
-the output from KLFitter after the fitting. The ttbar lepton+jets likelihood,
+minimalist input and implementation. The example also shows how to retrieve the
+output from KLFitter after the fitting. The ttbar lepton+jets likelihood,
 implemented in the class
-[LikelihoodTopLeptonJets](../include/KLFitter/LikelihoodTopLeptonJets.h) has been
-chosen for the example, but from the implementation it should be straightforward
-to extend the implementation to other available likelihoods. Detailed
-explanations of all likelihoods can be found in the [main KLFitter
+[LikelihoodTopLeptonJets](../include/KLFitter/LikelihoodTopLeptonJets.h) has
+been chosen for the example, but from the implementation it should be
+straightforward to extend the implementation to other available likelihoods.
+Detailed explanations of all likelihoods can be found in the [main KLFitter
 documentation](WhatIsKLF.md).
 
 
@@ -23,13 +23,14 @@ additional argument. For example, if you followed the build instructions of the
 README, the cmake command will store the executable in the `bin` subdirectory.
 Then call
 
-```
-$ ./bin/example-top-ljets.exe ../
+```sh
+> ./bin/example-top-ljets.exe ../
 ```
 
 The location of the KLFitter source directory is needed to locate the input file
-for the example, stored under [data/examples](../data/examples), and the transfer
-functions, stored under [data/transferfunctions](../data/transferfunctions).
+for the example, stored under [data/examples](../data/examples), and the
+transfer functions, stored under
+[data/transferfunctions](../data/transferfunctions).
 
 
 ### Implementation
@@ -40,30 +41,33 @@ The implementation of the example consists of three different files:
 ttbar lepton+jets events. The file contains all necessary variables to run the
 KLFitter lepton+jets likelihood (described in detail in the [main
 documentation](WhatIsKLF.md)).
-* A [header file](../util/TreeReaderTopLJets.h) for the `TreeReaderTopLJets` class
-that provides an interface to read the variables from the input file easily.
-This class is used to loop over all input events and load the event information.
+* A [header file](../util/TreeReaderTopLJets.h) for the `TreeReaderTopLJets`
+class that provides an interface to read the variables from the input file
+easily. This class is used to loop over all input events and load the event
+information.
 * An [implementation file](../util/example-top-ljets.cxx) that provides a
-minimalistic implementation of KLFitter in a toy-analysis. The file contains
-detailed comments about every command and substep to use KLFitter.
+minimalist implementation of KLFitter in a toy-analysis. The file contains
+detailed comments about every command and sub-step to use KLFitter.
 
 
 ## Input file
 
-The input file for the provided example (../data/examples/top-ljets-input.root) is
-a _HepSim_ sample taken [from the
-homepage](http://atlaswww.hep.anl.gov/hepsim/info.php?item=142) of the HepSim
+The input file for the provided example (../data/examples/top-ljets-input.root)
+is a _HepSim_ sample taken [from the home
+page](http://atlaswww.hep.anl.gov/hepsim/info.php?item=142) of the HepSim
 project [1]. The sample simulates ttbar+jet processes in proton-proton
-collisions at a centre-of-mass energy of 13 TeV. The processes are generated
-using the Madgraph matrix element generator interfaced with Herwig6. The
-simulated detector corresponds to the _Snowmass_ detector [2], which is a toy detector used for the 2013 Snowmass studies.
+collisions at a center-of-mass energy of 13 TeV. The processes are generated
+using the MadGraph matrix element generator interfaced with Herwig6. The
+simulated detector corresponds to the _Snowmass_ detector [2], which is a toy
+detector used for the 2013 Snowmass studies.
 
 The original Delphes format of the input ROOT files is transformed into a
 standard ROOT tree, the events are skimmed and only variables relevant for the
 KLFitter reconstruction are kept. The event skimming sets the following
 requirements for events to be kept:
+
 * at least 4 jets with a transverse momentum of at least 25 GeV. The eta of the
-  jets is required to fulfil |eta| < 4.9.
+  jets is required to fulfill |eta| < 4.9.
 * exactly one charged lepton (i.e. electron or muon) with a transverse momentum
   of at least 25 GeV and |eta| < 4.9.
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -33,24 +33,32 @@ be tested by checking whether `whereis c++` and `which c++` point to the same
 binary. To tell cmake to use the latter one, you can export the compiler
 location:
 
-```
-export CXX=`which c++`
-export CC=`which gcc`
+```sh
+> export CXX=`which c++`
+> export CC=`which gcc`
 ```
 
 ## Questions/problems with the implementation
 
 #### What is the difference between the top mass parameter and the hadronic/leptonic top mass?
 
-This question refers to `LikelihoodTopLeptonjets`: The top mass parameter is the central value of the top mass Breit-Wigner distribution. The hadronic and leptonic top masses are the invariant masses of the three particles from the hadronic and leptonic top decay, respectively. The hadronic and leptonic top masses are assumed to be Breit-Wigner distributed around a central value, i.e. the top mass parameter, in the definition of the likelihood.
+This question refers to `LikelihoodTopLeptonjets`: The top mass parameter is the
+central value of the top mass Breit-Wigner distribution. The hadronic and
+leptonic top masses are the invariant masses of the three particles from the
+hadronic and leptonic top decay, respectively. The hadronic and leptonic top
+masses are assumed to be Breit-Wigner distributed around a central value, i.e.
+the top mass parameter, in the definition of the likelihood.
 
 #### In which units should I add objects to KLFitter?
 
-KLFitter handles all four-vectors in GeV. This means also that all values in `PhysicsConstants` need to be set in GeV.
+KLFitter handles all four-vectors in GeV. This means also that all values in
+`PhysicsConstants` need to be set in GeV.
 
 #### Why do I get a message `WARNING : A particle with negative mass...`?
 
-Particles that are added to the KLFitter must not have negative masses. Negative masses lead to bad fits with `NaN` outputs. It is a feature that once such a bad fit was performed, all fits in the following events also become bad.
+Particles that are added to the KLFitter must not have negative masses. Negative
+masses lead to bad fits with `NaN` outputs. It is a feature that once such a bad
+fit was performed, all fits in the following events also become bad.
 
 #### Why are the fit results of all events starting from one event `NaN`?
 
@@ -58,7 +66,13 @@ Please check that you do not pass particles with negative masses to KLFitter.
 
 #### What does KLFitter do if more than 2 jets are b-tagged and the b-tagging veto is used?
 
-This question refers to `LikelihoodTopLeptonjets`, but it also applies to other likelihoods where you could pass more b-tagged jets to KLFitter than b-quarks are present in the model: With the "b-tagging veto" methods (such as `kVeto` or `kVetoNoFit`), events with > 2 b-tags are not compatible with the underlying model you are testing with KLFitter. Hence, all event probabilities will be zero (`kVeto` and related) or all permutations will be removed, so that none remains (`kVetoNoFit` and related).
+This question refers to `LikelihoodTopLeptonjets`, but it also applies to other
+likelihoods where you could pass more b-tagged jets to KLFitter than b-quarks
+are present in the model: With the "b-tagging veto" methods (such as `kVeto` or
+`kVetoNoFit`), events with > 2 b-tags are not compatible with the underlying
+model you are testing with KLFitter. Hence, all event probabilities will be zero
+(`kVeto` and related) or all permutations will be removed, so that none remains
+(`kVetoNoFit` and related).
 
 #### Does KLFitter need at least one tagged b-jet if you use one of the b-tagging methods?
 
@@ -66,11 +80,21 @@ No.
 
 #### Why do I get a `vector out of range` error when switching from an "e+jets" event to a "mu+jets" event (or vice versa)?
 
-This question refers to `LikelihoodTopLeptonjets` (and related likelihoods): `LikelihoodTopLeptonJets` is testing a hypothesis for the underlying model, which can either be "e+jets" or "mu+jets". You can set this via `LikelihoodTopLeptonJets::SetLeptonType(LeptonType leptontype)`. The default is `kElectron`. When switching from an "e+jets" to a "mu+jets" event (or vice versa), you must also change the underlying model. If you do not do this, `LikelihoodTopLeptonJets` will ask for the first lepton of the other type and will throw a `vector out of range` exception.
+This question refers to `LikelihoodTopLeptonjets` (and related likelihoods):
+`LikelihoodTopLeptonJets` is testing a hypothesis for the underlying model,
+which can either be "e+jets" or "mu+jets". You can set this via
+`LikelihoodTopLeptonJets::SetLeptonType(LeptonType leptontype)`. The default is
+`kElectron`. When switching from an "e+jets" to a "mu+jets" event (or vice
+versa), you must also change the underlying model. If you do not do this,
+`LikelihoodTopLeptonJets` will ask for the first lepton of the other type and
+will throw a `vector out of range` exception.
 
 #### Why is the number of permutations not reduced when I use the b-tagging veto `kVeto`?
 
-In this option, we do not want to remove permutations due to the b-tagging approach. Only the event probability is affected by weighting it with either 0 or 1, but not the number of permutations, although b-tags veto certain permutations. To reduce the number of permutations use `kVetoNoFit`.
+In this option, we do not want to remove permutations due to the b-tagging
+approach. Only the event probability is affected by weighting it with either 0
+or 1, but not the number of permutations, although b-tags veto certain
+permutations. To reduce the number of permutations use `kVetoNoFit`.
 
 #### Why do I get a `index out of range` error when I use the `kVetoNoFit` b-tagging veto?
 
@@ -82,12 +106,28 @@ The number of permutations, N, is:
 
 N = (n!) / (2 * (n-4)!)
 
-where n is the number of considered jets. The factor 2 accounts for the indistinguishable light quarks and the factor (n-4)! removes all invariant permutations of the jets that are not used in the fit.
+where n is the number of considered jets. The factor 2 accounts for the
+indistinguishable light quarks and the factor (n-4)! removes all invariant
+permutations of the jets that are not used in the fit.
 
 #### I have 2520 permutations in one event. What did I do wrong?
 
-This answer is specific to `LikelihoodTopLeptonjets`, but it applies to other likelihoods in a similar way: I means that you consider by far too many (in this example 10) jets in the kinematic fit, i.e. you probably pass all jets in the event to KLFitter. Besides of the calculation of the permutation table (for 2520 permutation) taking a lot of time, it most probably does not make sense to fit more than 5 or 6 jets. With more jets passed to KLFitter, it is very likely that by chance you will find any kind of event with a lepton and missing transverse momentum matching somehow the lepton+jet decay topology and an identification of the correct permutation is unlikely.
+This answer is specific to `LikelihoodTopLeptonjets`, but it applies to other
+likelihoods in a similar way: I means that you consider by far too many (in this
+example 10) jets in the kinematic fit, i.e. you probably pass all jets in the
+event to KLFitter. Besides of the calculation of the permutation table (for 2520
+permutation) taking a lot of time, it most probably does not make sense to fit
+more than 5 or 6 jets. With more jets passed to KLFitter, it is very likely that
+by chance you will find any kind of event with a lepton and missing transverse
+momentum matching somehow the lepton+jet decay topology and an identification of
+the correct permutation is unlikely.
 
 #### How do I improve speed when using large numbers of jets as input to KLFitter?
 
-Say, you want to use 6 jets in your analysis, but still want to consider more jets within the possible permutations, say up to 8. Then, you can give an additional argument to `KLFitter::SetParticles(KLFitter::Particles * particles, int nPartonsInPermutations = -1)` and set `nPartonsInPermutations` to 6, while you pass up to 8 jets to KLFitter. The calculation of the permutations will not take into account all 8! jet permutations, but efficiently only calculate those needed.
+Say, you want to use 6 jets in your analysis, but still want to consider more
+jets within the possible permutations, say up to 8. Then, you can give an
+additional argument to `KLFitter::SetParticles(KLFitter::Particles * particles,
+int nPartonsInPermutations = -1)` and set `nPartonsInPermutations` to 6, while
+you pass up to 8 jets to KLFitter. The calculation of the permutations will not
+take into account all 8! jet permutations, but efficiently only calculate those
+needed.

--- a/doc/WhatIsKLF.md
+++ b/doc/WhatIsKLF.md
@@ -31,7 +31,8 @@ If you are using KLFitter, please consider citing the KLFitter paper:
 
 > J.Erdmann, S.Guindon, K.Kröninger, B.Lemmer, O.Nackenhorst, A.Quadt and P.Stolte, *A likelihood-based reconstruction algorithm for top-quark pairs and the KLFitter framework*, [Nucl. Instrum. Meth. A 748 (2014) 18](https://doi.org/10.1016/j.nima.2014.02.029).
 
-A list of works citing the KLFitter paper can be found [on inspire](https://inspirehep.net/search?ln=en&p=refersto%3Arecid%3A1272847).
+A list of works citing the KLFitter paper can be found [on
+inspire](https://inspirehep.net/search?ln=en&p=refersto%3Arecid%3A1272847).
 
 
 
@@ -266,9 +267,9 @@ mass of the two leptons:
 - the on-shell production of two charged leptons with a Breit-Wigner
   distribution with mass and width of the Z boson, weighted with fraction f, and
 - the off-shell production of two charged leptons with the expected inverse
-quadratic dependence on the invariant mass of the two leptons, weighted with the
-fraction (1-f). The cut-off constant that appears in the off-shell part of the
-likelihood can be set by the user.
+  quadratic dependence on the invariant mass of the two leptons, weighted with
+  the fraction (1-f). The cut-off constant that appears in the off-shell part of
+  the likelihood can be set by the user.
 
 ![](LikelihoodTTZTrilepton.png)
 
@@ -345,8 +346,8 @@ energy given the true energy of a parton. These parameterizations are
 detector-specific and in general need to be derived by the user for their
 specific application. Gaussian and double-Gaussian parameterizations are
 pre-defined in KLFitter with the specific parameters to be determined by the
-user. Alternative parameterizations are in principle possible. A tool is provided
-for the derivation of double-Gaussian transfer functions,
+user. Alternative parameterizations are in principle possible. A tool is
+provided for the derivation of double-Gaussian transfer functions,
 [TFtool](https://gitlab.cern.ch/KLFitter/TFtool).
 
 
@@ -409,8 +410,8 @@ The measured quantities are the four-vectors of jets and charged leptons, as
 well as the missing transverse momentum components. An object of type
 `Particles` is passed to the `Fitter` object. The input quantities can either be
 set by defining `TLorentzVectors` and adding them to Particles object, or by
-using an interface. Please also refer to the [example](Example.md) for the
-exact implementation.
+using an interface. Please also refer to the [example](Example.md) for the exact
+implementation.
 
 ### Combinatorics
 
@@ -441,8 +442,8 @@ detailed information about the permutation can be retrieved.
 
 ##### Fit convergence status
 
-The fit convergence status can be obtained and stored in an unsigned integer
-bit word via:
+The fit convergence status can be obtained and stored in an unsigned integer bit
+word via:
 
 ```c++
 unsigned int ConvergenceStatusBitWord = fitter.ConvergenceStatus();

--- a/doc/WhatIsKLF.md
+++ b/doc/WhatIsKLF.md
@@ -1,4 +1,4 @@
-# KLFitter—the Kinematic Likelihood Fitter
+# KLFitter – The Kinematic Likelihood Fitter
 
 ### Introduction
 
@@ -113,7 +113,7 @@ The following likelihood is implemented in the class
 `BoostedLikelihoodTopLeptonJets` for the reconstruction of lepton+jets ttbar
 events with a high momentum of the hadronically decaying top quark, in which the
 decay products of the hadronically decaying W boson are merged to form only one
-jet instead of two. This likelihood has the potential to outperfrom
+jet instead of two. This likelihood has the potential to outperform
 `LikelihoodTopLeptonJets` for transverse momenta of the hadronically decaying W
 boson of about 400 GeV. In comparison to `LikelihoodTopLeptonJets`, this
 likelihood only considers three instead of four jets and does not consider any
@@ -123,10 +123,10 @@ make use of the mass of the merged jet.
 ![](BoostedLikelihoodTopLeptonJets.png)
 
 
-### Allhadronic ttbar events
+### All-hadronic ttbar events
 
 The following likelihood is implemented in the class `LikelihoodTopAllHadronic`
-for the reconstruction of allhadronic ttbar events. It consists of Breit-Wigner
+for the reconstruction of all-hadronic ttbar events. It consists of Breit-Wigner
 distributions for the top-quarks and the W-bosons and transfer functions for the
 six jets. As in the case of `LikelihoodTopLeptonJets`, the top-quark mass can be
 chosen to be fixed or a free parameter in the fit.
@@ -139,7 +139,7 @@ chosen to be fixed or a free parameter in the fit.
 The following likelihood is implemented in the class `LikelihoodTopDilepton` for
 the reconstruction of dileptonic ttbar events. It uses the four-momenta of two
 jets and two charged leptons and the two components and the missing transverse
-momentum in the neutrino-weighting method to solve the underconstrained
+momentum in the neutrino-weighting method to solve the under-constrained
 kinematic system. The likelihood consists of the transfer functions for the two
 charged leptons and the two jets, as well as Gaussian functions G(...) that
 describe the transfer function of the missing transverse momentum as a function
@@ -280,7 +280,7 @@ the reconstruction of the associated production of a single top quark and a W
 boson in the lepton+jets channel. In comparison to `LikelihoodTopLeptonJets`,
 this likelihood contains only three instead of four jets. Two variants of the
 likelihood are provided: one variant assumes that the top quark decays
-semileptonically, the other variant assumes that it decays full hadronic. The
+semi-leptonically, the other variant assumes that it decays full hadronic. The
 user can switch between these two variants by setting:
 
 ```c++
@@ -320,7 +320,7 @@ require that the b-tagging information for the jets is passed to KLFitter.
 - Option `LikelihoodBase::kWorkingPoint`: With this option, b-tagging
   information is not used to veto events, but to multiply the event probability
   with a b-tagging probability. It is calculated from the product of the
-  b-tagging probabilitites of the individual jets by assigning:
+  b-tagging probabilities of the individual jets by assigning:
   - the b-tagging efficiency (one minus the b-tagging efficiency) for each
     b-tagged (non-b-tagged) jet that is in the position of a b-quark from the
     top-quark decay;
@@ -340,12 +340,12 @@ require that the b-tagging information for the jets is passed to KLFitter.
 ## Transfer functions
 
 The transfer functions `W(measured property | true property)` are a
-parametrization of the detector response, for example for the measured jet
-energy given the true energy of a parton. These parametrizations are
+parameterization of the detector response, for example for the measured jet
+energy given the true energy of a parton. These parameterizations are
 detector-specific and in general need to be derived by the user for their
-specific application. Gaussian and double-Gaussian parametrizations are
+specific application. Gaussian and double-Gaussian parameterizations are
 pre-defined in KLFitter with the specific parameters to be determined by the
-user. Alternative parametrizations are in principle possible. A tool is provided
+user. Alternative parameterizations are in principle possible. A tool is provided
 for the derivation of double-Gaussian transfer functions,
 [TFtool](https://gitlab.cern.ch/KLFitter/TFtool).
 
@@ -356,7 +356,7 @@ for the derivation of double-Gaussian transfer functions,
 During the fit, the negative logarithm of the likelihood is minimized with
 minimization methods that are available from the
 [BAT](http://www.mppmu.mpg.de/bat/) library. The default algorithm for
-minimizaton is Minuit. Alternatively, simulated annealing or Markov Chain Monte
+minimization is Minuit. Alternatively, simulated annealing or Markov Chain Monte
 Carlo can be used:
 
 ```c++

--- a/doc/WhatIsKLF.md
+++ b/doc/WhatIsKLF.md
@@ -293,7 +293,7 @@ LikelihoodSgTopWtLJ::SetLeptonicTop();
 
 
 
-### Using flavor-tagging information
+## Using flavor-tagging information
 
 There are several ways of considering flavor-tagging information in KLFitter,
 which can be set for the likelihoods via the
@@ -440,7 +440,7 @@ For each event and each permutation, after calling the fit method of the
 `KLFitter::Fitter` class, the fit status, the calculated likelihood values, and
 detailed information about the permutation can be retrieved.
 
-##### Fit convergence status
+#### Fit convergence status
 
 The fit convergence status can be obtained and stored in an unsigned integer bit
 word via:
@@ -470,7 +470,7 @@ with the bit-wise _or_ operator:
 bool MinuitDidNotConverge = (ConvergenceStatusBitWord & fitter.MinuitDidNotConvergeMask) != 0;
 ```
 
-##### Retrieving the fit results
+#### Retrieving the fit results
 
 The instance of the fitter class also allows to retrieve the calculated log
 likelihood value of the fit. This, and the event probability can be extracted


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR does a couple of changes to the documentation of KLFitter. Those include:
- Fixes for a couple of typos
- Stricter enforcing of formatting in the documentation
- Re-commit of the FAQ document, switching from DOS to utf-8 encoding
- Updates to the author/contributor list