### PR TITLE
Reduce ROOT dependencies in public header files

### DIFF
--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -20,15 +20,17 @@
 #ifndef KLFITTER_BOOSTEDLIKELIHOODTOPLEPTONJETS_H_
 #define KLFITTER_BOOSTEDLIKELIHOODTOPLEPTONJETS_H_
 
+#include <cmath>
 #include <iostream>
 #include <vector>
+
+class TLorentzVector;
 
 namespace KLFitter {
   class ResolutionBase;
 }
 
 #include "KLFitter/LikelihoodBase.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -26,7 +26,6 @@
 #include "BAT/BCLog.h"
 #include "BAT/BCModel.h"
 #include "KLFitter/Particles.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -107,12 +107,12 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   /**
     * Associate the hadronic leg of the event to the top quark for likelihood calculation.
     */
-  void SetHadronicTop() { fHadronicTop = kTRUE; }
+  void SetHadronicTop() { fHadronicTop = true; }
 
   /**
     * Associate the leptonic leg of the event to the top quark for likelihood calculation.
     */
-  void SetLeptonicTop() { fHadronicTop = kFALSE; }
+  void SetLeptonicTop() { fHadronicTop = false; }
 
   void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -20,6 +20,7 @@
 #ifndef KLFITTER_LIKELIHOODSGTOPWTLJ_H_
 #define KLFITTER_LIKELIHOODSGTOPWTLJ_H_
 
+#include <cmath>
 #include <vector>
 
 namespace KLFitter {

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -20,15 +20,17 @@
 #ifndef KLFITTER_LIKELIHOODTTHLEPTONJETS_H_
 #define KLFITTER_LIKELIHOODTTHLEPTONJETS_H_
 
+#include <cmath>
 #include <iostream>
 #include <vector>
+
+class TLorentzVector;
 
 namespace KLFitter {
   class ResolutionBase;
 }
 
 #include "KLFitter/LikelihoodBase.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -20,6 +20,7 @@
 #ifndef KLFITTER_LIKELIHOODTTZTRILEPTON_H_
 #define KLFITTER_LIKELIHOODTTZTRILEPTON_H_
 
+#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -28,7 +29,6 @@ namespace KLFitter {
 }
 
 #include "KLFitter/LikelihoodBase.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -20,6 +20,7 @@
 #ifndef KLFITTER_LIKELIHOODTOPALLHADRONIC_H_
 #define KLFITTER_LIKELIHOODTOPALLHADRONIC_H_
 
+#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -28,7 +29,6 @@ namespace KLFitter {
 }
 
 #include "KLFitter/LikelihoodBase.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -27,14 +27,16 @@
 #include <utility>
 #include <vector>
 
+class TLorentzVector;
+
 namespace KLFitter {
+  class NuSolutions;  // defined in implementation file
   class ResolutionBase;
 }
 
 #include "BAT/BCH1D.h"
 #include "BAT/BCModel.h"
 #include "KLFitter/LikelihoodBase.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 
