### PR TITLE
Consistent usage of keywords virtual, override, final, and inline

### DIFF
--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -85,7 +85,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * @param sumet total scalar ET.
    * @return An error flag.
    */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet);
+  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
   /**
    * Set a flag. If flag is true the invariant top quark mass is
@@ -121,21 +121,21 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
    * Define the parameters of the fit.
    */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
    * The prior probability definition, overloaded from BCModel.
    * @param parameters A vector of parameters (double values).
    * @return The logarithm of the prior probability.
    */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
    * The posterior probability definition, overloaded from BCModel.
    * @param parameters A vector of parameters (double values).
    * @return The logarithm of the prior probability.
    */
-  virtual double LogLikelihood(const std::vector <double> & parameters);
+  double LogLikelihood(const std::vector <double> & parameters) override;
 
   /**
    * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
@@ -151,13 +151,13 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * 7:  BW_Thad
    * 8: BW_Tlep
    */
-  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters);
+  std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
   /**
    * Get initial values for the parameters.
    * @return vector of initial values.
    */
-  virtual std::vector<double> GetInitialParameters();
+  std::vector<double> GetInitialParameters() override;
 
   /**
    * Get initial values for the parameters with a dummy of "0.0" for the neutrino pz.
@@ -171,17 +171,17 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * Check if there are TF problems.
    * @return Return false if TF problem.
    */
-  virtual bool NoTFProblem(std::vector<double> parameters);
+  bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
    * Return the set of model particles.
    * @return A pointer to the particles.
    */
