### PR TITLE
Bugfix for Particles::RemoveParticles() memory issue

### DIFF
--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -177,9 +177,7 @@ int KLFitter::Particles::RemoveParticle(int index, KLFitter::Particles::Particle
     return 0;
 
   // remove particle
-  TLorentzVector* lv = (*ParticleContainer(ptype))[index].get();
   ParticleContainer(ptype)->erase(ParticleContainer(ptype)->begin() + index);
-  delete lv;
   ParticleNameContainer(ptype)->erase(ParticleNameContainer(ptype)->begin() + index);
 
   // no error


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With the recent introduction of smart pointers into the Particle class (see
issue #22), the Particles::RemoveParticles() function was not updated correctly.
When using that function, there was a double deletion of memory, hold by a
unique pointer. This is now fixed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This function is not used anywhere in the KLFitter classes, and therefore the bug wasn't trivial to detect. It has been implemented for testing reasons into the example file, also to check that the bugfix actually solves the problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