@@ -43,15 +45,6 @@ namespace KLFitter {
  * \brief The KLFitter namespace
  */
 namespace KLFitter {
-//! Neutrino Solution Set
-class NuSolutions {
- public:
-  TLorentzVector nu1, nu2;
-  int NSolutions;
-  NuSolutions():NSolutions(0) {}
-  ~NuSolutions() {}
-};
-
 /**
   * \class KLFitter::LikelihoodTopDilepton
   * \brief A class implementing a likelihood for the ttbar dilepton channel.

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -20,15 +20,17 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETS_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETS_H_
 
+#include <cmath>
 #include <iostream>
 #include <vector>
+
+class TLorentzVector;
 
 namespace KLFitter {
   class ResolutionBase;
 }
 
 #include "KLFitter/LikelihoodBase.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -22,14 +22,15 @@
 
 #include <iostream>
 
+class TH1F;
+class TH2F;
+class TLorentzVector;
+
 namespace KLFitter {
   class ResolutionBase;
 }
 
 #include "KLFitter/LikelihoodTopLeptonJets.h"
-#include "TH1F.h"
-#include "TH2F.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -20,15 +20,17 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETS_ANGULAR_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETS_ANGULAR_H_
 
+#include <cmath>
 #include <iostream>
 #include <vector>
+
+class TLorentzVector;
 
 namespace KLFitter {
   class ResolutionBase;
 }
 
 #include "KLFitter/LikelihoodBase.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -20,15 +20,17 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETS_JETANGLES_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETS_JETANGLES_H_
 
+#include <cmath>
 #include <iostream>
 #include <vector>
+
+class TLorentzVector;
 
 namespace KLFitter {
   class ResolutionBase;
 }
 
 #include "KLFitter/LikelihoodBase.h"
-#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -20,6 +20,7 @@
 #ifndef KLFITTER_PARTICLES_H_
 #define KLFITTER_PARTICLES_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -452,7 +453,7 @@ class Particles {
     * @param ptype The type of the particle.
     * @return The particle container.
     */
-  std::vector <TLorentzVector *> * ParticleContainer(KLFitter::Particles::ParticleType ptype);
+  std::vector <std::unique_ptr<TLorentzVector> > * ParticleContainer(KLFitter::Particles::ParticleType ptype);
 
   /**
     * Return the particle name container of a type of particles
@@ -467,7 +468,7 @@ class Particles {
     * @param index The index of particle.
     * @return An error flag.
     */
-  int CheckIndex(std::vector <TLorentzVector *> * container, int index);
+  int CheckIndex(std::vector <std::unique_ptr<TLorentzVector> > * container, int index);
 
   /* @} */
 
@@ -475,37 +476,37 @@ class Particles {
   /**
     * A set of quarks and gluons.
     */
-  std::vector <TLorentzVector *> fPartons;
+  std::vector<std::unique_ptr<TLorentzVector> > fPartons;
 
   /**
     * A set of electrons.
     */
-  std::vector <TLorentzVector *> fElectrons;
+  std::vector <std::unique_ptr<TLorentzVector> > fElectrons;
 
   /**
     * A set of muons.
     */
-  std::vector <TLorentzVector *> fMuons;
+  std::vector <std::unique_ptr<TLorentzVector> > fMuons;
 
   /**
     * A set of taus.
     */
-  std::vector <TLorentzVector *> fTaus;
+  std::vector <std::unique_ptr<TLorentzVector> > fTaus;
 
   /**
     * A set of neutrinos.
     */
-  std::vector <TLorentzVector *> fNeutrinos;
+  std::vector <std::unique_ptr<TLorentzVector> > fNeutrinos;
 
   /**
     * A set of bosons.
     */
-  std::vector <TLorentzVector *> fBosons;
+  std::vector <std::unique_ptr<TLorentzVector> > fBosons;
 
   /**
     * A set of photons.
     */
-  std::vector <TLorentzVector *> fPhotons;
+  std::vector <std::unique_ptr<TLorentzVector> > fPhotons;
 
   /**
     * The name of the partons.

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -24,8 +24,6 @@
 #include <string>
 #include <vector>
 
-#include "TLorentzVector.h"
-
 // ---------------------------------------------------------
 
 class TLorentzVector;

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -78,43 +78,43 @@ class Particles {
     * Return the number of partons.
     * @return The number of partons.
     */
-  int NPartons() { return static_cast<int>(fPartons -> size()); }
+  int NPartons() { return static_cast<int>(fPartons.size()); }
 
   /**
     * Return the number of electrons.
     * @return The number of electrons.
     */
-  int NElectrons() { return int (fElectrons -> size()); }
+  int NElectrons() { return int (fElectrons.size()); }
 
   /**
     * Return the number of muons.
     * @return The number of muons.
     */
-  int NMuons() { return int (fMuons -> size()); }
+  int NMuons() { return int (fMuons.size()); }
 
   /**
     * Return the number of taus.
     * @return The number of taus.
     */
-  int NTaus() { return int (fTaus -> size()); }
+  int NTaus() { return int (fTaus.size()); }
 
   /**
     * Return the number of neutrinos.
     * @return The number of neutrinos.
     */
-  int NNeutrinos() { return int (fNeutrinos -> size()); }
+  int NNeutrinos() { return int (fNeutrinos.size()); }
 
   /**
     * Return the number of bosons.
     * @return The number of bosons.
     */
-  int NBosons() { return int (fBosons -> size()); }
+  int NBosons() { return int (fBosons.size()); }
 
   /**
     * Return the number of photons.
     * @return The number of photons.
     */
-  int NPhotons() { return int (fPhotons -> size()); }
+  int NPhotons() { return int (fPhotons.size()); }
 
   /**
     * Return the particle with a certain name
@@ -194,7 +194,7 @@ class Particles {
     * Return the number of particles.
     * @return The number of particles.
     */
-  int NParticles() { return static_cast<int>(fPartons -> size() + fElectrons -> size() + fMuons -> size() + fTaus -> size() + fNeutrinos -> size() + fBosons -> size() + fPhotons -> size()); }
+  int NParticles() { return static_cast<int>(fPartons.size() + fElectrons.size() + fMuons.size() + fTaus.size() + fNeutrinos.size() + fBosons.size() + fPhotons.size()); }
 
   /**
     * Return the number of particles of a certain type.
@@ -271,42 +271,42 @@ class Particles {
     * @param index The parton index
     * @return The parton true flavor.
     */
-  TrueFlavorType TrueFlavor(int index) { return (*fTrueFlavor)[index]; }
+  TrueFlavorType TrueFlavor(int index) { return fTrueFlavor[index]; }
 
   /**
     * Return has the jet been b-tagged?
     * @param index The parton index
     * @return The parton b-tagging boolean.
     */
-  bool IsBTagged(int index) { return (*fIsBTagged)[index]; }
+  bool IsBTagged(int index) { return fIsBTagged[index]; }
 
   /**
     * Return the jet b-tagging efficiency.
     * @param index The parton index
     * @return The jet b-tagging efficiency.
     */
-  double BTaggingEfficiency(int index) { return (*fBTaggingEfficiency)[index]; }
+  double BTaggingEfficiency(int index) { return fBTaggingEfficiency[index]; }
 
   /**
     * Return the jet b-tagging rejection.
     * @param index The parton index
     * @return The jet b-tagging rejection.
     */
-  double BTaggingRejection(int index) { return (*fBTaggingRejection)[index]; }
+  double BTaggingRejection(int index) { return fBTaggingRejection[index]; }
 
   /**
     * Return the jet b-tagging weight.
     * @param index The parton index
     * @return The jet b-tagging weight.
     */
-  double BTagWeight(int index) { return (*fBTagWeight)[index]; }
+  double BTagWeight(int index) { return fBTagWeight[index]; }
 
   /**
     * Return the bool of a set tagging weight.
     * @param index The parton index
     * @return The bool of a set tagging weight
     */
-  bool BTagWeightSet(int index) { return (*fBTagWeightSet)[index]; }
+  bool BTagWeightSet(int index) { return fBTagWeightSet[index]; }
 
   /**
     * Return the detector eta of a particle with some index and type.
@@ -475,147 +475,147 @@ class Particles {
   /**
     * A set of quarks and gluons.
     */
-  std::vector <TLorentzVector *> * fPartons;
+  std::vector <TLorentzVector *> fPartons;
 
   /**
     * A set of electrons.
     */
-  std::vector <TLorentzVector *> * fElectrons;
+  std::vector <TLorentzVector *> fElectrons;
 
   /**
     * A set of muons.
     */
-  std::vector <TLorentzVector *> * fMuons;
+  std::vector <TLorentzVector *> fMuons;
 
   /**
     * A set of taus.
     */
-  std::vector <TLorentzVector *> * fTaus;
+  std::vector <TLorentzVector *> fTaus;
 
   /**
     * A set of neutrinos.
     */
-  std::vector <TLorentzVector *> * fNeutrinos;
+  std::vector <TLorentzVector *> fNeutrinos;
 
   /**
     * A set of bosons.
     */
-  std::vector <TLorentzVector *> * fBosons;
+  std::vector <TLorentzVector *> fBosons;
 
   /**
     * A set of photons.
     */
-  std::vector <TLorentzVector *> * fPhotons;
+  std::vector <TLorentzVector *> fPhotons;
 
   /**
     * The name of the partons.
     */
-  std::vector <std::string> * fNamePartons;
+  std::vector <std::string> fNamePartons;
 
   /**
     * The name of the electrons.
     */
-  std::vector <std::string> * fNameElectrons;
+  std::vector <std::string> fNameElectrons;
 
   /**
     * The name of the muons.
     */
-  std::vector <std::string> * fNameMuons;
+  std::vector <std::string> fNameMuons;
 
   /**
     * The name of the taus.
     */
-  std::vector <std::string> * fNameTaus;
+  std::vector <std::string> fNameTaus;
 
   /**
     * The name of the neutrinos.
     */
-  std::vector <std::string> * fNameNeutrinos;
+  std::vector <std::string> fNameNeutrinos;
 
   /**
     * The name of the bosons.
     */
-  std::vector <std::string> * fNameBosons;
+  std::vector <std::string> fNameBosons;
 
   /**
     * The name of the photons.
     */
-  std::vector <std::string> * fNamePhotons;
+  std::vector <std::string> fNamePhotons;
 
   /**
     * The index of the corresponding measured parton.
     */
-  std::vector <int> * fJetIndex;
+  std::vector <int> fJetIndex;
 
   /**
     * The index of the corresponding measured electron.
     */
-  std::vector <int> * fElectronIndex;
+  std::vector <int> fElectronIndex;
 
   /**
     * The index of the corresponding measured muon.
     */
-  std::vector <int> * fMuonIndex;
+  std::vector <int> fMuonIndex;
 
   /**
     * The index of the corresponding measured photon.
     */
-  std::vector <int> * fPhotonIndex;
+  std::vector <int> fPhotonIndex;
 
   /**
     * Vector containing the true flavor.
     */
-  std::vector<TrueFlavorType> * fTrueFlavor;
+  std::vector<TrueFlavorType> fTrueFlavor;
 
   /**
     * Vector containing a boolean for the b-tagging.
     */
-  std::vector<bool> * fIsBTagged;
+  std::vector<bool> fIsBTagged;
 
   /**
     * Vector containing the b-tagging efficiencies for the jets.
     */
-  std::vector<double> * fBTaggingEfficiency;
+  std::vector<double> fBTaggingEfficiency;
 
   /**
     * Vector containing the b-tagging rejection for the jets.
     */
-  std::vector<double> * fBTaggingRejection;
+  std::vector<double> fBTaggingRejection;
 
   /**
     * Vector containing the b-tagging weights for the jets.
     */
-  std::vector<double> * fBTagWeight;
+  std::vector<double> fBTagWeight;
 
   /**
     * Vector containing the bool if b-tagging weights for the jets were set.
     */
-  std::vector<bool> * fBTagWeightSet;
+  std::vector<bool> fBTagWeightSet;
 
   /**
     * Vector containing the detector eta of electrons.
     */
-  std::vector <double> * fElectronDetEta;
+  std::vector <double> fElectronDetEta;
   /**
     * Vector containing the detector eta of muons.
     */
-  std::vector <double> * fMuonDetEta;
+  std::vector <double> fMuonDetEta;
   /**
     * Vector containing the detector eta of jets.
     */
-  std::vector <double> * fJetDetEta;
+  std::vector <double> fJetDetEta;
   /**
     * Vector containing the detector eta of photons.
     */
-  std::vector <double> * fPhotonDetEta;
+  std::vector <double> fPhotonDetEta;
   /**
     * Vector containing the charge of electrons.
     */
-  std::vector <float> * fElectronCharge;
+  std::vector <float> fElectronCharge;
   /**
     * Vector containing the charge of muons.
     */
-  std::vector <float> * fMuonCharge;
+  std::vector <float> fMuonCharge;
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -453,7 +453,7 @@ class Particles {
     * @param ptype The type of the particle.
     * @return The particle container.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > * ParticleContainer(KLFitter::Particles::ParticleType ptype);
+  std::vector<std::unique_ptr<TLorentzVector> >* ParticleContainer(KLFitter::Particles::ParticleType ptype);
 
   /**
     * Return the particle name container of a type of particles
@@ -468,7 +468,7 @@ class Particles {
     * @param index The index of particle.
     * @return An error flag.
     */
-  int CheckIndex(std::vector <std::unique_ptr<TLorentzVector> > * container, int index);
+  int CheckIndex(std::vector<std::unique_ptr<TLorentzVector> >* container, int index);
 
   /* @} */
 
@@ -481,87 +481,87 @@ class Particles {
   /**
     * A set of electrons.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fElectrons;
+  std::vector<std::unique_ptr<TLorentzVector> > fElectrons;
 
   /**
     * A set of muons.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fMuons;
+  std::vector<std::unique_ptr<TLorentzVector> > fMuons;
 
   /**
     * A set of taus.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fTaus;
+  std::vector<std::unique_ptr<TLorentzVector> > fTaus;
 
   /**
     * A set of neutrinos.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fNeutrinos;
+  std::vector<std::unique_ptr<TLorentzVector> > fNeutrinos;
 
   /**
     * A set of bosons.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fBosons;
+  std::vector<std::unique_ptr<TLorentzVector> > fBosons;
 
   /**
     * A set of photons.
     */
-  std::vector <std::unique_ptr<TLorentzVector> > fPhotons;
+  std::vector<std::unique_ptr<TLorentzVector> > fPhotons;
 
   /**
     * The name of the partons.
     */
-  std::vector <std::string> fNamePartons;
+  std::vector<std::string> fNamePartons;
 
   /**
     * The name of the electrons.
     */
-  std::vector <std::string> fNameElectrons;
+  std::vector<std::string> fNameElectrons;
 
   /**
     * The name of the muons.
     */
-  std::vector <std::string> fNameMuons;
+  std::vector<std::string> fNameMuons;
 
   /**
     * The name of the taus.
     */
-  std::vector <std::string> fNameTaus;
+  std::vector<std::string> fNameTaus;
 
   /**
     * The name of the neutrinos.
     */
-  std::vector <std::string> fNameNeutrinos;
+  std::vector<std::string> fNameNeutrinos;
 
   /**
     * The name of the bosons.
     */
-  std::vector <std::string> fNameBosons;
+  std::vector<std::string> fNameBosons;
 
   /**
     * The name of the photons.
     */
-  std::vector <std::string> fNamePhotons;
+  std::vector<std::string> fNamePhotons;
 
   /**
     * The index of the corresponding measured parton.
     */
-  std::vector <int> fJetIndex;
+  std::vector<int> fJetIndex;
 
   /**
     * The index of the corresponding measured electron.
     */
-  std::vector <int> fElectronIndex;
+  std::vector<int> fElectronIndex;
 
   /**
     * The index of the corresponding measured muon.
     */
-  std::vector <int> fMuonIndex;
+  std::vector<int> fMuonIndex;
 
   /**
     * The index of the corresponding measured photon.
     */
-  std::vector <int> fPhotonIndex;
+  std::vector<int> fPhotonIndex;
 
   /**
     * Vector containing the true flavor.

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -29,6 +29,7 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
+#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 KLFitter::BoostedLikelihoodTopLeptonJets::BoostedLikelihoodTopLeptonJets() : KLFitter::LikelihoodBase::LikelihoodBase()

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -29,6 +29,7 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
+#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodSgTopWtLJ::LikelihoodSgTopWtLJ(): KLFitter::LikelihoodBase::LikelihoodBase()

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -32,7 +32,7 @@
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodSgTopWtLJ::LikelihoodSgTopWtLJ(): KLFitter::LikelihoodBase::LikelihoodBase()
-  , fHadronicTop(kTRUE)
+  , fHadronicTop(true)
   , fFlagUseJetMass(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -29,6 +29,7 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
+#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodTTHLeptonJets::LikelihoodTTHLeptonJets() : KLFitter::LikelihoodBase::LikelihoodBase()

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -29,6 +29,7 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
+#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodTTZTrilepton::LikelihoodTTZTrilepton() : KLFitter::LikelihoodBase::LikelihoodBase()

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -30,6 +30,7 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
+#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopAllHadronic::LikelihoodTopAllHadronic() : KLFitter::LikelihoodBase::LikelihoodBase()

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -33,6 +33,16 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
+#include "TLorentzVector.h"
+
+//! Neutrino Solution Set
+class KLFitter::NuSolutions {
+public:
+  TLorentzVector nu1, nu2;
+  int NSolutions;
+  NuSolutions():NSolutions(0) {}
+  ~NuSolutions() {}
+};
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopDilepton::LikelihoodTopDilepton() : KLFitter::LikelihoodBase::LikelihoodBase()

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -29,6 +29,7 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
+#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets() : KLFitter::LikelihoodBase::LikelihoodBase()

--- a/src/LikelihoodTopLeptonJetsUDSep.cxx
+++ b/src/LikelihoodTopLeptonJetsUDSep.cxx
@@ -29,6 +29,9 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopLeptonJetsUDSep::LikelihoodTopLeptonJetsUDSep() : KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets(),

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -29,6 +29,7 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
+#include "TLorentzVector.h"
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopLeptonJets_Angular::LikelihoodTopLeptonJets_Angular() : KLFitter::LikelihoodBase::LikelihoodBase()

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -29,6 +29,7 @@
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/DetectorBase.h"
+#include "TLorentzVector.h"
 #include "TMath.h"
 
 // ---------------------------------------------------------

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -32,7 +32,7 @@ KLFitter::Particles::~Particles() {
 // ---------------------------------------------------------
 int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex) {
   // get particle container
-  std::vector <std::unique_ptr<TLorentzVector> >* container = ParticleContainer(ptype);
+  auto container = ParticleContainer(ptype);
 
   // check if container exists
   if (!container) {
@@ -85,7 +85,7 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, f
 // ---------------------------------------------------------
 int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
   // get particle container
-  std::vector <std::unique_ptr<TLorentzVector> >* container = ParticleContainer(ptype);
+  auto container = ParticleContainer(ptype);
 
   // check if container exists
   if (!container) {
@@ -219,7 +219,7 @@ TLorentzVector* KLFitter::Particles::Particle(std::string name) {
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Particle(int index, KLFitter::Particles::ParticleType ptype) {
   // get particle container
-  std::vector <std::unique_ptr<TLorentzVector> >* container = ParticleContainer(ptype);
+  auto container = ParticleContainer(ptype);
 
   if (index < 0 || index > NParticles(ptype)) {
     std::cout << "KLFitter::Particles::Particle(). Index out of range." << std::endl;
@@ -349,14 +349,14 @@ TLorentzVector* KLFitter::Particles::Photon(int index) {
 }
 
 // ---------------------------------------------------------
-int  KLFitter::Particles::NParticles(KLFitter::Particles::ParticleType ptype) {
+int KLFitter::Particles::NParticles(KLFitter::Particles::ParticleType ptype) {
   return static_cast<int>(ParticleContainer(ptype)->size());
 }
 
 // ---------------------------------------------------------
 std::string KLFitter::Particles::NameParticle(int index, KLFitter::Particles::ParticleType ptype) {
   // get particle container
-  std::vector <std::unique_ptr<TLorentzVector> >* container = ParticleContainer(ptype);
+  auto container = ParticleContainer(ptype);
 
   // check container and index
   if (!CheckIndex(container, index))
@@ -367,7 +367,7 @@ std::string KLFitter::Particles::NameParticle(int index, KLFitter::Particles::Pa
 }
 
 // ---------------------------------------------------------
-int KLFitter::Particles::CheckIndex(std::vector <std::unique_ptr<TLorentzVector> >* container, int index) {
+int KLFitter::Particles::CheckIndex(std::vector<std::unique_ptr<TLorentzVector> >* container, int index) {
   // check container
   if (!container) {
     std::cout << "KLFitter::Particles::CheckIndex(). Container does not exist." << std::endl;
@@ -385,7 +385,7 @@ int KLFitter::Particles::CheckIndex(std::vector <std::unique_ptr<TLorentzVector>
 }
 
 // ---------------------------------------------------------
-std::vector <std::unique_ptr<TLorentzVector> >* KLFitter::Particles::ParticleContainer(KLFitter::Particles::ParticleType ptype) {
+std::vector<std::unique_ptr<TLorentzVector> >* KLFitter::Particles::ParticleContainer(KLFitter::Particles::ParticleType ptype) {
   // return particle container
   switch (ptype) {
   case KLFitter::Particles::kParton:

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -21,6 +21,8 @@
 
 #include <iostream>
 
+#include "TLorentzVector.h"
+
 // ---------------------------------------------------------
 KLFitter::Particles::Particles() {
 }

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -53,7 +53,7 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, f
   if (!FindParticle(name, vect, &index, &temptype)) {
     // add particle
     // create pointer copy of particle content which is owend by Particles
-    auto cparticle = std::make_unique<TLorentzVector>(particle->Px(), particle->Py(), particle->Pz(), particle->E());
+    std::unique_ptr<TLorentzVector> cparticle{new TLorentzVector{particle->Px(), particle->Py(), particle->Pz(), particle->E()}};
     container->emplace_back(std::move(cparticle));
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kElectron) {
@@ -106,7 +106,7 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, K
   if (!FindParticle(name, vect, &index, &temptype)) {
     // add particle
     // create pointer copy of particle content which is owend by Particles
-    auto cparticle = std::make_unique<TLorentzVector>(particle->Px(), particle->Py(), particle->Pz(), particle->E());
+    std::unique_ptr<TLorentzVector> cparticle{new TLorentzVector{particle->Px(), particle->Py(), particle->Pz(), particle->E()}};
     container->emplace_back(std::move(cparticle));
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kParton) {

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -22,170 +22,59 @@
 #include <iostream>
 
 // ---------------------------------------------------------
-KLFitter::Particles::Particles() :
-  fPartons(new std::vector <TLorentzVector *>(0)),
-  fElectrons(new std::vector <TLorentzVector *>(0)),
-  fMuons(new std::vector <TLorentzVector *>(0)),
-  fTaus(new std::vector <TLorentzVector *>(0)),
-  fNeutrinos(new std::vector <TLorentzVector *>(0)),
-  fBosons(new std::vector <TLorentzVector *>(0)),
-  fPhotons(new std::vector <TLorentzVector *>(0)),
-
-  fNamePartons(new std::vector <std::string>(0)),
-  fNameElectrons(new std::vector <std::string>(0)),
-  fNameMuons(new std::vector <std::string>(0)),
-  fNameTaus(new std::vector <std::string>(0)),
-  fNameNeutrinos(new std::vector <std::string>(0)),
-  fNameBosons(new std::vector <std::string>(0)),
-  fNamePhotons(new std::vector <std::string>(0)),
-
-  fJetIndex(new std::vector <int>(0)),
-  fElectronIndex(new std::vector <int>(0)),
-  fMuonIndex(new std::vector <int>(0)),
-  fPhotonIndex(new std::vector <int>(0)),
-
-  fTrueFlavor(new std::vector<TrueFlavorType>(0)),
-  fIsBTagged(new std::vector<bool>(0)),
-  fBTaggingEfficiency(new std::vector<double>(0)),
-  fBTaggingRejection(new std::vector<double>(0)),
-
-  fBTagWeight(new std::vector<double>(0)),
-  fBTagWeightSet(new std::vector<bool>(0)),
-
-  fElectronDetEta(new std::vector<double>(0)),
-  fMuonDetEta(new std::vector<double>(0)),
-  fJetDetEta(new std::vector<double>(0)),
-  fPhotonDetEta(new std::vector<double>(0)),
-  fElectronCharge(new std::vector<float>(0)),
-  fMuonCharge(new std::vector<float>(0)) {
+KLFitter::Particles::Particles() {
 }
 
 // ---------------------------------------------------------
 KLFitter::Particles::~Particles() {
-  while (!fPartons->empty()) {
-    TLorentzVector* lv = fPartons->front();
-    fPartons->erase(fPartons->begin());
+  while (!fPartons.empty()) {
+    TLorentzVector* lv = fPartons.front();
+    fPartons.erase(fPartons.begin());
     if (lv)
       delete lv;
   }
-  delete fPartons;
 
-  while (!fElectrons->empty()) {
-    TLorentzVector* lv = fElectrons->front();
-    fElectrons->erase(fElectrons->begin());
+  while (!fElectrons.empty()) {
+    TLorentzVector* lv = fElectrons.front();
+    fElectrons.erase(fElectrons.begin());
     if (lv)
       delete lv;
   }
-  delete fElectrons;
 
-  while (!fMuons->empty()) {
-    TLorentzVector* lv = fMuons->front();
-    fMuons->erase(fMuons->begin());
+  while (!fMuons.empty()) {
+    TLorentzVector* lv = fMuons.front();
+    fMuons.erase(fMuons.begin());
     if (lv)
       delete lv;
   }
-  delete fMuons;
 
-  while (!fTaus->empty()) {
-    TLorentzVector* lv = fTaus->front();
-    fTaus->erase(fTaus->begin());
+  while (!fTaus.empty()) {
+    TLorentzVector* lv = fTaus.front();
+    fTaus.erase(fTaus.begin());
     if (lv)
       delete lv;
   }
-  delete fTaus;
 
-  while (!fNeutrinos->empty()) {
-    TLorentzVector* lv = fNeutrinos->front();
-    fNeutrinos->erase(fNeutrinos->begin());
+  while (!fNeutrinos.empty()) {
+    TLorentzVector* lv = fNeutrinos.front();
+    fNeutrinos.erase(fNeutrinos.begin());
     if (lv)
       delete lv;
   }
-  delete fNeutrinos;
 
-  while (!fBosons->empty()) {
-    TLorentzVector* lv = fBosons->front();
-    fBosons->erase(fBosons->begin());
+  while (!fBosons.empty()) {
+    TLorentzVector* lv = fBosons.front();
+    fBosons.erase(fBosons.begin());
     if (lv)
       delete lv;
   }
-  delete fBosons;
 
-  while (!fPhotons->empty()) {
-    TLorentzVector* lv = fPhotons->front();
-    fPhotons->erase(fPhotons->begin());
+  while (!fPhotons.empty()) {
+    TLorentzVector* lv = fPhotons.front();
+    fPhotons.erase(fPhotons.begin());
     if (lv)
       delete lv;
   }
-  delete fPhotons;
-
-  if (fNamePartons)
-    delete fNamePartons;
-
-  if (fNameElectrons)
-    delete fNameElectrons;
-
-  if (fNameMuons)
-    delete fNameMuons;
-
-  if (fNameTaus)
-    delete fNameTaus;
-
-  if (fNameNeutrinos)
-    delete fNameNeutrinos;
-
-  if (fNameBosons)
-    delete fNameBosons;
-
-  if (fNamePhotons)
-    delete fNamePhotons;
-
-  if (fJetIndex)
-    delete fJetIndex;
-
-  if (fElectronIndex)
-    delete fElectronIndex;
-
-  if (fMuonIndex)
-    delete fMuonIndex;
-
-  if (fPhotonIndex)
-    delete fPhotonIndex;
-
-  if (fTrueFlavor)
-    delete fTrueFlavor;
-
-  if (fIsBTagged)
-    delete fIsBTagged;
-
-  if (fBTaggingEfficiency)
-    delete fBTaggingEfficiency;
-
-  if (fBTaggingRejection)
-    delete fBTaggingRejection;
-
-  if (fBTagWeight)
-    delete fBTagWeight;
-
-  if (fBTagWeightSet)
-    delete fBTagWeightSet;
-
-  if (fElectronDetEta)
-    delete fElectronDetEta;
-
-  if (fMuonDetEta)
-    delete fMuonDetEta;
-
-  if (fJetDetEta)
-    delete fJetDetEta;
-
-  if (fPhotonDetEta)
-    delete fPhotonDetEta;
-
-  if (fElectronCharge)
-    delete fElectronCharge;
-
-  if (fMuonCharge)
-    delete fMuonCharge;
 }
 
 // ---------------------------------------------------------
@@ -216,16 +105,16 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, f
     container->push_back(cparticle);
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kElectron) {
-      fElectronIndex->push_back(measuredindex);
-      fElectronDetEta->push_back(DetEta);
-      fElectronCharge->push_back(LepCharge);
+      fElectronIndex.push_back(measuredindex);
+      fElectronDetEta.push_back(DetEta);
+      fElectronCharge.push_back(LepCharge);
     } else if (ptype == KLFitter::Particles::kMuon) {
-      fMuonIndex->push_back(measuredindex);
-      fMuonDetEta->push_back(DetEta);
-      fMuonCharge->push_back(LepCharge);
+      fMuonIndex.push_back(measuredindex);
+      fMuonDetEta.push_back(DetEta);
+      fMuonCharge.push_back(LepCharge);
     } else if (ptype == KLFitter::Particles::kPhoton) {
-      fPhotonIndex->push_back(measuredindex);
-      fPhotonDetEta->push_back(DetEta);
+      fPhotonIndex.push_back(measuredindex);
+      fPhotonDetEta.push_back(DetEta);
     }
   } else {
     std::cout << "KLFitter::Particles::AddParticle(). Particle with the name " << name << " exists already." << std::endl;
@@ -269,27 +158,27 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, K
     container->push_back(cparticle);
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kParton) {
-      fTrueFlavor->push_back(trueflav);
-      fIsBTagged->push_back(isBtagged);
-      fBTaggingEfficiency->push_back(bTagEff);
-      fBTaggingRejection->push_back(bTagRej);
-      fJetIndex->push_back(measuredindex);
-      fJetDetEta->push_back(DetEta);
-      fBTagWeight->push_back(btagweight);
+      fTrueFlavor.push_back(trueflav);
+      fIsBTagged.push_back(isBtagged);
+      fBTaggingEfficiency.push_back(bTagEff);
+      fBTaggingRejection.push_back(bTagRej);
+      fJetIndex.push_back(measuredindex);
+      fJetDetEta.push_back(DetEta);
+      fBTagWeight.push_back(btagweight);
       if (btagweight != 999) {
-        fBTagWeightSet->push_back(true);
+        fBTagWeightSet.push_back(true);
       } else {
-        fBTagWeightSet->push_back(false);
+        fBTagWeightSet.push_back(false);
       }
     } else if (ptype == KLFitter::Particles::kElectron) {
-      fElectronIndex->push_back(measuredindex);
-      fElectronDetEta->push_back(DetEta);
+      fElectronIndex.push_back(measuredindex);
+      fElectronDetEta.push_back(DetEta);
     } else if (ptype == KLFitter::Particles::kMuon) {
-      fMuonIndex->push_back(measuredindex);
-      fMuonDetEta->push_back(DetEta);
+      fMuonIndex.push_back(measuredindex);
+      fMuonDetEta.push_back(DetEta);
     } else if (ptype == KLFitter::Particles::kPhoton) {
-      fPhotonIndex->push_back(measuredindex);
-      fPhotonDetEta->push_back(DetEta);
+      fPhotonIndex.push_back(measuredindex);
+      fPhotonDetEta.push_back(DetEta);
     }
   } else {
     std::cout << "KLFitter::Particles::AddParticle(). Particle with the name " << name << " exists already." << std::endl;
@@ -392,70 +281,70 @@ TLorentzVector* KLFitter::Particles::Particle(int index, KLFitter::Particles::Pa
 // ---------------------------------------------------------
 int KLFitter::Particles::FindParticle(std::string name, TLorentzVector* &particle, int *index, KLFitter::Particles::ParticleType *ptype) {
   // loop over all partons
-  unsigned int npartons = fNamePartons->size();
+  unsigned int npartons = fNamePartons.size();
   for (unsigned int i = 0; i < npartons; ++i)
-    if (name == (*fNamePartons)[i]) {
-      particle = (*fPartons)[i];
+    if (name == fNamePartons[i]) {
+      particle = fPartons[i];
       *index = i;
       *ptype = KLFitter::Particles::kParton;
       return 1;
     }
 
   // loop over all electrons
-  unsigned int nelectrons = fNameElectrons->size();
+  unsigned int nelectrons = fNameElectrons.size();
   for (unsigned int i = 0; i < nelectrons; ++i)
-    if (name == (*fNameElectrons)[i]) {
-      particle = (*fElectrons)[i];
+    if (name == fNameElectrons[i]) {
+      particle = fElectrons[i];
       *index = i;
       *ptype = KLFitter::Particles::kElectron;
       return 1;
     }
 
   // loop over all muons
-  unsigned int nmuons = fNameMuons->size();
+  unsigned int nmuons = fNameMuons.size();
   for (unsigned int i = 0; i < nmuons; ++i)
-    if (name == (*fNameMuons)[i]) {
-      particle = (*fMuons)[i];
+    if (name == fNameMuons[i]) {
+      particle = fMuons[i];
       *index = i;
       *ptype = KLFitter::Particles::kMuon;
       return 1;
     }
 
   // loop over all taus
-  unsigned int ntaus = fNameTaus->size();
+  unsigned int ntaus = fNameTaus.size();
   for (unsigned int i = 0; i < ntaus; ++i)
-    if (name == (*fNameTaus)[i]) {
-      particle = (*fTaus)[i];
+    if (name == fNameTaus[i]) {
+      particle = fTaus[i];
       *index = i;
       *ptype = KLFitter::Particles::kTau;
       return 1;
     }
 
   // loop over all neutrinos
-  unsigned int nneutrinos = fNameNeutrinos->size();
+  unsigned int nneutrinos = fNameNeutrinos.size();
   for (unsigned int i = 0; i < nneutrinos; ++i)
-    if (name == (*fNameNeutrinos)[i]) {
-      particle = (*fNeutrinos)[i];
+    if (name == fNameNeutrinos[i]) {
+      particle = fNeutrinos[i];
       *index = i;
       *ptype = KLFitter::Particles::kNeutrino;
       return 1;
     }
 
   // loop over all bosons
-  unsigned int nbosons = fNameBosons->size();
+  unsigned int nbosons = fNameBosons.size();
   for (unsigned int i = 0; i < nbosons; ++i)
-    if (name == (*fNameBosons)[i]) {
-      particle = (*fBosons)[i];
+    if (name == fNameBosons[i]) {
+      particle = fBosons[i];
       *index = i;
       *ptype = KLFitter::Particles::kBoson;
       return 1;
     }
 
   // loop over all photons
-  unsigned int nphotons = fNamePhotons->size();
+  unsigned int nphotons = fNamePhotons.size();
   for (unsigned int i = 0; i < nphotons; ++i)
-    if (name == (*fNamePhotons)[i]) {
-      particle = (*fPhotons)[i];
+    if (name == fNamePhotons[i]) {
+      particle = fPhotons[i];
       *index = i;
       *ptype = KLFitter::Particles::kPhoton;
       return 1;
@@ -468,43 +357,43 @@ int KLFitter::Particles::FindParticle(std::string name, TLorentzVector* &particl
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Parton(int index) {
   // no check on index range for CPU-time reasons
-  return (*fPartons)[index];
+  return fPartons[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Electron(int index) {
   // no check on index range for CPU-time reasons
-  return (*fElectrons)[index];
+  return fElectrons[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Muon(int index) {
   // no check on index range for CPU-time reasons
-  return (*fMuons)[index];
+  return fMuons[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Tau(int index) {
   // no check on index range for CPU-time reasons
-  return (*fTaus)[index];
+  return fTaus[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Boson(int index) {
   // no check on index range for CPU-time reasons
-  return (*fBosons)[index];
+  return fBosons[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Neutrino(int index) {
   // no check on index range for CPU-time reasons
-  return (*fNeutrinos)[index];
+  return fNeutrinos[index];
 }
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::Particles::Photon(int index) {
   // no check on index range for CPU-time reasons
-  return (*fPhotons)[index];
+  return fPhotons[index];
 }
 
 // ---------------------------------------------------------
@@ -548,25 +437,25 @@ std::vector <TLorentzVector *>* KLFitter::Particles::ParticleContainer(KLFitter:
   // return particle container
   switch (ptype) {
   case KLFitter::Particles::kParton:
-    return fPartons;
+    return &fPartons;
     break;
   case KLFitter::Particles::kElectron:
-    return fElectrons;
+    return &fElectrons;
     break;
   case KLFitter::Particles::kMuon:
-    return fMuons;
+    return &fMuons;
     break;
   case KLFitter::Particles::kTau:
-    return fTaus;
+    return &fTaus;
     break;
   case KLFitter::Particles::kNeutrino:
-    return fNeutrinos;
+    return &fNeutrinos;
     break;
   case KLFitter::Particles::kBoson:
-    return fBosons;
+    return &fBosons;
     break;
   case KLFitter::Particles::kPhoton:
-    return fPhotons;
+    return &fPhotons;
     break;
   }
 
@@ -579,19 +468,19 @@ std::vector <TLorentzVector *>* KLFitter::Particles::ParticleContainer(KLFitter:
 std::vector <std::string>* KLFitter::Particles::ParticleNameContainer(KLFitter::Particles::ParticleType ptype) {
   // return container
   if (ptype == KLFitter::Particles::kParton) {
-    return fNamePartons;
+    return &fNamePartons;
   } else if (ptype == KLFitter::Particles::kElectron) {
-    return fNameElectrons;
+    return &fNameElectrons;
   } else if (ptype == KLFitter::Particles::kMuon) {
-    return fNameMuons;
+    return &fNameMuons;
   } else if (ptype == KLFitter::Particles::kTau) {
-    return fNameTaus;
+    return &fNameTaus;
   } else if (ptype == KLFitter::Particles::kBoson) {
-    return fNameBosons;
+    return &fNameBosons;
   } else if (ptype == KLFitter::Particles::kNeutrino) {
-    return fNameNeutrinos;
+    return &fNameNeutrinos;
   } else if (ptype == KLFitter::Particles::kPhoton) {
-    return fNamePhotons;
+    return &fNamePhotons;
   } else {
     // or null pointer
     std::cout << "KLFitter::Particles::ParticleNameContainer(). Particle type not known." << std::endl;
@@ -607,13 +496,13 @@ double KLFitter::Particles::DetEta(int index, KLFitter::Particles::ParticleType 
   }
 
   if (ptype == KLFitter::Particles::kParton) {
-    return (*fJetDetEta)[index];
+    return fJetDetEta[index];
   } else if (ptype == KLFitter::Particles::kElectron) {
-    return (*fElectronDetEta)[index];
+    return fElectronDetEta[index];
   } else if (ptype == KLFitter::Particles::kMuon) {
-    return (*fMuonDetEta)[index];
+    return fMuonDetEta[index];
   } else if (ptype == KLFitter::Particles::kPhoton) {
-    return (*fPhotonDetEta)[index];
+    return fPhotonDetEta[index];
   }
 
   // return error value
@@ -628,16 +517,16 @@ float KLFitter::Particles::LeptonCharge(int index, KLFitter::Particles::Particle
   }
 
   if (ptype == KLFitter::Particles::kElectron) {
-    if (fElectronCharge->size()== 0) {
+    if (fElectronCharge.size()== 0) {
       return -9;
     } else {
-      return (*fElectronCharge)[index];
+      return fElectronCharge[index];
     }
   } else if (ptype == KLFitter::Particles::kMuon) {
-    if (fMuonCharge->size()== 0) {
+    if (fMuonCharge.size()== 0) {
       return -9;
     } else {
-      return (*fMuonCharge)[index];
+      return fMuonCharge[index];
     }
   } else {
     std::cout << "KLFitter::Particles::LepCharge NO LEPTON TYPE!" << std::endl;
@@ -650,36 +539,36 @@ float KLFitter::Particles::LeptonCharge(int index, KLFitter::Particles::Particle
 // ---------------------------------------------------------
 int KLFitter::Particles::JetIndex(int index) {
   // no check on index range for CPU-time reasons
-  return (*fJetIndex)[index];
+  return fJetIndex[index];
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::ElectronIndex(int index) {
   // no check on index range for CPU-time reasons
-  return (*fElectronIndex)[index];
+  return fElectronIndex[index];
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::MuonIndex(int index) {
   // no check on index range for CPU-time reasons
-  return (*fMuonIndex)[index];
+  return fMuonIndex[index];
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::PhotonIndex(int index) {
   // no check on index range for CPU-time reasons
-  return (*fPhotonIndex)[index];
+  return fPhotonIndex[index];
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::SetIsBTagged(int index, bool isBTagged) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fIsBTagged->size())) {
+  if (index < 0 || index >= static_cast<int>(fIsBTagged.size())) {
     std::cout << " KLFitter::SetIsBTagged(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fIsBTagged)[index] = isBTagged;
+  fIsBTagged[index] = isBTagged;
 
   return 1;
 }
@@ -687,12 +576,12 @@ int KLFitter::Particles::SetIsBTagged(int index, bool isBTagged) {
 // ---------------------------------------------------------
 int KLFitter::Particles::SetBTagWeight(int index, double btagweight) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fBTagWeight->size())) {
+  if (index < 0 || index >= static_cast<int>(fBTagWeight.size())) {
     std::cout << " KLFitter::SetBTagWeight(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fBTagWeight)[index] = btagweight;
+  fBTagWeight[index] = btagweight;
   SetBTagWeightSet(index, true);
 
   return 1;
@@ -701,12 +590,12 @@ int KLFitter::Particles::SetBTagWeight(int index, double btagweight) {
 // ---------------------------------------------------------
 int KLFitter::Particles::SetBTagWeightSet(int index, bool btagweightset) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fBTagWeightSet->size())) {
+  if (index < 0 || index >= static_cast<int>(fBTagWeightSet.size())) {
     std::cout << " KLFitter::SetBTagWeightSet(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fBTagWeightSet)[index] = btagweightset;
+  fBTagWeightSet[index] = btagweightset;
 
   return 1;
 }
@@ -714,12 +603,12 @@ int KLFitter::Particles::SetBTagWeightSet(int index, bool btagweightset) {
 // ---------------------------------------------------------
 int KLFitter::Particles::SetBTaggingEfficiency(int index, double btagEff) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fBTaggingEfficiency->size())) {
+  if (index < 0 || index >= static_cast<int>(fBTaggingEfficiency.size())) {
     std::cout << " KLFitter::SetBTaggingEfficiency(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fBTaggingEfficiency)[index] = btagEff;
+  fBTaggingEfficiency[index] = btagEff;
 
   return 1;
 }
@@ -727,23 +616,23 @@ int KLFitter::Particles::SetBTaggingEfficiency(int index, double btagEff) {
 // ---------------------------------------------------------
 int KLFitter::Particles::SetBTaggingRejection(int index, double btagRej) {
   // check index
-  if (index < 0 || index >= static_cast<int>(fBTaggingRejection->size())) {
+  if (index < 0 || index >= static_cast<int>(fBTaggingRejection.size())) {
     std::cout << " KLFitter::SetBTaggingRejection(). Index out of range." << std::endl;
     return 0;
   }
 
-  (*fBTaggingRejection)[index] = btagRej;
+  fBTaggingRejection[index] = btagRej;
 
   return 1;
 }
 
 // ---------------------------------------------------------
 int KLFitter::Particles::NBTags() {
-  unsigned int n = fIsBTagged->size();
+  unsigned int n = fIsBTagged.size();
   int sum = 0;
 
   for (unsigned int i = 0; i < n; ++i) {
-    if ((*fIsBTagged)[i]) {
+    if (fIsBTagged[i]) {
       sum++;
     }
   }

--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -19,6 +19,7 @@
 
 #include "KLFitter/Permutations.h"
 
+#include <algorithm>
 #include <iostream>
 #include <set>
 
@@ -326,7 +327,7 @@ int KLFitter::Permutations::CreateSubTable(int Nobj, std::vector < std::vector<i
 
     do {
       table->push_back(new std::vector<int>(vidx));
-    } while (next_permutation(vidx.begin(), vidx.end()));
+    } while (std::next_permutation(vidx.begin(), vidx.end()));
   } else {
     std::vector<std::vector<int> > v = Get_M_from_N(Nobj, Nmax);
 
@@ -334,7 +335,7 @@ int KLFitter::Permutations::CreateSubTable(int Nobj, std::vector < std::vector<i
       std::vector<int> vidx = v[i];
       do {
         table->push_back(new std::vector<int>(vidx));
-      } while (next_permutation(vidx.begin(), vidx.end()));
+      } while (std::next_permutation(vidx.begin(), vidx.end()));
     }
   }
 

--- a/util/example-top-ljets.cxx
+++ b/util/example-top-ljets.cxx
@@ -33,6 +33,7 @@
 
 // ROOT includes
 #include "TFile.h"
+#include "TLorentzVector.h"
 #include "TTree.h"
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This removes all explicit includes of ROOT header files within the public library headers. Instead, we use forward-declarations as much as possible, and then only include the ROOT headers in the implementation files. This avoid cross-dependencies, and keeps us as independent from ROOT as possible.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#21 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Pleas note that this should only be merged after #22.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled and tested. Code works as before.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