-  virtual KLFitter::Particles* ParticlesModel() {
+  KLFitter::Particles* ParticlesModel() override {
     BuildModelParticles();
     return fParticlesModel;
   }
-  virtual KLFitter::Particles** PParticlesModel() {
+  KLFitter::Particles** PParticlesModel() override {
     BuildModelParticles();
     return &fParticlesModel;
   }
@@ -201,7 +201,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
    * Initialize the likelihood for the event
    */
-  virtual int Initialize();
+  int Initialize() override;
 
   /**
    * Adjust parameter ranges
@@ -218,13 +218,13 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * Remove invariant particle permutations.
    * @return An error code.
    */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
    * Remove forbidden particle permutations.
    * @return An error code.
    */
-  int RemoveForbiddenParticlePermutations();
+  int RemoveForbiddenParticlePermutations() override;
 
   /**
    * Build the model particles from the best fit parameters.

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -290,7 +290,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * @param e The parton energy (not modified).
    * @return The parton mass.
    */
-  inline double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
     double mass(0.);
     if (fFlagUseJetMass) {
       mass = jetmass > 0. ? jetmass : 0.;

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -58,7 +58,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
    * The default destructor.
    */
-  virtual ~BoostedLikelihoodTopLeptonJets();
+  ~BoostedLikelihoodTopLeptonJets();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -165,7 +165,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * GetInitialParameters().
    * @return vector of initial values.
    */
-  virtual std::vector<double> GetInitialParametersWoNeutrinoPz();
+  std::vector<double> GetInitialParametersWoNeutrinoPz();
 
   /**
    * Check if there are TF problems.
@@ -196,7 +196,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * Update 4-vectors of model particles.
    * @return An error flag.
    */
-  virtual int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters);
 
   /**
    * Initialize the likelihood for the event
@@ -206,13 +206,13 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
    * Adjust parameter ranges
    */
-  virtual int AdjustParameterRanges();
+  int AdjustParameterRanges();
 
   /**
    * Define the model particles
    * @return An error code.
    */
-  virtual int DefineModelParticles();
+  int DefineModelParticles();
 
   /**
    * Remove invariant particle permutations.
@@ -256,7 +256,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * and the W mass.
    * @return A vector with 0, 1 or 2 neutrino pz solutions.
    */
-  virtual std::vector<double> GetNeutrinoPzSolutions();
+  std::vector<double> GetNeutrinoPzSolutions();
 
   /**
    * Calculates the neutrino pz solutions from the measured values

--- a/include/KLFitter/DetectorAtlas_7TeV.h
+++ b/include/KLFitter/DetectorAtlas_7TeV.h
@@ -52,7 +52,7 @@ class DetectorAtlas_7TeV : public DetectorBase {
   /**
     * The default destructor.
     */
-  virtual ~DetectorAtlas_7TeV();
+  ~DetectorAtlas_7TeV();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/DetectorAtlas_7TeV.h
+++ b/include/KLFitter/DetectorAtlas_7TeV.h
@@ -63,76 +63,76 @@ class DetectorAtlas_7TeV : public DetectorBase {
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyLightJet(double eta = 0.);
+  ResolutionBase* ResEnergyLightJet(double eta = 0.) override;
 
   /**
     * Return the energy resolution of b jets.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyBJet(double eta = 0.);
+  ResolutionBase* ResEnergyBJet(double eta = 0.) override;
 
   /**
     * Return the energy resolution of gluon jets.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyGluonJet(double eta = 0.);
+  ResolutionBase* ResEnergyGluonJet(double eta = 0.) override;
 
   /**
     * Return the energy resolution of electrons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyElectron(double eta = 0.);
+  ResolutionBase* ResEnergyElectron(double eta = 0.) override;
 
   /**
     * Return the energy resolution of muons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyMuon(double eta = 0.);
+  ResolutionBase* ResEnergyMuon(double eta = 0.) override;
 
   /**
     * Return the energy resolution of photons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyPhoton(double eta = 0.);
+  ResolutionBase* ResEnergyPhoton(double eta = 0.) override;
 
   /**
     * Return the missing ET resolution.
     * @return A pointer to the missing ET resolution.
     */
-  ResolutionBase* ResMissingET();
+  ResolutionBase* ResMissingET() override;
 
   /**
     * Return the eta resolution of light jets.
     * @param eta The eta of the particle.
     * @return A pointer to the eta resolution object.
     */
-  ResolutionBase* ResEtaLightJet(double eta = 0.);
+  ResolutionBase* ResEtaLightJet(double eta = 0.) override;
 
   /**
     * Return the eta resolution of b jets.
     * @param eta The eta of the particle.
     * @return A pointer to the eta resolution object.
     */
-  ResolutionBase* ResEtaBJet(double eta = 0.);
+  ResolutionBase* ResEtaBJet(double eta = 0.) override;
 
   /**
     * Return the phi resolution of light jets.
     * @param eta The phi of the particle.
     * @return A pointer to the phi resolution object.
     */
-  ResolutionBase* ResPhiLightJet(double eta = 0.);
+  ResolutionBase* ResPhiLightJet(double eta = 0.) override;
 
   /**
     * Return the phi resolution of b jets.
     * @param eta The phi of the particle.
     * @return A pointer to the phi resolution object.
     */
-  ResolutionBase* ResPhiBJet(double eta = 0.);
+  ResolutionBase* ResPhiBJet(double eta = 0.) override;
 
   /* @} */
 

--- a/include/KLFitter/DetectorAtlas_8TeV.h
+++ b/include/KLFitter/DetectorAtlas_8TeV.h
@@ -52,7 +52,7 @@ class DetectorAtlas_8TeV : public DetectorBase {
   /**
     * The default destructor.
     */
-  virtual ~DetectorAtlas_8TeV();
+  ~DetectorAtlas_8TeV();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/DetectorAtlas_8TeV.h
+++ b/include/KLFitter/DetectorAtlas_8TeV.h
@@ -63,76 +63,76 @@ class DetectorAtlas_8TeV : public DetectorBase {
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyLightJet(double eta = 0.);
+  ResolutionBase* ResEnergyLightJet(double eta = 0.) override;
 
   /**
     * Return the energy resolution of b jets.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyBJet(double eta = 0.);
+  ResolutionBase* ResEnergyBJet(double eta = 0.) override;
 
   /**
     * Return the energy resolution of gluon jets.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyGluonJet(double eta = 0.);
+  ResolutionBase* ResEnergyGluonJet(double eta = 0.) override;
 
   /**
     * Return the energy resolution of electrons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyElectron(double eta = 0.);
+  ResolutionBase* ResEnergyElectron(double eta = 0.) override;
 
   /**
     * Return the energy resolution of muons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyMuon(double eta = 0.);
+  ResolutionBase* ResEnergyMuon(double eta = 0.) override;
 
   /**
     * Return the energy resolution of photons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyPhoton(double eta = 0.);
+  ResolutionBase* ResEnergyPhoton(double eta = 0.) override;
 
   /**
     * Return the missing ET resolution.
     * @return A pointer to the missing ET resolution.
     */
-  ResolutionBase* ResMissingET();
+  ResolutionBase* ResMissingET() override;
 
   /**
     * Return the eta resolution of light jets.
     * @param eta The eta of the particle.
     * @return A pointer to the eta resolution object.
     */
-  ResolutionBase* ResEtaLightJet(double eta = 0.);
+  ResolutionBase* ResEtaLightJet(double eta = 0.) override;
 
   /**
     * Return the eta resolution of b jets.
     * @param eta The eta of the particle.
     * @return A pointer to the eta resolution object.
     */
-  ResolutionBase* ResEtaBJet(double eta = 0.);
+  ResolutionBase* ResEtaBJet(double eta = 0.) override;
 
   /**
     * Return the phi resolution of light jets.
     * @param eta The phi of the particle.
     * @return A pointer to the phi resolution object.
     */
-  ResolutionBase* ResPhiLightJet(double eta = 0.);
+  ResolutionBase* ResPhiLightJet(double eta = 0.) override;
 
   /**
     * Return the phi resolution of b jets.
     * @param eta The phi of the particle.
     * @return A pointer to the phi resolution object.
     */
-  ResolutionBase* ResPhiBJet(double eta = 0.);
+  ResolutionBase* ResPhiBJet(double eta = 0.) override;
 
   /* @} */
 

--- a/include/KLFitter/DetectorSnowmass.h
+++ b/include/KLFitter/DetectorSnowmass.h
@@ -63,34 +63,34 @@ class DetectorSnowmass : public DetectorBase {
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyLightJet(double eta = 0.);
+  ResolutionBase* ResEnergyLightJet(double eta = 0.) override;
 
   /**
     * Return the energy resolution of b-jets.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyBJet(double eta = 0.);
+  ResolutionBase* ResEnergyBJet(double eta = 0.) override;
 
   /**
     * Return the energy resolution of electrons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  ResolutionBase* ResEnergyElectron(double eta = 0.);
+  ResolutionBase* ResEnergyElectron(double eta = 0.) override;
 
   /**
     * Return the momentum resolution of muons.
     * @param eta The eta of the particle.
     * @return A pointer to the momentum resolution object.
     */
-  ResolutionBase* ResEnergyMuon(double eta = 0.);
+  ResolutionBase* ResEnergyMuon(double eta = 0.) override;
 
   /**
     * Return the missing ET resolution.
     * @return A pointer to the missing ET resolution.
     */
-  ResolutionBase* ResMissingET();
+  ResolutionBase* ResMissingET() override;
 
   /* @} */
 

--- a/include/KLFitter/DetectorSnowmass.h
+++ b/include/KLFitter/DetectorSnowmass.h
@@ -52,7 +52,7 @@ class DetectorSnowmass : public DetectorBase {
   /**
     * The default destructor.
     */
-  virtual ~DetectorSnowmass();
+  ~DetectorSnowmass();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/Fitter.h
+++ b/include/KLFitter/Fitter.h
@@ -41,7 +41,7 @@ class Permutations;
   * This class owns all particles, the detector description, the
   * likelihood, etc. This is the class seen by the user.
   */
-class Fitter {
+class Fitter final {
  public:
   /** \name Constructors and destructors */
   /* @{ */
@@ -54,7 +54,7 @@ class Fitter {
   /**
     * The default destructor.
     */
-  virtual ~Fitter();
+  ~Fitter();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -185,7 +185,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  virtual int CalculateLorentzVectors(std::vector <double> parameters);
+  int CalculateLorentzVectors(std::vector <double> parameters);
 
   /**
     * Initialize the likelihood for the event
@@ -195,13 +195,13 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  virtual int AdjustParameterRanges();
+  int AdjustParameterRanges();
 
   /**
     * Define the model particles
     * @return An error code.
     */
-  virtual int DefineModelParticles();
+  int DefineModelParticles();
 
   /**
     * Remove invariant particle permutations.
@@ -236,7 +236,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * and the W mass.
     * @return A vector with 0, 1 or 2 neutrino pz solutions.
     */
-  virtual std::vector<double> GetNeutrinoPzSolutions();
+  std::vector<double> GetNeutrinoPzSolutions();
 
   /**
     * Save permuted particles.

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -57,7 +57,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   /**
     * The default destructor.
     */
-  virtual ~LikelihoodSgTopWtLJ();
+  ~LikelihoodSgTopWtLJ();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -258,7 +258,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * @param e The parton energy (not modified).
     * @return The parton mass.
     */
-  inline double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
     double mass(0.);
     if (fFlagUseJetMass) {
       mass = jetmass > 0. ? jetmass : 0.;

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -103,7 +103,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * @param sumet total scalar ET.
     * @return An error flag.
     */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet);
+  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
   /**
     * Associate the hadronic leg of the event to the top quark for likelihood calculation.
@@ -134,43 +134,43 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
     * The prior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogLikelihood(const std::vector<double> & parameters);
+  double LogLikelihood(const std::vector<double> & parameters) override;
 
   /**
     * Get initial values for the parameters.
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParameters();
+  std::vector<double> GetInitialParameters() override;
 
   /**
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters);
+  bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() {
+  KLFitter::Particles* ParticlesModel() override {
     BuildModelParticles();
     return fParticlesModel;
   }
-  virtual KLFitter::Particles** PParticlesModel() {
+  KLFitter::Particles** PParticlesModel() override {
     BuildModelParticles();
     return &fParticlesModel;
   }
@@ -190,7 +190,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   /**
     * Initialize the likelihood for the event
     */
-  virtual int Initialize();
+  int Initialize() override;
 
   /**
     * Adjust parameter ranges
@@ -207,7 +207,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
     * Build the model particles from the best fit parameters.

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -59,7 +59,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * The default destructor.
     */
-  virtual ~LikelihoodTTHLeptonJets();
+  ~LikelihoodTTHLeptonJets();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -300,7 +300,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * @param e The parton energy (not modified).
     * @return The parton mass.
     */
-  inline double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
     double mass(0.);
     if (fFlagUseJetMass) {
       mass = jetmass > 0. ? jetmass : 0.;

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -175,7 +175,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * GetInitialParameters().
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParametersWoNeutrinoPz();
+  std::vector<double> GetInitialParametersWoNeutrinoPz();
 
   /**
     * Check if there are TF problems.
@@ -206,7 +206,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  virtual int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters);
 
   /**
     * Initialize the likelihood for the event
@@ -216,13 +216,13 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  virtual int AdjustParameterRanges();
+  int AdjustParameterRanges();
 
   /**
     * Define the model particles
     * @return An error code.
     */
-  virtual int DefineModelParticles();
+  int DefineModelParticles();
 
   /**
     * Remove invariant particle permutations.
@@ -266,7 +266,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * and the W mass.
     * @return A vector with 0, 1 or 2 neutrino pz solutions.
     */
-  virtual std::vector<double> GetNeutrinoPzSolutions();
+  std::vector<double> GetNeutrinoPzSolutions();
 
   /**
     * Calculates the neutrino pz solutions from the measured values

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -86,7 +86,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * @param sumet total scalar ET.
     * @return An error flag.
     */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet);
+  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
   /**
     * Set a flag. If flag is true the invariant top quark mass is
@@ -126,14 +126,14 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
     * The prior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.
@@ -141,7 +141,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * @return The logarithm of the prior probability.
     */
 
-  virtual double LogLikelihood(const std::vector <double> & parameters);
+  double LogLikelihood(const std::vector <double> & parameters) override;
   /**
     * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
     * @param parameters A vector of parameters (double values).
@@ -161,13 +161,13 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * 12: BW_Tlep
     * 13: BW_Higgs
     */
-  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters);
+  std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
   /**
     * Get initial values for the parameters.
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParameters();
+  std::vector<double> GetInitialParameters() override;
 
   /**
     * Get initial values for the parameters with a dummy of "0.0" for the neutrino pz.
@@ -181,17 +181,17 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters);
+  bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() {
+  KLFitter::Particles* ParticlesModel() override {
     BuildModelParticles();
     return fParticlesModel;
   }
-  virtual KLFitter::Particles** PParticlesModel() {
+  KLFitter::Particles** PParticlesModel() override {
     BuildModelParticles();
     return &fParticlesModel;
   }
@@ -211,7 +211,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Initialize the likelihood for the event
     */
-  virtual int Initialize();
+  int Initialize() override;
 
   /**
     * Adjust parameter ranges
@@ -228,13 +228,13 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  int RemoveForbiddenParticlePermutations();
+  int RemoveForbiddenParticlePermutations() override;
 
   /**
     * Build the model particles from the best fit parameters.

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -57,7 +57,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   /**
     * The default destructor.
     */
-  virtual ~LikelihoodTTZTrilepton();
+  ~LikelihoodTTZTrilepton();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -66,12 +66,12 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   /**
     * Get the cut-off value of the 1/E^2 distribution.
     */
-  inline double GetInvMassCutoff() { return fInvMassCutoff; }
+  double GetInvMassCutoff() { return fInvMassCutoff; }
 
   /**
     * Get the fraction of on-shell events.
     */
-  inline float GetOnShellFraction() { return fOnShellFraction; }
+  float GetOnShellFraction() { return fOnShellFraction; }
 
   /* @} */
   /** \name Member functions (Set)  */
@@ -99,12 +99,12 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   /**
     * Set the cut-off value of the 1/E^2 distribution.
     */
-  inline void SetInvMassCutoff(double cutoff) { fInvMassCutoff = cutoff; }
+  void SetInvMassCutoff(double cutoff) { fInvMassCutoff = cutoff; }
 
   /**
     * Set the fraction of on-shell events.
     */
-  inline void SetOnShellFraction(double fraction) { fOnShellFraction = fraction; }
+  void SetOnShellFraction(double fraction) { fOnShellFraction = fraction; }
 
   /**
     * Set a flag. If flag is true the invariant top quark mass is
@@ -338,7 +338,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * @param e The parton energy (not modified).
     * @return The parton mass.
     */
-  inline double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
     double mass(0.);
     if (fFlagUseJetMass) {
       mass = jetmass > 0. ? jetmass : 0.;

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -189,7 +189,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * GetInitialParameters().
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParametersWoNeutrinoPz();
+  std::vector<double> GetInitialParametersWoNeutrinoPz();
 
   /**
     * Check if there are TF problems.
@@ -244,7 +244,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  virtual int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters);
 
   /**
     * Initialize the likelihood for the event
@@ -254,13 +254,13 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  virtual int AdjustParameterRanges();
+  int AdjustParameterRanges();
 
   /**
     * Define the model particles
     * @return An error code.
     */
-  virtual int DefineModelParticles();
+  int DefineModelParticles();
 
   /**
     * Remove invariant particle permutations.
@@ -304,7 +304,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * and the W mass.
     * @return A vector with 0, 1 or 2 neutrino pz solutions.
     */
-  virtual std::vector<double> GetNeutrinoPzSolutions();
+  std::vector<double> GetNeutrinoPzSolutions();
 
   /**
     * Calculates the neutrino pz solutions from the measured values

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -94,7 +94,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * @param sumet total scalar ET.
     * @return An error flag.
     */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet);
+  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
   /**
     * Set the cut-off value of the 1/E^2 distribution.
@@ -140,21 +140,21 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
     * The prior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogLikelihood(const std::vector <double> & parameters);
+  double LogLikelihood(const std::vector <double> & parameters) override;
 
   /**
     * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
@@ -175,13 +175,13 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * 12: BW_Tlep
     * 13: BW_Z
     */
-  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters);
+  std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
   /**
     * Get initial values for the parameters.
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParameters();
+  std::vector<double> GetInitialParameters() override;
 
   /**
     * Get initial values for the parameters with a dummy of "0.0" for the neutrino pz.
@@ -195,17 +195,17 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters);
+  bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() {
+  KLFitter::Particles* ParticlesModel() override {
     BuildModelParticles();
     return fParticlesModel;
   }
-  virtual KLFitter::Particles** PParticlesModel() {
+  KLFitter::Particles** PParticlesModel() override {
     BuildModelParticles();
     return &fParticlesModel;
   }
@@ -249,7 +249,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   /**
     * Initialize the likelihood for the event
     */
-  virtual int Initialize();
+  int Initialize() override;
 
   /**
     * Adjust parameter ranges
@@ -266,13 +266,13 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  int RemoveForbiddenParticlePermutations();
+  int RemoveForbiddenParticlePermutations() override;
 
   /**
     * Build the model particles from the best fit parameters.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -242,7 +242,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * @param e The parton energy (not modified).
     * @return The parton mass.
     */
-  inline double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
     double mass(0.);
     if (fFlagUseJetMass) {
       mass = jetmass > 0. ? jetmass : 0.;

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -161,7 +161,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  virtual int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters);
 
   /**
     * Initialize the likelihood for the event
@@ -171,13 +171,13 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  virtual int AdjustParameterRanges();
+  int AdjustParameterRanges();
 
   /**
     * Define the model particles
     * @return An error code.
     */
-  virtual int DefineModelParticles();
+  int DefineModelParticles();
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -93,21 +93,21 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
     * The prior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogLikelihood(const std::vector <double> &  parameters);
+  double LogLikelihood(const std::vector <double> &  parameters) override;
 
   /**
     * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
@@ -124,29 +124,29 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * 8:  BW_Thad1
     * 9:  BW_Thad2
     */
-  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters);
+  std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
   /**
     * Get initial values for the parameters.
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParameters();
+  std::vector<double> GetInitialParameters() override;
 
   /**
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters);
+  bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() {
+  KLFitter::Particles* ParticlesModel() override {
     BuildModelParticles();
     return fParticlesModel;
   }
-  virtual KLFitter::Particles** PParticlesModel() {
+  KLFitter::Particles** PParticlesModel() override {
     BuildModelParticles();
     return &fParticlesModel;
   }
@@ -166,7 +166,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   /**
     * Initialize the likelihood for the event
     */
-  virtual int Initialize();
+  int Initialize() override;
 
   /**
     * Adjust parameter ranges
@@ -183,13 +183,13 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  int RemoveForbiddenParticlePermutations();
+  int RemoveForbiddenParticlePermutations() override;
 
   /**
     * Remove forbidden particle permutations - forcing b-jets on the position of a b parton.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -56,7 +56,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   /**
     * The default destructor.
     */
-  virtual ~LikelihoodTopAllHadronic();
+  ~LikelihoodTopAllHadronic();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -91,7 +91,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * @param sumet total scalar ET.
     * @return An error flag.
     */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet);
+  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
   /**
     * Set a flag. If flag is true the invariant top quark mass is
@@ -133,7 +133,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
     * Define sharp gauss prior for mtop par if mtop fixed
@@ -152,14 +152,14 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * @return The logarithm of the prior probability.
     */
 
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogLikelihood(const std::vector <double> & parameters);
+  double LogLikelihood(const std::vector <double> & parameters) override;
 
   /**
     * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
@@ -174,29 +174,29 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * 6:  Nu_Eta
     * 7:  Minv(lep,jet)
     */
-  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters);
+  std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
   /**
     * Get initial values for the parameters.
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParameters();
+  std::vector<double> GetInitialParameters() override;
 
   /**
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters);
+  bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() {
+  KLFitter::Particles* ParticlesModel() override {
     BuildModelParticles();
     return fParticlesModel;
   }
-  virtual KLFitter::Particles** PParticlesModel() {
+  KLFitter::Particles** PParticlesModel() override {
     BuildModelParticles();
     return &fParticlesModel;
   }
@@ -263,7 +263,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   /**
     * Initialize the likelihood for the event
     */
-  virtual int Initialize();
+  int Initialize() override;
 
   /**
     * Adjust parameter ranges
@@ -280,13 +280,13 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  int RemoveForbiddenParticlePermutations();
+  int RemoveForbiddenParticlePermutations() override;
 
   /**
     * Build the model particles from the best fit parameters.
@@ -298,19 +298,19 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * Calculate other variables out of the KLFitter parameters for each MCMCiteration
     *
     */
-  void MCMCIterationInterface();
+  void MCMCIterationInterface() override;
 
   /**
     * Get BAT BCH1D histograms of Mttbar
     * @return BCH1D histograms
     */
-  BCH1D * GetHistMttbar() { return fHistMttbar; }
+  BCH1D * GetHistMttbar() override { return fHistMttbar; }
 
   /**
     * Get BAT BCH1D histograms of CosTheta
     * @return BCH1D histograms
     */
-  BCH1D * GetHistCosTheta() { return fHistCosTheta;  }
+  BCH1D * GetHistCosTheta() override { return fHistCosTheta;  }
 
   /**
     * calculate cos(theta*) for both top and antitop

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -351,7 +351,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * @param e The parton energy (not modified).
     * @return The parton mass.
     */
-  inline double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
     double mass(0.);
     if (fFlagUseJetMass) {
       mass = jetmass > 0. ? jetmass : 0.;

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -138,7 +138,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   /**
     * Define sharp gauss prior for mtop par if mtop fixed
     */
-  virtual void DefinePrior();
+  void DefinePrior();
 
   /**
     * Define BCH1D and TH1D histograms to be filled
@@ -258,7 +258,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  virtual int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters);
 
   /**
     * Initialize the likelihood for the event
@@ -268,13 +268,13 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  virtual int AdjustParameterRanges();
+  int AdjustParameterRanges();
 
   /**
     * Define the model particles
     * @return An error code.
     */
-  virtual int DefineModelParticles();
+  int DefineModelParticles();
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -64,7 +64,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   /**
     * The default destructor.
     */
-  virtual ~LikelihoodTopDilepton();
+  ~LikelihoodTopDilepton();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -85,7 +85,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * @param sumet total scalar ET.
     * @return An error flag.
     */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet);
+  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
   /**
     * Set a flag. If flag is true the invariant top quark mass is
@@ -121,21 +121,21 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
     * The prior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogLikelihood(const std::vector <double> & parameters);
+  double LogLikelihood(const std::vector <double> & parameters) override;
 
   /**
     * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
@@ -153,13 +153,13 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * 9:  BW_Thad
     * 10: BW_Tlep
     */
-  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters);
+  std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
   /**
     * Get initial values for the parameters.
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParameters();
+  std::vector<double> GetInitialParameters() override;
 
   /**
     * Get initial values for the parameters with a dummy of "0.0" for the neutrino pz.
@@ -173,17 +173,17 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters);
+  bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() {
+  KLFitter::Particles* ParticlesModel() override {
     BuildModelParticles();
     return fParticlesModel;
   }
-  virtual KLFitter::Particles** PParticlesModel() {
+  KLFitter::Particles** PParticlesModel() override {
     BuildModelParticles();
     return &fParticlesModel;
   }
@@ -203,7 +203,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Initialize the likelihood for the event
     */
-  virtual int Initialize();
+  int Initialize() override;
 
   /**
     * Adjust parameter ranges
@@ -220,13 +220,13 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  int RemoveForbiddenParticlePermutations();
+  int RemoveForbiddenParticlePermutations() override;
 
   /**
     * Build the model particles from the best fit parameters.

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -292,7 +292,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * @param e The parton energy (not modified).
     * @return The parton mass.
     */
-  inline double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
     double mass(0.);
     if (fFlagUseJetMass) {
       mass = jetmass > 0. ? jetmass : 0.;

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -58,7 +58,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * The default destructor.
     */
-  virtual ~LikelihoodTopLeptonJets();
+  ~LikelihoodTopLeptonJets();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -167,7 +167,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * GetInitialParameters().
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParametersWoNeutrinoPz();
+  std::vector<double> GetInitialParametersWoNeutrinoPz();
 
   /**
     * Check if there are TF problems.
@@ -198,7 +198,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  virtual int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters);
 
   /**
     * Initialize the likelihood for the event
@@ -208,7 +208,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  virtual int AdjustParameterRanges();
+  int AdjustParameterRanges();
 
   /**
     * Define the model particles
@@ -258,7 +258,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * and the W mass.
     * @return A vector with 0, 1 or 2 neutrino pz solutions.
     */
-  virtual std::vector<double> GetNeutrinoPzSolutions();
+  std::vector<double> GetNeutrinoPzSolutions();
 
   /**
     * Calculates the neutrino pz solutions from the measured values

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -74,21 +74,21 @@ class LikelihoodTopLeptonJetsUDSep : public KLFitter::LikelihoodTopLeptonJets {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
     * Return the log of the event probability fof the current
     * combination
     * @return The event probability
     */
-  double LogEventProbability();
+  double LogEventProbability() override;
 
   /**
     * Return the contribution from b tagging to the log of the
     * event probability for the current combination
     * @return The event probability contribution
     */
-  double LogEventProbabilityBTag();
+  double LogEventProbabilityBTag() override;
 
   /**
     * Return the contribution from pT and b tag weight probability (by LJetSeparationMethod)
@@ -204,7 +204,7 @@ class LikelihoodTopLeptonJetsUDSep : public KLFitter::LikelihoodTopLeptonJets {
     * Check if the permutation is LH invariant.
     * @return Permutation of the invariant partner, -1 if there is no one.
     */
-  int LHInvariantPermutationPartner(int iperm, int nperms, int *switchpar1, int *switchpar2);
+  int LHInvariantPermutationPartner(int iperm, int nperms, int *switchpar1, int *switchpar2) override;
 
   /**
     * Set histogram for tag weight distribution of up type jets.
@@ -235,19 +235,19 @@ class LikelihoodTopLeptonJetsUDSep : public KLFitter::LikelihoodTopLeptonJets {
     * Define the model particles
     * @return An error code.
     */
-  virtual int DefineModelParticles();
+  int DefineModelParticles() override;
 
   /**
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  int RemoveForbiddenParticlePermutations() { return 1; }
+  int RemoveForbiddenParticlePermutations() override { return 1; }
 
   /**
     * A flag for using an additional reweighting of the permutations with the pT and tag weight probability (default: false);

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -67,7 +67,7 @@ class LikelihoodTopLeptonJetsUDSep : public KLFitter::LikelihoodTopLeptonJets {
   /**
     * The default destructor.
     */
-  virtual ~LikelihoodTopLeptonJetsUDSep();
+  ~LikelihoodTopLeptonJetsUDSep();
 
   /* @} */
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -85,7 +85,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * @param sumet total scalar ET.
     * @return An error flag.
     */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet);
+  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
   /**
     * Set a flag. If flag is true the invariant top quark mass is
@@ -119,21 +119,21 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
     * The prior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogLikelihood(const std::vector <double> & parameters);
+  double LogLikelihood(const std::vector <double> & parameters) override;
 
   /**
     * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
@@ -151,13 +151,13 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * 9:  BW_Thad
     * 10: BW_Tlep
     */
-  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters);
+  std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
   /**
     * Get initial values for the parameters.
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParameters();
+  std::vector<double> GetInitialParameters() override;
 
   /**
     * Get initial values for the parameters with a dummy of "0.0" for the neutrino pz.
@@ -171,17 +171,17 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters);
+  bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() {
+  KLFitter::Particles* ParticlesModel() override {
     BuildModelParticles();
     return fParticlesModel;
   }
-  virtual KLFitter::Particles** PParticlesModel() {
+  KLFitter::Particles** PParticlesModel() override {
     BuildModelParticles();
     return &fParticlesModel;
   }
@@ -201,7 +201,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   /**
     * Initialize the likelihood for the event
     */
-  virtual int Initialize();
+  int Initialize() override;
 
   /**
     * Adjust parameter ranges
@@ -218,13 +218,13 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  int RemoveForbiddenParticlePermutations();
+  int RemoveForbiddenParticlePermutations() override;
 
   /**
     * Build the model particles from the best fit parameters.

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -58,7 +58,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   /**
     * The default destructor.
     */
-  virtual ~LikelihoodTopLeptonJets_Angular();
+  ~LikelihoodTopLeptonJets_Angular();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -165,7 +165,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * GetInitialParameters().
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParametersWoNeutrinoPz();
+  std::vector<double> GetInitialParametersWoNeutrinoPz();
 
   /**
     * Check if there are TF problems.
@@ -196,7 +196,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  virtual int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters);
 
   /**
     * Initialize the likelihood for the event
@@ -206,13 +206,13 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  virtual int AdjustParameterRanges();
+  int AdjustParameterRanges();
 
   /**
     * Define the model particles
     * @return An error code.
     */
-  virtual int DefineModelParticles();
+  int DefineModelParticles();
 
   /**
     * Remove invariant particle permutations.
@@ -251,7 +251,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * and the W mass.
     * @return A vector with 0, 1 or 2 neutrino pz solutions.
     */
-  virtual std::vector<double> GetNeutrinoPzSolutions();
+  std::vector<double> GetNeutrinoPzSolutions();
 
   /**
     * Calculates the neutrino pz solutions from the measured values

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -285,7 +285,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * @param e The parton energy (not modified).
     * @return The parton mass.
     */
-  inline double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
     double mass(0.);
     if (fFlagUseJetMass) {
       mass = jetmass > 0. ? jetmass : 0.;

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -85,7 +85,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * @param sumet total scalar ET.
     * @return An error flag.
     */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet);
+  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
   /**
     * Set a flag. If flag is true the invariant top quark mass is
@@ -121,21 +121,21 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters();
+  void DefineParameters() override;
 
   /**
     * The prior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogLikelihood(const std::vector <double> & parameters);
+  double LogLikelihood(const std::vector <double> & parameters) override;
 
   /**
     * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
@@ -161,13 +161,13 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     *17:  BW_Thad
     *18:  BW_Tlep
     */
-  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters);
+  std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
   /**
     * Get initial values for the parameters.
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParameters();
+  std::vector<double> GetInitialParameters() override;
 
   /**
     * Get initial values for the parameters with a dummy of "0.0" for the neutrino pz.
@@ -181,17 +181,17 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters);
+  bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() {
+  KLFitter::Particles* ParticlesModel() override {
     BuildModelParticles();
     return fParticlesModel;
   }
-  virtual KLFitter::Particles** PParticlesModel() {
+  KLFitter::Particles** PParticlesModel() override {
     BuildModelParticles();
     return &fParticlesModel;
   }
@@ -211,7 +211,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   /**
     * Initialize the likelihood for the event
     */
-  virtual int Initialize();
+  int Initialize() override;
 
   /**
     * Adjust parameter ranges
@@ -228,13 +228,13 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  int RemoveInvariantParticlePermutations();
+  int RemoveInvariantParticlePermutations() override;
 
   /**
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  int RemoveForbiddenParticlePermutations();
+  int RemoveForbiddenParticlePermutations() override;
 
   /**
     * Build the model particles from the best fit parameters.

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -175,7 +175,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * GetInitialParameters().
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParametersWoNeutrinoPz();
+  std::vector<double> GetInitialParametersWoNeutrinoPz();
 
   /**
     * Check if there are TF problems.
@@ -206,7 +206,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  virtual int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters);
 
   /**
     * Initialize the likelihood for the event
@@ -216,13 +216,13 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  virtual int AdjustParameterRanges();
+  int AdjustParameterRanges();
 
   /**
     * Define the model particles
     * @return An error code.
     */
-  virtual int DefineModelParticles();
+  int DefineModelParticles();
 
   /**
     * Remove invariant particle permutations.
@@ -266,7 +266,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * and the W mass.
     * @return A vector with 0, 1 or 2 neutrino pz solutions.
     */
-  virtual std::vector<double> GetNeutrinoPzSolutions();
+  std::vector<double> GetNeutrinoPzSolutions();
 
   /**
     * Calculates the neutrino pz solutions from the measured values

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -305,7 +305,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * @param e The parton energy (not modified).
     * @return The parton mass.
     */
-  inline double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
     double mass(0.);
     if (fFlagUseJetMass) {
       mass = jetmass > 0. ? jetmass : 0.;

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -58,7 +58,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   /**
     * The default destructor.
     */
-  virtual ~LikelihoodTopLeptonJets_JetAngles();
+  ~LikelihoodTopLeptonJets_JetAngles();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -40,7 +40,7 @@ namespace KLFitter {
   * This class contains sets of TLorentzVectors for quarks, leptons,
   * etc.
   */
-class Particles {
+class Particles final {
  public:
   /** \name Enumerators */
   /* @{ */
@@ -67,7 +67,7 @@ class Particles {
   /**
     * The default destructor.
     */
-  virtual ~Particles();
+  ~Particles();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/Permutations.h
+++ b/include/KLFitter/Permutations.h
@@ -40,7 +40,7 @@ namespace KLFitter {
   * permutations and created a table. The pointer of the current
   * permutation is set to the entry in the table.
   */
-class Permutations {
+class Permutations final {
  public:
   /** \name Constructors and destructors */
   /* @{ */
@@ -55,7 +55,7 @@ class Permutations {
   /**
     * The default destructor.
     */
-  virtual ~Permutations();
+  ~Permutations();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/PhysicsConstants.h
+++ b/include/KLFitter/PhysicsConstants.h
@@ -33,7 +33,7 @@ namespace KLFitter {
   *
   * This class contains physics constants.
   */
-class PhysicsConstants {
+class PhysicsConstants final {
  public:
   /** \name Constructors and destructors */
   /* @{ */
@@ -46,7 +46,7 @@ class PhysicsConstants {
   /**
     * The default destructor.
     */
-  virtual ~PhysicsConstants();
+  ~PhysicsConstants();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResDoubleGaussBase.h
+++ b/include/KLFitter/ResDoubleGaussBase.h
@@ -106,7 +106,7 @@ class ResDoubleGaussBase : public ResolutionBase {
     * @param xmeas The measured value of x.
     * @return The width.
     */
-  virtual double GetSigma(double xmeas);
+  double GetSigma(double xmeas) override;
 
   /**
     * Return the probability of the true value of x given the
@@ -116,7 +116,7 @@ class ResDoubleGaussBase : public ResolutionBase {
     * @param good False if problem with TF.
     * @return The probability.
     */
-  virtual double p(double x, double xmeas, bool *good);
+  double p(double x, double xmeas, bool *good) override;
 
   /**
     * Return the probability of the true value of x given the
@@ -127,7 +127,7 @@ class ResDoubleGaussBase : public ResolutionBase {
     * @param par Optional additional parameter (SumET in case of MET TF).
     * @return The probability.
     */
-  virtual double p(double x, double xmeas, bool *good, double par) { *good = true; return 0; }
+  double p(double x, double xmeas, bool *good, double par) override { *good = true; return 0; }
 
   /* @} */
 

--- a/include/KLFitter/ResDoubleGaussBase.h
+++ b/include/KLFitter/ResDoubleGaussBase.h
@@ -138,7 +138,7 @@ class ResDoubleGaussBase : public ResolutionBase {
     * @param sigma2 (the 2nd sigma).
     * @return False if problem with TF.
     */
-  inline static bool CheckDoubleGaussianSanity(double *sigma1, double *amplitude2, double *sigma2) {
+  static bool CheckDoubleGaussianSanity(double *sigma1, double *amplitude2, double *sigma2) {
     if (*amplitude2 < 0.) *amplitude2 = 0.;
     if (*sigma1 < 0.) {
       //        std::cout << "KLFitter::ResDoubleGauss::CheckDoubleGaussianSanity() ERROR IN TRANSFERFUNCTIONS the sigma of the 1st Gaussian is < 0  -  FIT RESULT MAY NOT BE RELIABLE" << std::endl;

--- a/include/KLFitter/ResDoubleGaussE_1.h
+++ b/include/KLFitter/ResDoubleGaussE_1.h
@@ -70,35 +70,35 @@ class ResDoubleGaussE_1 : public ResDoubleGaussBase {
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean1(double x);
+  double GetMean1(double x) override;
 
   /**
     * Calculate the width of the first Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma1(double x);
+  double GetSigma1(double x) override;
 
   /**
     * Calculate the amplitude of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetAmplitude2(double x);
+  double GetAmplitude2(double x) override;
 
   /**
     * Calculate the mean of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean2(double x);
+  double GetMean2(double x) override;
 
   /**
     * Calculate the width of the sedcond Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma2(double x);
+  double GetSigma2(double x) override;
 
   /* @} */
 };

--- a/include/KLFitter/ResDoubleGaussE_1.h
+++ b/include/KLFitter/ResDoubleGaussE_1.h
@@ -59,7 +59,7 @@ class ResDoubleGaussE_1 : public ResDoubleGaussBase {
   /**
     * The default destructor.
     */
-  virtual ~ResDoubleGaussE_1();
+  ~ResDoubleGaussE_1();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResDoubleGaussE_2.h
+++ b/include/KLFitter/ResDoubleGaussE_2.h
@@ -58,7 +58,7 @@ class ResDoubleGaussE_2 : public ResDoubleGaussBase {
   /**
     * The default destructor.
     */
-  virtual ~ResDoubleGaussE_2();
+  ~ResDoubleGaussE_2();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResDoubleGaussE_2.h
+++ b/include/KLFitter/ResDoubleGaussE_2.h
@@ -69,35 +69,35 @@ class ResDoubleGaussE_2 : public ResDoubleGaussBase {
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean1(double x);
+  double GetMean1(double x) override;
 
   /**
     * Calculate the width of the first Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma1(double x);
+  double GetSigma1(double x) override;
 
   /**
     * Calculate the amplitude of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetAmplitude2(double x);
+  double GetAmplitude2(double x) override;
 
   /**
     * Calculate the mean of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean2(double x);
+  double GetMean2(double x) override;
 
   /**
     * Calculate the width of the sedcond Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma2(double x);
+  double GetSigma2(double x) override;
 
   /* @} */
 };

--- a/include/KLFitter/ResDoubleGaussE_3.h
+++ b/include/KLFitter/ResDoubleGaussE_3.h
@@ -69,35 +69,35 @@ class ResDoubleGaussE_3 : public ResDoubleGaussBase {
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean1(double x);
+  double GetMean1(double x) override;
 
   /**
     * Calculate the width of the first Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma1(double x);
+  double GetSigma1(double x) override;
 
   /**
     * Calculate the amplitude of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetAmplitude2(double x);
+  double GetAmplitude2(double x) override;
 
   /**
     * Calculate the mean of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean2(double x);
+  double GetMean2(double x) override;
 
   /**
     * Calculate the width of the sedcond Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma2(double x);
+  double GetSigma2(double x) override;
 
   /* @} */
 };

--- a/include/KLFitter/ResDoubleGaussE_3.h
+++ b/include/KLFitter/ResDoubleGaussE_3.h
@@ -58,7 +58,7 @@ class ResDoubleGaussE_3 : public ResDoubleGaussBase {
   /**
     * The default destructor.
     */
-  virtual ~ResDoubleGaussE_3();
+  ~ResDoubleGaussE_3();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResDoubleGaussE_4.h
+++ b/include/KLFitter/ResDoubleGaussE_4.h
@@ -69,35 +69,35 @@ class ResDoubleGaussE_4 : public ResDoubleGaussBase {
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean1(double x);
+  double GetMean1(double x) override;
 
   /**
     * Calculate the width of the first Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma1(double x);
+  double GetSigma1(double x) override;
 
   /**
     * Calculate the amplitude of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetAmplitude2(double x);
+  double GetAmplitude2(double x) override;
 
   /**
     * Calculate the mean of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean2(double x);
+  double GetMean2(double x) override;
 
   /**
     * Calculate the width of the sedcond Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma2(double x);
+  double GetSigma2(double x) override;
 
   /* @} */
 };

--- a/include/KLFitter/ResDoubleGaussE_4.h
+++ b/include/KLFitter/ResDoubleGaussE_4.h
@@ -58,7 +58,7 @@ class ResDoubleGaussE_4 : public ResDoubleGaussBase {
   /**
     * The default destructor.
     */
-  virtual ~ResDoubleGaussE_4();
+  ~ResDoubleGaussE_4();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResDoubleGaussE_5.h
+++ b/include/KLFitter/ResDoubleGaussE_5.h
@@ -69,35 +69,35 @@ class ResDoubleGaussE_5 : public ResDoubleGaussBase {
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean1(double x);
+  double GetMean1(double x) override;
 
   /**
     * Calculate the width of the first Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma1(double x);
+  double GetSigma1(double x) override;
 
   /**
     * Calculate the amplitude of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetAmplitude2(double x);
+  double GetAmplitude2(double x) override;
 
   /**
     * Calculate the mean of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean2(double x);
+  double GetMean2(double x) override;
 
   /**
     * Calculate the width of the sedcond Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma2(double x);
+  double GetSigma2(double x) override;
 
   /* @} */
 };

--- a/include/KLFitter/ResDoubleGaussE_5.h
+++ b/include/KLFitter/ResDoubleGaussE_5.h
@@ -58,7 +58,7 @@ class ResDoubleGaussE_5 : public ResDoubleGaussBase {
   /**
     * The default destructor.
     */
-  virtual ~ResDoubleGaussE_5();
+  ~ResDoubleGaussE_5();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResDoubleGaussPt.h
+++ b/include/KLFitter/ResDoubleGaussPt.h
@@ -69,35 +69,35 @@ class ResDoubleGaussPt : public ResDoubleGaussBase {
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean1(double x);
+  double GetMean1(double x) override;
 
   /**
     * Calculate the width of the first Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma1(double x);
+  double GetSigma1(double x) override;
 
   /**
     * Calculate the amplitude of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetAmplitude2(double x);
+  double GetAmplitude2(double x) override;
 
   /**
     * Calculate the mean of the second Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetMean2(double x);
+  double GetMean2(double x) override;
 
   /**
     * Calculate the width of the sedcond Gaussian from the TF parameters and the value of x.
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma2(double x);
+  double GetSigma2(double x) override;
 
   /* @} */
 };

--- a/include/KLFitter/ResDoubleGaussPt.h
+++ b/include/KLFitter/ResDoubleGaussPt.h
@@ -58,7 +58,7 @@ class ResDoubleGaussPt : public ResDoubleGaussBase {
   /**
     * The default destructor.
     */
-  virtual ~ResDoubleGaussPt();
+  ~ResDoubleGaussPt();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResGauss.h
+++ b/include/KLFitter/ResGauss.h
@@ -68,7 +68,7 @@ class ResGauss : public ResolutionBase {
     * @param dummy Dummy parameter. Only needed to satisfy the interface.
     * @return The width.
     */
-  virtual double GetSigma(double dummy = 0);
+  double GetSigma(double dummy = 0) override;
 
   /**
     * Return the probability of the true value of x given the
@@ -78,7 +78,7 @@ class ResGauss : public ResolutionBase {
     * @param good False if problem with TF.
     * @return The probability.
     */
-  double p(double x, double xmeas, bool *good);
+  double p(double x, double xmeas, bool *good) override;
 
   /**
     * Return the probability of the true value of x given the
@@ -89,7 +89,7 @@ class ResGauss : public ResolutionBase {
     * @param par Optional additional parameter (SumET in case of MET TF).
     * @return The probability.
     */
-  virtual double p(double x, double xmeas, bool *good, double par) { *good = true; return 0; }
+  double p(double x, double xmeas, bool *good, double par) override { *good = true; return 0; }
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGauss.h
+++ b/include/KLFitter/ResGauss.h
@@ -56,7 +56,7 @@ class ResGauss : public ResolutionBase {
   /**
     * The default destructor.
     */
-  virtual ~ResGauss();
+  ~ResGauss();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResGaussE.h
+++ b/include/KLFitter/ResGaussE.h
@@ -63,7 +63,7 @@ class ResGaussE : public ResolutionBase {
   /**
     * The default destructor.
     */
-  virtual ~ResGaussE();
+  ~ResGaussE();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResGaussE.h
+++ b/include/KLFitter/ResGaussE.h
@@ -75,7 +75,7 @@ class ResGaussE : public ResolutionBase {
     * @param x true energy as parameter of the TF.
     * @return The width.
     */
-  virtual double GetSigma(double x);
+  double GetSigma(double x) override;
 
   /**
     * Return the probability of the true value of x given the
@@ -86,7 +86,7 @@ class ResGaussE : public ResolutionBase {
     * @param par Optional additional parameter (SumET in case of MET TF).
     * @return The probability.
     */
-  double p(double x, double xmeas, bool *good);
+  double p(double x, double xmeas, bool *good) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGaussPt.h
+++ b/include/KLFitter/ResGaussPt.h
@@ -75,7 +75,7 @@ class ResGaussPt : public ResolutionBase {
     * @param x true energy as parameter of the TF.
     * @return The width.
     */
-  virtual double GetSigma(double x);
+  double GetSigma(double x) override;
 
   /**
     * Return the probability of the true value of x given the
@@ -86,7 +86,7 @@ class ResGaussPt : public ResolutionBase {
     * @param par Optional additional parameter (SumET in case of MET TF).
     * @return The probability.
     */
-  double p(double x, double xmeas, bool *good);
+  double p(double x, double xmeas, bool *good) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGaussPt.h
+++ b/include/KLFitter/ResGaussPt.h
@@ -63,7 +63,7 @@ class ResGaussPt : public ResolutionBase {
   /**
     * The default destructor.
     */
-  virtual ~ResGaussPt();
+  ~ResGaussPt();
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/ResGauss_MET.h
+++ b/include/KLFitter/ResGauss_MET.h
@@ -70,7 +70,7 @@ class ResGauss_MET : public ResolutionBase {
     * @param sumet SumET as parameter for the MET TF.
     * @return The width.
     */
-  virtual double GetSigma(double sumet);
+  double GetSigma(double sumet) override;
 
   /**
     * Return the probability of the true value of x given the
@@ -80,7 +80,7 @@ class ResGauss_MET : public ResolutionBase {
     * @param good False if problem with TF.
     * @return The probability.
     */
-  virtual double p(double x, double xmeas, bool *good) { *good = true; return 0; }
+  double p(double x, double xmeas, bool *good) override { *good = true; return 0; }
 
   /**
     * Return the probability of the true value of x given the
@@ -91,7 +91,7 @@ class ResGauss_MET : public ResolutionBase {
     * @param good False if problem with TF.
     * @return The probability.
     */
-  double p(double x, double xmeas, bool *good, double sumet);
+  double p(double x, double xmeas, bool *good, double sumet) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGauss_MET.h
+++ b/include/KLFitter/ResGauss_MET.h
@@ -58,7 +58,7 @@ class ResGauss_MET : public ResolutionBase {
   /**
     * The default destructor.
     */
-  virtual ~ResGauss_MET();
+  ~ResGauss_MET();
 
   /* @} */
   /** \name Member functions (Get)  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR introduces a more consistent usage of the keywords `virtual`, `override` and `final` (the latter two of which haven't been used so far). Changes in detail:
1. Use `override` keyword for reimplemented methods in derived classes. `override`, much more than another `virtual` explains what's actually happening: the methods are reimplemented and overwrite the base class implementation. This also ensures that the syntax between base class and derived class implementation is identical. This change was applied to the derived classes of type likelihood, detector, and resolution. At the same time, `virtual` as a keyword was removed from those methods.
2. Remove the `virtual` keyword also from the destructors of the derived classes. While using `virtual` for the base class destructor is essential, it is redundant for derived class destructors (and deprecated according to isocpp/CppCoreGuidelines#721).
3. Core classes, i.e. Fitter, Particles, Permutations, and PhysicsConstants, are marked with the keyword `final` to prevent them from being used as base classes. If that changes in the future, this keyword can be removed, but it is useful to trigger a compilation error if someone attempts to do so.
4. The keyword `virtual` was removed from all methods that are not reimplemented anywhere. Specifically, a lot of the derived likelihood classes had virtual methods implemented, none of which exist in LikelihoodBase, nor get reimplemented in another derived class. To avoid suggesting this kind of inheritance, the keyword was removed.
5. A few methods are implemented in the header files directly. For these cases, the compiler directive `inline` was used very inconsistently. As all those cases are `inline` by definition and get auto-optimised by the compiler either way, the keywords were removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
General applied rules are:
1. Use `virtual` for base class methods that are intended/expected to be overwritten in a derived class.
2. Use `override` for _all_ overwritten virtual methods. Using the keyword `virtual` in derived classes is confusing and hides what's actually happening.
3. Use `final` if methods and or classes are not meant to be reimplemented/derived.
4. Use the compiler directive `inline` when a function is implemented in multiple translation units and this needs to be pointed out. For header-implemented functions, this is trivial, and the keyword is not necessary.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled and tested with example binaries as usual.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
