### PR TITLE
Introduce smart pointers in class Particles

### DIFF
--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -20,6 +20,7 @@
 #ifndef KLFITTER_PARTICLES_H_
 #define KLFITTER_PARTICLES_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -452,7 +453,7 @@ class Particles {
     * @param ptype The type of the particle.
     * @return The particle container.
     */
-  std::vector <TLorentzVector *> * ParticleContainer(KLFitter::Particles::ParticleType ptype);
+  std::vector <std::unique_ptr<TLorentzVector> > * ParticleContainer(KLFitter::Particles::ParticleType ptype);
 
   /**
     * Return the particle name container of a type of particles
@@ -467,7 +468,7 @@ class Particles {
     * @param index The index of particle.
     * @return An error flag.
     */
-  int CheckIndex(std::vector <TLorentzVector *> * container, int index);
+  int CheckIndex(std::vector <std::unique_ptr<TLorentzVector> > * container, int index);
 
   /* @} */
 
@@ -475,37 +476,37 @@ class Particles {
   /**
     * A set of quarks and gluons.
     */
-  std::vector <TLorentzVector *> fPartons;
+  std::vector<std::unique_ptr<TLorentzVector> > fPartons;
 
   /**
     * A set of electrons.
     */
-  std::vector <TLorentzVector *> fElectrons;
+  std::vector <std::unique_ptr<TLorentzVector> > fElectrons;
 
   /**
     * A set of muons.
     */
-  std::vector <TLorentzVector *> fMuons;
+  std::vector <std::unique_ptr<TLorentzVector> > fMuons;
 
   /**
     * A set of taus.
     */
-  std::vector <TLorentzVector *> fTaus;
+  std::vector <std::unique_ptr<TLorentzVector> > fTaus;
 
   /**
     * A set of neutrinos.
     */
-  std::vector <TLorentzVector *> fNeutrinos;
+  std::vector <std::unique_ptr<TLorentzVector> > fNeutrinos;
 
   /**
     * A set of bosons.
     */
-  std::vector <TLorentzVector *> fBosons;
+  std::vector <std::unique_ptr<TLorentzVector> > fBosons;
 
   /**
     * A set of photons.
     */
-  std::vector <TLorentzVector *> fPhotons;
+  std::vector <std::unique_ptr<TLorentzVector> > fPhotons;
 
   /**
     * The name of the partons.

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -78,43 +78,43 @@ class Particles {
     * Return the number of partons.
     * @return The number of partons.
     */
-  int NPartons() { return static_cast<int>(fPartons -> size()); }
+  int NPartons() { return static_cast<int>(fPartons.size()); }
 
   /**
     * Return the number of electrons.
     * @return The number of electrons.
     */
-  int NElectrons() { return int (fElectrons -> size()); }
+  int NElectrons() { return int (fElectrons.size()); }
 
   /**
     * Return the number of muons.
     * @return The number of muons.
     */
-  int NMuons() { return int (fMuons -> size()); }
+  int NMuons() { return int (fMuons.size()); }
 
   /**
     * Return the number of taus.
     * @return The number of taus.
     */
-  int NTaus() { return int (fTaus -> size()); }
+  int NTaus() { return int (fTaus.size()); }
 
   /**
     * Return the number of neutrinos.
     * @return The number of neutrinos.
     */
-  int NNeutrinos() { return int (fNeutrinos -> size()); }
+  int NNeutrinos() { return int (fNeutrinos.size()); }
 
   /**
     * Return the number of bosons.
     * @return The number of bosons.
     */
-  int NBosons() { return int (fBosons -> size()); }
+  int NBosons() { return int (fBosons.size()); }
 
   /**
     * Return the number of photons.
     * @return The number of photons.
     */
-  int NPhotons() { return int (fPhotons -> size()); }
+  int NPhotons() { return int (fPhotons.size()); }
 
   /**
     * Return the particle with a certain name
@@ -194,7 +194,7 @@ class Particles {
     * Return the number of particles.
     * @return The number of particles.
     */
-  int NParticles() { return static_cast<int>(fPartons -> size() + fElectrons -> size() + fMuons -> size() + fTaus -> size() + fNeutrinos -> size() + fBosons -> size() + fPhotons -> size()); }
+  int NParticles() { return static_cast<int>(fPartons.size() + fElectrons.size() + fMuons.size() + fTaus.size() + fNeutrinos.size() + fBosons.size() + fPhotons.size()); }
 
   /**
     * Return the number of particles of a certain type.
@@ -271,42 +271,42 @@ class Particles {
     * @param index The parton index
     * @return The parton true flavor.
     */
-  TrueFlavorType TrueFlavor(int index) { return (*fTrueFlavor)[index]; }
+  TrueFlavorType TrueFlavor(int index) { return fTrueFlavor[index]; }
 
   /**
     * Return has the jet been b-tagged?
     * @param index The parton index
     * @return The parton b-tagging boolean.
     */
-  bool IsBTagged(int index) { return (*fIsBTagged)[index]; }
+  bool IsBTagged(int index) { return fIsBTagged[index]; }
 
   /**
     * Return the jet b-tagging efficiency.
     * @param index The parton index
     * @return The jet b-tagging efficiency.
     */
-  double BTaggingEfficiency(int index) { return (*fBTaggingEfficiency)[index]; }
+  double BTaggingEfficiency(int index) { return fBTaggingEfficiency[index]; }
 
   /**
     * Return the jet b-tagging rejection.
     * @param index The parton index
     * @return The jet b-tagging rejection.
     */
-  double BTaggingRejection(int index) { return (*fBTaggingRejection)[index]; }
+  double BTaggingRejection(int index) { return fBTaggingRejection[index]; }
 
   /**
     * Return the jet b-tagging weight.
     * @param index The parton index
     * @return The jet b-tagging weight.
     */
-  double BTagWeight(int index) { return (*fBTagWeight)[index]; }
+  double BTagWeight(int index) { return fBTagWeight[index]; }
 
   /**
     * Return the bool of a set tagging weight.
     * @param index The parton index
     * @return The bool of a set tagging weight
     */
-  bool BTagWeightSet(int index) { return (*fBTagWeightSet)[index]; }
+  bool BTagWeightSet(int index) { return fBTagWeightSet[index]; }
 
   /**
     * Return the detector eta of a particle with some index and type.
@@ -475,147 +475,147 @@ class Particles {
   /**
     * A set of quarks and gluons.
     */
-  std::vector <TLorentzVector *> * fPartons;
+  std::vector <TLorentzVector *> fPartons;
 
   /**
     * A set of electrons.
     */
-  std::vector <TLorentzVector *> * fElectrons;
+  std::vector <TLorentzVector *> fElectrons;
 
   /**
     * A set of muons.
     */
-  std::vector <TLorentzVector *> * fMuons;
+  std::vector <TLorentzVector *> fMuons;
 
   /**
     * A set of taus.
     */
-  std::vector <TLorentzVector *> * fTaus;
+  std::vector <TLorentzVector *> fTaus;
 
   /**
     * A set of neutrinos.
     */
-  std::vector <TLorentzVector *> * fNeutrinos;
+  std::vector <TLorentzVector *> fNeutrinos;
 
   /**
     * A set of bosons.
     */
-  std::vector <TLorentzVector *> * fBosons;
+  std::vector <TLorentzVector *> fBosons;
 
   /**
     * A set of photons.
     */
-  std::vector <TLorentzVector *> * fPhotons;
+  std::vector <TLorentzVector *> fPhotons;
 
   /**
     * The name of the partons.
     */
-  std::vector <std::string> * fNamePartons;
+  std::vector <std::string> fNamePartons;
 
   /**
     * The name of the electrons.
     */
-  std::vector <std::string> * fNameElectrons;
+  std::vector <std::string> fNameElectrons;
 
   /**
     * The name of the muons.
     */
-  std::vector <std::string> * fNameMuons;
+  std::vector <std::string> fNameMuons;
 
   /**
     * The name of the taus.
     */
-  std::vector <std::string> * fNameTaus;
+  std::vector <std::string> fNameTaus;
 
   /**
     * The name of the neutrinos.
     */
-  std::vector <std::string> * fNameNeutrinos;
+  std::vector <std::string> fNameNeutrinos;
 
   /**
     * The name of the bosons.
     */
-  std::vector <std::string> * fNameBosons;
+  std::vector <std::string> fNameBosons;
 
   /**
     * The name of the photons.
     */
-  std::vector <std::string> * fNamePhotons;
+  std::vector <std::string> fNamePhotons;
 
   /**
     * The index of the corresponding measured parton.
     */
-  std::vector <int> * fJetIndex;
+  std::vector <int> fJetIndex;
 
   /**
     * The index of the corresponding measured electron.
     */
-  std::vector <int> * fElectronIndex;
+  std::vector <int> fElectronIndex;
 
   /**
     * The index of the corresponding measured muon.
     */
-  std::vector <int> * fMuonIndex;
+  std::vector <int> fMuonIndex;
 
   /**
     * The index of the corresponding measured photon.
     */
-  std::vector <int> * fPhotonIndex;
+  std::vector <int> fPhotonIndex;
 
   /**
     * Vector containing the true flavor.
     */
-  std::vector<TrueFlavorType> * fTrueFlavor;
+  std::vector<TrueFlavorType> fTrueFlavor;
 
   /**
     * Vector containing a boolean for the b-tagging.
     */
-  std::vector<bool> * fIsBTagged;
+  std::vector<bool> fIsBTagged;
 
   /**
     * Vector containing the b-tagging efficiencies for the jets.
     */
-  std::vector<double> * fBTaggingEfficiency;
+  std::vector<double> fBTaggingEfficiency;
 
   /**
     * Vector containing the b-tagging rejection for the jets.
     */
-  std::vector<double> * fBTaggingRejection;
+  std::vector<double> fBTaggingRejection;
 
   /**
     * Vector containing the b-tagging weights for the jets.
     */
-  std::vector<double> * fBTagWeight;
+  std::vector<double> fBTagWeight;
 
   /**
     * Vector containing the bool if b-tagging weights for the jets were set.
     */
-  std::vector<bool> * fBTagWeightSet;
+  std::vector<bool> fBTagWeightSet;
 
   /**
     * Vector containing the detector eta of electrons.
     */
-  std::vector <double> * fElectronDetEta;
+  std::vector <double> fElectronDetEta;
   /**
     * Vector containing the detector eta of muons.
     */
-  std::vector <double> * fMuonDetEta;
+  std::vector <double> fMuonDetEta;
   /**
     * Vector containing the detector eta of jets.
     */
-  std::vector <double> * fJetDetEta;
+  std::vector <double> fJetDetEta;
   /**
     * Vector containing the detector eta of photons.
     */
-  std::vector <double> * fPhotonDetEta;
+  std::vector <double> fPhotonDetEta;
   /**
     * Vector containing the charge of electrons.
     */
-  std::vector <float> * fElectronCharge;
+  std::vector <float> fElectronCharge;
   /**
     * Vector containing the charge of muons.
     */
-  std::vector <float> * fMuonCharge;
+  std::vector <float> fMuonCharge;
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -453,7 +453,7 @@ class Particles {
     * @param ptype The type of the particle.
     * @return The particle container.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > * ParticleContainer(KLFitter::Particles::ParticleType ptype);
+  std::vector<std::unique_ptr<TLorentzVector> >* ParticleContainer(KLFitter::Particles::ParticleType ptype);
 
   /**
     * Return the particle name container of a type of particles
@@ -468,7 +468,7 @@ class Particles {
     * @param index The index of particle.
     * @return An error flag.
     */
-  int CheckIndex(std::vector <std::unique_ptr<TLorentzVector> > * container, int index);
+  int CheckIndex(std::vector<std::unique_ptr<TLorentzVector> >* container, int index);
 
   /* @} */
 
@@ -481,87 +481,87 @@ class Particles {
   /**
     * A set of electrons.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fElectrons;
+  std::vector<std::unique_ptr<TLorentzVector> > fElectrons;
 
   /**
     * A set of muons.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fMuons;
+  std::vector<std::unique_ptr<TLorentzVector> > fMuons;
 
   /**
     * A set of taus.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fTaus;
+  std::vector<std::unique_ptr<TLorentzVector> > fTaus;
 
   /**
     * A set of neutrinos.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fNeutrinos;
+  std::vector<std::unique_ptr<TLorentzVector> > fNeutrinos;
 
   /**
     * A set of bosons.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fBosons;
+  std::vector<std::unique_ptr<TLorentzVector> > fBosons;
 
   /**
     * A set of photons.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fPhotons;
+  std::vector<std::unique_ptr<TLorentzVector> > fPhotons;
 
   /**
     * The name of the partons.
     */
-  std::vector <std::string> fNamePartons;
+  std::vector<std::string> fNamePartons;
 
   /**
     * The name of the electrons.
     */
-  std::vector <std::string> fNameElectrons;
+  std::vector<std::string> fNameElectrons;
 
   /**
     * The name of the muons.
     */
-  std::vector <std::string> fNameMuons;
+  std::vector<std::string> fNameMuons;
 
   /**
     * The name of the taus.
     */
-  std::vector <std::string> fNameTaus;
+  std::vector<std::string> fNameTaus;
 
   /**
     * The name of the neutrinos.
     */
-  std::vector <std::string> fNameNeutrinos;
+  std::vector<std::string> fNameNeutrinos;
 
   /**
     * The name of the bosons.
     */
-  std::vector <std::string> fNameBosons;
+  std::vector<std::string> fNameBosons;
 
   /**
     * The name of the photons.
     */
-  std::vector <std::string> fNamePhotons;
+  std::vector<std::string> fNamePhotons;
 
   /**
     * The index of the corresponding measured parton.
     */
-  std::vector <int> fJetIndex;
+  std::vector<int> fJetIndex;
 
   /**
     * The index of the corresponding measured electron.
     */
-  std::vector <int> fElectronIndex;
+  std::vector<int> fElectronIndex;
 
   /**
     * The index of the corresponding measured muon.
     */
-  std::vector <int> fMuonIndex;
+  std::vector<int> fMuonIndex;
 
   /**
     * The index of the corresponding measured photon.
     */
-  std::vector <int> fPhotonIndex;
+  std::vector<int> fPhotonIndex;
 
   /**
     * Vector containing the true flavor.

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -32,7 +32,7 @@ KLFitter::Particles::~Particles() {
 // ---------------------------------------------------------
 int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex) {
   // get particle container
-  std::vector <std::unique_ptr<TLorentzVector> >* container = ParticleContainer(ptype);
+  auto container = ParticleContainer(ptype);
 
   // check if container exists
   if (!container) {
@@ -85,7 +85,7 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, f
 // ---------------------------------------------------------
 int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
   // get particle container
-  std::vector <std::unique_ptr<TLorentzVector> >* container = ParticleContainer(ptype);
+  auto container = ParticleContainer(ptype);
 
   // check if container exists
   if (!container) {
@@ -219,7 +219,7 @@ TLorentzVector* KLFitter::Particles::Particle(std::string name) {
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Particle(int index, KLFitter::Particles::ParticleType ptype) {
   // get particle container
-  std::vector <std::unique_ptr<TLorentzVector> >* container = ParticleContainer(ptype);
+  auto container = ParticleContainer(ptype);
 
   if (index < 0 || index > NParticles(ptype)) {
     std::cout << "KLFitter::Particles::Particle(). Index out of range." << std::endl;
@@ -349,14 +349,14 @@ TLorentzVector* KLFitter::Particles::Photon(int index) {
 }
 
 // ---------------------------------------------------------
-int  KLFitter::Particles::NParticles(KLFitter::Particles::ParticleType ptype) {
+int KLFitter::Particles::NParticles(KLFitter::Particles::ParticleType ptype) {
   return static_cast<int>(ParticleContainer(ptype)->size());
 }
 
 // ---------------------------------------------------------
 std::string KLFitter::Particles::NameParticle(int index, KLFitter::Particles::ParticleType ptype) {
   // get particle container
-  std::vector <std::unique_ptr<TLorentzVector> >* container = ParticleContainer(ptype);
+  auto container = ParticleContainer(ptype);
 
   // check container and index
   if (!CheckIndex(container, index))
@@ -367,7 +367,7 @@ std::string KLFitter::Particles::NameParticle(int index, KLFitter::Particles::Pa
 }
 
 // ---------------------------------------------------------
-int KLFitter::Particles::CheckIndex(std::vector <std::unique_ptr<TLorentzVector> >* container, int index) {
+int KLFitter::Particles::CheckIndex(std::vector<std::unique_ptr<TLorentzVector> >* container, int index) {
   // check container
   if (!container) {
     std::cout << "KLFitter::Particles::CheckIndex(). Container does not exist." << std::endl;
@@ -385,7 +385,7 @@ int KLFitter::Particles::CheckIndex(std::vector <std::unique_ptr<TLorentzVector>
 }
 
 // ---------------------------------------------------------
-std::vector <std::unique_ptr<TLorentzVector> >* KLFitter::Particles::ParticleContainer(KLFitter::Particles::ParticleType ptype) {
+std::vector<std::unique_ptr<TLorentzVector> >* KLFitter::Particles::ParticleContainer(KLFitter::Particles::ParticleType ptype) {
   // return particle container
   switch (ptype) {
   case KLFitter::Particles::kParton:

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -53,7 +53,7 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, f
   if (!FindParticle(name, vect, &index, &temptype)) {
     // add particle
     // create pointer copy of particle content which is owend by Particles
-    auto cparticle = std::make_unique<TLorentzVector>(particle->Px(), particle->Py(), particle->Pz(), particle->E());
+    std::unique_ptr<TLorentzVector> cparticle{new TLorentzVector{particle->Px(), particle->Py(), particle->Pz(), particle->E()}};
     container->emplace_back(std::move(cparticle));
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kElectron) {
@@ -106,7 +106,7 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, K
   if (!FindParticle(name, vect, &index, &temptype)) {
     // add particle
     // create pointer copy of particle content which is owend by Particles
-    auto cparticle = std::make_unique<TLorentzVector>(particle->Px(), particle->Py(), particle->Pz(), particle->E());
+    std::unique_ptr<TLorentzVector> cparticle{new TLorentzVector{particle->Px(), particle->Py(), particle->Pz(), particle->E()}};
     container->emplace_back(std::move(cparticle));
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kParton) {

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -22,170 +22,59 @@
 #include <iostream>
 
 // ---------------------------------------------------------
-KLFitter::Particles::Particles() :
-  fPartons(new std::vector <TLorentzVector *>(0)),
-  fElectrons(new std::vector <TLorentzVector *>(0)),
-  fMuons(new std::vector <TLorentzVector *>(0)),
-  fTaus(new std::vector <TLorentzVector *>(0)),
-  fNeutrinos(new std::vector <TLorentzVector *>(0)),
-  fBosons(new std::vector <TLorentzVector *>(0)),
-  fPhotons(new std::vector <TLorentzVector *>(0)),
-
-  fNamePartons(new std::vector <std::string>(0)),
-  fNameElectrons(new std::vector <std::string>(0)),
-  fNameMuons(new std::vector <std::string>(0)),
-  fNameTaus(new std::vector <std::string>(0)),
-  fNameNeutrinos(new std::vector <std::string>(0)),
-  fNameBosons(new std::vector <std::string>(0)),
-  fNamePhotons(new std::vector <std::string>(0)),
-
-  fJetIndex(new std::vector <int>(0)),
-  fElectronIndex(new std::vector <int>(0)),
-  fMuonIndex(new std::vector <int>(0)),
-  fPhotonIndex(new std::vector <int>(0)),
-
-  fTrueFlavor(new std::vector<TrueFlavorType>(0)),
-  fIsBTagged(new std::vector<bool>(0)),
-  fBTaggingEfficiency(new std::vector<double>(0)),
-  fBTaggingRejection(new std::vector<double>(0)),
-
-  fBTagWeight(new std::vector<double>(0)),
-  fBTagWeightSet(new std::vector<bool>(0)),
-
-  fElectronDetEta(new std::vector<double>(0)),
-  fMuonDetEta(new std::vector<double>(0)),
-  fJetDetEta(new std::vector<double>(0)),
-  fPhotonDetEta(new std::vector<double>(0)),
-  fElectronCharge(new std::vector<float>(0)),
-  fMuonCharge(new std::vector<float>(0)) {
+KLFitter::Particles::Particles() {
 }
 
 // ---------------------------------------------------------
 KLFitter::Particles::~Particles() {
-  while (!fPartons->empty()) {
-    TLorentzVector* lv = fPartons->front();
-    fPartons->erase(fPartons->begin());
+  while (!fPartons.empty()) {
+    TLorentzVector* lv = fPartons.front();
+    fPartons.erase(fPartons.begin());
     if (lv)
       delete lv;
   }
-  delete fPartons;
 
-  while (!fElectrons->empty()) {
-    TLorentzVector* lv = fElectrons->front();
-    fElectrons->erase(fElectrons->begin());
+  while (!fElectrons.empty()) {
+    TLorentzVector* lv = fElectrons.front();
+    fElectrons.erase(fElectrons.begin());
     if (lv)
       delete lv;
   }
-  delete fElectrons;
 
-  while (!fMuons->empty()) {
-    TLorentzVector* lv = fMuons->front();
-    fMuons->erase(fMuons->begin());
+  while (!fMuons.empty()) {
+    TLorentzVector* lv = fMuons.front();
+    fMuons.erase(fMuons.begin());
     if (lv)
       delete lv;
   }
-  delete fMuons;
 
-  while (!fTaus->empty()) {
-    TLorentzVector* lv = fTaus->front();
-    fTaus->erase(fTaus->begin());
+  while (!fTaus.empty()) {
+    TLorentzVector* lv = fTaus.front();
+    fTaus.erase(fTaus.begin());
     if (lv)
       delete lv;
   }
-  delete fTaus;
 
-  while (!fNeutrinos->empty()) {
-    TLorentzVector* lv = fNeutrinos->front();
-    fNeutrinos->erase(fNeutrinos->begin());
+  while (!fNeutrinos.empty()) {
+    TLorentzVector* lv = fNeutrinos.front();
+    fNeutrinos.erase(fNeutrinos.begin());
     if (lv)
       delete lv;
   }
-  delete fNeutrinos;
 
-  while (!fBosons->empty()) {
-    TLorentzVector* lv = fBosons->front();
-    fBosons->erase(fBosons->begin());
+  while (!fBosons.empty()) {
+    TLorentzVector* lv = fBosons.front();
+    fBosons.erase(fBosons.begin());
     if (lv)
       delete lv;
   }
-  delete fBosons;
 
-  while (!fPhotons->empty()) {
-    TLorentzVector* lv = fPhotons->front();
-    fPhotons->erase(fPhotons->begin());
+  while (!fPhotons.empty()) {
+    TLorentzVector* lv = fPhotons.front();
+    fPhotons.erase(fPhotons.begin());
     if (lv)
       delete lv;
   }
-  delete fPhotons;
-
-  if (fNamePartons)
-    delete fNamePartons;
-
-  if (fNameElectrons)
-    delete fNameElectrons;
-
-  if (fNameMuons)
-    delete fNameMuons;
-
-  if (fNameTaus)
-    delete fNameTaus;
-
-  if (fNameNeutrinos)
-    delete fNameNeutrinos;
-
-  if (fNameBosons)
-    delete fNameBosons;
-
-  if (fNamePhotons)
-    delete fNamePhotons;
-
-  if (fJetIndex)
-    delete fJetIndex;
-
-  if (fElectronIndex)
-    delete fElectronIndex;
-
-  if (fMuonIndex)
-    delete fMuonIndex;
-
-  if (fPhotonIndex)
-    delete fPhotonIndex;
-
-  if (fTrueFlavor)
-    delete fTrueFlavor;
-
-  if (fIsBTagged)
-    delete fIsBTagged;
-
-  if (fBTaggingEfficiency)
-    delete fBTaggingEfficiency;
-
-  if (fBTaggingRejection)
-    delete fBTaggingRejection;
-
-  if (fBTagWeight)
-    delete fBTagWeight;
-
-  if (fBTagWeightSet)
-    delete fBTagWeightSet;
-
-  if (fElectronDetEta)
-    delete fElectronDetEta;
-
-  if (fMuonDetEta)
-    delete fMuonDetEta;
-
-  if (fJetDetEta)
-    delete fJetDetEta;
-
-  if (fPhotonDetEta)
-    delete fPhotonDetEta;
-
-  if (fElectronCharge)
-    delete fElectronCharge;
-
-  if (fMuonCharge)
-    delete fMuonCharge;
 }
 
 // ---------------------------------------------------------
@@ -216,16 +105,16 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, f
     container->push_back(cparticle);
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kElectron) {
-      fElectronIndex->push_back(measuredindex);
-      fElectronDetEta->push_back(DetEta);
-      fElectronCharge->push_back(LepCharge);
+      fElectronIndex.push_back(measuredindex);
+      fElectronDetEta.push_back(DetEta);
+      fElectronCharge.push_back(LepCharge);
     } else if (ptype == KLFitter::Particles::kMuon) {
-      fMuonIndex->push_back(measuredindex);
-      fMuonDetEta->push_back(DetEta);
-      fMuonCharge->push_back(LepCharge);
+      fMuonIndex.push_back(measuredindex);
+      fMuonDetEta.push_back(DetEta);
+      fMuonCharge.push_back(LepCharge);
     } else if (ptype == KLFitter::Particles::kPhoton) {
-      fPhotonIndex->push_back(measuredindex);
-      fPhotonDetEta->push_back(DetEta);
+      fPhotonIndex.push_back(measuredindex);
+      fPhotonDetEta.push_back(DetEta);
     }
   } else {
     std::cout << "KLFitter::Particles::AddParticle(). Particle with the name " << name << " exists already." << std::endl;
@@ -269,27 +158,27 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, K
     container->push_back(cparticle);
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kParton) {
-      fTrueFlavor->push_back(trueflav);
-      fIsBTagged->push_back(isBtagged);
-      fBTaggingEfficiency->push_back(bTagEff);
-      fBTaggingRejection->push_back(bTagRej);
-      fJetIndex->push_back(measuredindex);
-      fJetDetEta->push_back(DetEta);
-      fBTagWeight->push_back(btagweight);
+      fTrueFlavor.push_back(trueflav);
+      fIsBTagged.push_back(isBtagged);
+      fBTaggingEfficiency.push_back(bTagEff);
+      fBTaggingRejection.push_back(bTagRej);
+      fJetIndex.push_back(measuredindex);
+      fJetDetEta.push_back(DetEta);
+      fBTagWeight.push_back(btagweight);
       if (btagweight != 999) {
-        fBTagWeightSet->push_back(true);
+        fBTagWeightSet.push_back(true);
       } else {
-        fBTagWeightSet->push_back(false);
+        fBTagWeightSet.push_back(false);
       }
     } else if (ptype == KLFitter::Particles::kElectron) {
-      fElectronIndex->push_back(measuredindex);
-      fElectronDetEta->push_back(DetEta);
+      fElectronIndex.push_back(measuredindex);
+      fElectronDetEta.push_back(DetEta);
     } else if (ptype == KLFitter::Particles::kMuon) {
-      fMuonIndex->push_back(measuredindex);
-      fMuonDetEta->push_back(DetEta);
+      fMuonIndex.push_back(measuredindex);
+      fMuonDetEta.push_back(DetEta);
     } else if (ptype == KLFitter::Particles::kPhoton) {
-      fPhotonIndex->push_back(measuredindex);
-      fPhotonDetEta->push_back(DetEta);
+      fPhotonIndex.push_back(measuredindex);
+      fPhotonDetEta.push_back(DetEta);
     }
   } else {
     std::cout << "KLFitter::Particles::AddParticle(). Particle with the name " << name << " exists already." << std::endl;
@@ -392,70 +281,70 @@ TLorentzVector* KLFitter::Particles::Particle(int index, KLFitter::Particles::Pa
 // ---------------------------------------------------------
 int KLFitter::Particles::FindParticle(std::string name, TLorentzVector* &particle, int *index, KLFitter::Particles::ParticleType *ptype) {
   // loop over all partons
-  unsigned int npartons = fNamePartons->size();
+  unsigned int npartons = fNamePartons.size();
   for (unsigned int i = 0; i < npartons; ++i)
-    if (name == (*fNamePartons)[i]) {
-      particle = (*fPartons)[i];
+    if (name == fNamePartons[i]) {
+      particle = fPartons[i];
       *index = i;
       *ptype = KLFitter::Particles::kParton;
       return 1;
     }
 
   // loop over all electrons
-  unsigned int nelectrons = fNameElectrons->size();
+  unsigned int nelectrons = fNameElectrons.size();
   for (unsigned int i = 0; i < nelectrons; ++i)
-    if (name == (*fNameElectrons)[i]) {
-      particle = (*fElectrons)[i];
+    if (name == fNameElectrons[i]) {
+      particle = fElectrons[i];
       *index = i;
       *ptype = KLFitter::Particles::kElectron;
       return 1;
     }
 
   // loop over all muons
-  unsigned int nmuons = fNameMuons->size();
+  unsigned int nmuons = fNameMuons.size();
   for (unsigned int i = 0; i < nmuons; ++i)
-    if (name == (*fNameMuons)[i]) {
-      particle = (*fMuons)[i];
+    if (name == fNameMuons[i]) {
+      particle = fMuons[i];
       *index = i;
       *ptype = KLFitter::Particles::kMuon;
       return 1;
     }
 
   // loop over all taus
-  unsigned int ntaus = fNameTaus->size();
+  unsigned int ntaus = fNameTaus.size();
   for (unsigned int i = 0; i < ntaus; ++i)
-    if (name == (*fNameTaus)[i]) {
-      particle = (*fTaus)[i];
+    if (name == fNameTaus[i]) {
+      particle = fTaus[i];
       *index = i;
       *ptype = KLFitter::Particles::kTau;
       return 1;
     }
 
   // loop over all neutrinos
-  unsigned int nneutrinos = fNameNeutrinos->size();
+  unsigned int nneutrinos = fNameNeutrinos.size();
   for (unsigned int i = 0; i < nneutrinos; ++i)
-    if (name == (*fNameNeutrinos)[i]) {
-      particle = (*fNeutrinos)[i];
+    if (name == fNameNeutrinos[i]) {
+      particle = fNeutrinos[i];
       *index = i;
       *ptype = KLFitter::Particles::kNeutrino;
       return 1;
     }
 
   // loop over all bosons
-  unsigned int nbosons = fNameBosons->size();
+  unsigned int nbosons = fNameBosons.size();
   for (unsigned int i = 0; i < nbosons; ++i)
-    if (name == (*fNameBosons)[i]) {
-      particle = (*fBosons)[i];
+    if (name == fNameBosons[i]) {
+      particle = fBosons[i];
       *index = i;
       *ptype = KLFitter::Particles::kBoson;
       return 1;
     }
 
   // loop over all photons
-  unsigned int nphotons = fNamePhotons->size();
+  unsigned int nphotons = fNamePhotons.size();
   for (unsigned int i = 0; i < nphotons; ++i)
-    if (name == (*fNamePhotons)[i]) {
-      particle = (*fPhotons)[i];
+    if (name == fNamePhotons[i]) {
+      particle = fPhotons[i];
       *index = i;
       *ptype = KLFitter::Particles::kPhoton;
       return 1;
@@ -468,43 +357,43 @@ int KLFitter::Particles::FindParticle(std::string name, TLorentzVector* &particl
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Parton(int index) {
   // no check on index range for CPU-time reasons
-  return (*fPartons)[index];
+  return fPartons[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Electron(int index) {
   // no check on index range for CPU-time reasons
-  return (*fElectrons)[index];
+  return fElectrons[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Muon(int index) {
   // no check on index range for CPU-time reasons
-  return (*fMuons)[index];
+  return fMuons[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Tau(int index) {
   // no check on index range for CPU-time reasons
-  return (*fTaus)[index];
+  return fTaus[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Boson(int index) {
   // no check on index range for CPU-time reasons
-  return (*fBosons)[index];
+  return fBosons[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Neutrino(int index) {
   // no check on index range for CPU-time reasons
-  return (*fNeutrinos)[index];
+  return fNeutrinos[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Photon(int index) {
   // no check on index range for CPU-time reasons
-  return (*fPhotons)[index];
+  return fPhotons[index];
 }
 
 // ---------------------------------------------------------
@@ -548,25 +437,25 @@ std::vector <TLorentzVector *>* KLFitter::Particles::ParticleContainer(KLFitter:
   // return particle container
   switch (ptype) {
   case KLFitter::Particles::kParton:
-    return fPartons;
+    return &fPartons;
     break;
   case KLFitter::Particles::kElectron:
-    return fElectrons;
+    return &fElectrons;
     break;
   case KLFitter::Particles::kMuon:
-    return fMuons;
+    return &fMuons;
     break;
   case KLFitter::Particles::kTau:
-    return fTaus;
+    return &fTaus;
     break;
   case KLFitter::Particles::kNeutrino:
-    return fNeutrinos;
+    return &fNeutrinos;
     break;
   case KLFitter::Particles::kBoson:
-    return fBosons;
+    return &fBosons;
     break;
   case KLFitter::Particles::kPhoton:
-    return fPhotons;
+    return &fPhotons;
     break;
   }
 
@@ -579,19 +468,19 @@ std::vector <TLorentzVector *>* KLFitter::Particles::ParticleContainer(KLFitter:
 std::vector <std::string>* KLFitter::Particles::ParticleNameContainer(KLFitter::Particles::ParticleType ptype) {
   // return container
   if (ptype == KLFitter::Particles::kParton) {
-    return fNamePartons;
+    return &fNamePartons;
   } else if (ptype == KLFitter::Particles::kElectron) {
-    return fNameElectrons;
+    return &fNameElectrons;
   } else if (ptype == KLFitter::Particles::kMuon) {
-    return fNameMuons;
+    return &fNameMuons;
   } else if (ptype == KLFitter::Particles::kTau) {
-    return fNameTaus;
+    return &fNameTaus;
   } else if (ptype == KLFitter::Particles::kBoson) {
-    return fNameBosons;
+    return &fNameBosons;
   } else if (ptype == KLFitter::Particles::kNeutrino) {
-    return fNameNeutrinos;
+    return &fNameNeutrinos;
   } else if (ptype == KLFitter::Particles::kPhoton) {
-    return fNamePhotons;
+    return &fNamePhotons;
   } else {
     // or null pointer
     std::cout << "KLFitter::Particles::ParticleNameContainer(). Particle type not known." << std::endl;
@@ -607,13 +496,13 @@ double KLFitter::Particles::DetEta(int index, KLFitter::Particles::ParticleType 
   }
 
   if (ptype == KLFitter::Particles::kParton) {
-    return (*fJetDetEta)[index];
+    return fJetDetEta[index];
   } else if (ptype == KLFitter::Particles::kElectron) {
-    return (*fElectronDetEta)[index];
+    return fElectronDetEta[index];
   } else if (ptype == KLFitter::Particles::kMuon) {
-    return (*fMuonDetEta)[index];
+    return fMuonDetEta[index];
   } else if (ptype == KLFitter::Particles::kPhoton) {
-    return (*fPhotonDetEta)[index];
+    return fPhotonDetEta[index];
   }
 
   // return error value
@@ -628,16 +517,16 @@ float KLFitter::Particles::LeptonCharge(int index, KLFitter::Particles::Particle
   }
 
   if (ptype == KLFitter::Particles::kElectron) {
-    if (fElectronCharge->size()== 0) {
+    if (fElectronCharge.size()== 0) {
       return -9;
     } else {
-      return (*fElectronCharge)[index];
+      return fElectronCharge[index];
     }
   } else if (ptype == KLFitter::Particles::kMuon) {
-    if (fMuonCharge->size()== 0) {
+    if (fMuonCharge.size()== 0) {
       return -9;
     } else {
-      return (*fMuonCharge)[index];
+      return fMuonCharge[index];
     }
   } else {
     std::cout << "KLFitter::Particles::LepCharge NO LEPTON TYPE!" << std::endl;
@@ -650,36 +539,36 @@ float KLFitter::Particles::LeptonCharge(int index, KLFitter::Particles::Particle
 // ---------------------------------------------------------
 int KLFitter::Particles::JetIndex(int index) {
   // no check on index range for CPU-time reasons
-  return (*fJetIndex)[index];
+  return fJetIndex[index];
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::ElectronIndex(int index) {
   // no check on index range for CPU-time reasons
-  return (*fElectronIndex)[index];
+  return fElectronIndex[index];
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::MuonIndex(int index) {
   // no check on index range for CPU-time reasons
-  return (*fMuonIndex)[index];
+  return fMuonIndex[index];
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::PhotonIndex(int index) {
   // no check on index range for CPU-time reasons
-  return (*fPhotonIndex)[index];
+  return fPhotonIndex[index];
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::SetIsBTagged(int index, bool isBTagged) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fIsBTagged->size())) {
+  if (index < 0 || index >= static_cast<int>(fIsBTagged.size())) {
     std::cout << " KLFitter::SetIsBTagged(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fIsBTagged)[index] = isBTagged;
+  fIsBTagged[index] = isBTagged;
 
   return 1;
 }
@@ -687,12 +576,12 @@ int KLFitter::Particles::SetIsBTagged(int index, bool isBTagged) {
 // ---------------------------------------------------------
 int KLFitter::Particles::SetBTagWeight(int index, double btagweight) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fBTagWeight->size())) {
+  if (index < 0 || index >= static_cast<int>(fBTagWeight.size())) {
     std::cout << " KLFitter::SetBTagWeight(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fBTagWeight)[index] = btagweight;
+  fBTagWeight[index] = btagweight;
   SetBTagWeightSet(index, true);
 
   return 1;
@@ -701,12 +590,12 @@ int KLFitter::Particles::SetBTagWeight(int index, double btagweight) {
 // ---------------------------------------------------------
 int KLFitter::Particles::SetBTagWeightSet(int index, bool btagweightset) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fBTagWeightSet->size())) {
+  if (index < 0 || index >= static_cast<int>(fBTagWeightSet.size())) {
     std::cout << " KLFitter::SetBTagWeightSet(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fBTagWeightSet)[index] = btagweightset;
+  fBTagWeightSet[index] = btagweightset;
 
   return 1;
 }
@@ -714,12 +603,12 @@ int KLFitter::Particles::SetBTagWeightSet(int index, bool btagweightset) {
 // ---------------------------------------------------------
 int KLFitter::Particles::SetBTaggingEfficiency(int index, double btagEff) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fBTaggingEfficiency->size())) {
+  if (index < 0 || index >= static_cast<int>(fBTaggingEfficiency.size())) {
     std::cout << " KLFitter::SetBTaggingEfficiency(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fBTaggingEfficiency)[index] = btagEff;
+  fBTaggingEfficiency[index] = btagEff;
 
   return 1;
 }
@@ -727,23 +616,23 @@ int KLFitter::Particles::SetBTaggingEfficiency(int index, double btagEff) {
 // ---------------------------------------------------------
 int KLFitter::Particles::SetBTaggingRejection(int index, double btagRej) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fBTaggingRejection->size())) {
+  if (index < 0 || index >= static_cast<int>(fBTaggingRejection.size())) {
     std::cout << " KLFitter::SetBTaggingRejection(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fBTaggingRejection)[index] = btagRej;
+  fBTaggingRejection[index] = btagRej;
 
   return 1;
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::NBTags() {
-  unsigned int n = fIsBTagged->size();
+  unsigned int n = fIsBTagged.size();
   int sum = 0;
 
   for (unsigned int i = 0; i < n; ++i) {
-    if ((*fIsBTagged)[i]) {
+    if (fIsBTagged[i]) {
       sum++;
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes raw pointers from & introduces smart pointers to the class `Particles`. In particular, this class contained lots of pointers to containers, that had to be initialised in the constructor, and deleted in the destructor. Pointers there were unnecessary, so they were removed. 

A lot of these containers had, in addition, entries of pointer types, e.g. `std::vector<TLorentzVector*>*`. This made their handling a little more complicated than necessary. To avoid the necessary inclusion of the TLorentzVector class, these raw pointers were _not_ converted into objects types, but into smart pointers. That is, those containers now became `std::vector<std::unique_ptr<TLorentzVector>>`. This will allow forward declarations of the TLorentzVector class, which will be addressed in another PR.

With the switch from pointers to objects, and from raw to smart pointers, a lot of minor syntax changes throughout the class were necessary. In particular, it was necessary to adjust the method
```diff
-  std::vector <TLorentzVector *> * ParticleContainer(KLFitter::Particles::ParticleType ptype);
+  std::vector<std::unique_ptr<TLorentzVector> >* ParticleContainer(KLFitter::Particles::ParticleType ptype);
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#16 (removal of raw pointers)
#21 (reduction of ROOT dependencies/includes)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This clarifies a lot of the syntax; constructor and destructor implementations became unnecessary. In addition, memory is handled automatically, no `delete` commands necessary anywhere anymore.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The code was compiled and tested with the included unit tests and the example file. The behaviour is identical to what it was before. Valgrind was used to check for potential memory leaks. Here are the outputs before and after the changes:
```
==23239== LEAK SUMMARY:
==23239==    definitely lost: 144 bytes in 6 blocks
==23239==    indirectly lost: 168 bytes in 6 blocks
==23239==      possibly lost: 114,840 bytes in 883 blocks
==23239==    still reachable: 61,833,697 bytes in 98,383 blocks
==23239==         suppressed: 0 bytes in 0 blocks
```
```
==22560== LEAK SUMMARY:
==22560==    definitely lost: 144 bytes in 6 blocks
==22560==    indirectly lost: 168 bytes in 6 blocks
==22560==      possibly lost: 115,376 bytes in 890 blocks
==22560==    still reachable: 61,833,161 bytes in 98,376 blocks
==22560==         suppressed: 0 bytes in 0 blocks
```
All reported losses (definitely, indirectly, possibly) are due to cling/ROOT ... 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
