### PR TITLE
Clean-up of methods in likelihood classes

### DIFF
--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -157,12 +157,6 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    */
   std::vector<double> GetInitialParametersWoNeutrinoPz();
 
-  /**
-   * Check if there are TF problems.
-   * @return Return false if TF problem.
-   */
-  bool NoTFProblem(std::vector<double> parameters) override;
-
   /* @} */
 
  protected:
@@ -260,11 +254,6 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * jets.
    */
   LeptonType fTypeLepton;
-
-  /**
-   * Global variable for TF problems.
-   */
-  bool fTFgood;
 
   /**
    * Save resolution functions since the eta of the partons is not fitted.

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -196,7 +196,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * Update 4-vectors of model particles.
    * @return An error flag.
    */
-  int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
    * Initialize the likelihood for the event

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -183,11 +183,6 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
-   * Initialize the likelihood for the event
-   */
-  int Initialize() override;
-
-  /**
    * Adjust parameter ranges
    */
   int AdjustParameterRanges() override;

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -121,13 +121,6 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   void DefineParameters() override;
 
   /**
-   * The prior probability definition, overloaded from BCModel.
-   * @param parameters A vector of parameters (double values).
-   * @return The logarithm of the prior probability.
-   */
-  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
-
-  /**
    * The posterior probability definition, overloaded from BCModel.
    * @param parameters A vector of parameters (double values).
    * @return The logarithm of the prior probability.

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -273,7 +273,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
    * Save permuted particles.
    */
-  int SavePermutedParticles();
+  int SavePermutedParticles() override;
 
   /**
    * Save resolution functions.

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -212,7 +212,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * Define the model particles
    * @return An error code.
    */
-  int DefineModelParticles();
+  int DefineModelParticles() override;
 
   /**
    * Remove invariant particle permutations.

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -230,7 +230,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * Build the model particles from the best fit parameters.
    * @return An error code.
    */
-  int BuildModelParticles();
+  int BuildModelParticles() override;
 
   /* @} */
 

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -170,19 +170,6 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    */
   bool NoTFProblem(std::vector<double> parameters) override;
 
-  /**
-   * Return the set of model particles.
-   * @return A pointer to the particles.
-   */
-  KLFitter::Particles* ParticlesModel() override {
-    BuildModelParticles();
-    return fParticlesModel;
-  }
-  KLFitter::Particles** PParticlesModel() override {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
-
   /* @} */
 
  protected:

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -206,7 +206,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
    * Adjust parameter ranges
    */
-  int AdjustParameterRanges();
+  int AdjustParameterRanges() override;
 
   /**
    * Define the model particles

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -200,12 +200,6 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   int RemoveInvariantParticlePermutations() override;
 
   /**
-   * Remove forbidden particle permutations.
-   * @return An error code.
-   */
-  int RemoveForbiddenParticlePermutations() override;
-
-  /**
    * Build the model particles from the best fit parameters.
    * @return An error code.
    */

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -269,7 +269,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
    * Save resolution functions.
    */
-  int SaveResolutionFunctions();
+  int SaveResolutionFunctions() override;
 
   /**
    * The values of the x component of the missing ET.

--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -20,7 +20,6 @@
 #ifndef KLFITTER_BOOSTEDLIKELIHOODTOPLEPTONJETS_H_
 #define KLFITTER_BOOSTEDLIKELIHOODTOPLEPTONJETS_H_
 
-#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -93,8 +92,6 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * @param flag The flag.
    */
   void SetFlagTopMassFixed(bool flag) { fFlagTopMassFixed = flag; }
-
-  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   void SetFlagGetParSigmasFromTFs(bool flag) { fFlagGetParSigmasFromTFs = flag; }
 
@@ -241,12 +238,6 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   bool fFlagTopMassFixed;
 
   /**
-   * A flag for using the measured jet masses (true) instead of
-   * parton masses (false);
-   */
-  bool fFlagUseJetMass;
-
-  /**
    *  Flag for using ResolutionBase::GetSigma() to retrieve the parameter ranges
    */
   bool fFlagGetParSigmasFromTFs;
@@ -279,32 +270,6 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    * Save resolution functions.
    */
   int SaveResolutionFunctions();
-
-  /**
-   * Set model parton mass according to fFlagUseJetMass.
-   * @param jetmass The jet mass.
-   * @param quarkmass The quark mass.
-   * @param px The parton px (will be modified, if necessary).
-   * @param py The parton py (will be modified, if necessary).
-   * @param pz The parton pz (will be modified, if necessary).
-   * @param e The parton energy (not modified).
-   * @return The parton mass.
-   */
-  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
-    double mass(0.);
-    if (fFlagUseJetMass) {
-      mass = jetmass > 0. ? jetmass : 0.;
-    } else {
-      mass = quarkmass;
-    }
-    double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
-    double p_newmass = sqrt(e * e - mass * mass);
-    double scale = p_newmass / p_orig;
-    *px *= scale;
-    *py *= scale;
-    *pz *= scale;
-    return mass;
-  }
 
   /**
    * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -98,8 +98,8 @@ class LikelihoodBase : public BCModel {
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() { return fParticlesModel; }
-  virtual KLFitter::Particles** PParticlesModel() { return &fParticlesModel; }
+  virtual KLFitter::Particles* ParticlesModel() = 0;
+  virtual KLFitter::Particles** PParticlesModel() = 0;
 
   /**
     * Return the number of model particles.
@@ -174,7 +174,7 @@ class LikelihoodBase : public BCModel {
     * @param sumet total scalar ET.
     * @return An error flag.
     */
-  virtual int SetET_miss_XY_SumET(double etx, double ety, double sumet) { return 0; }
+  virtual int SetET_miss_XY_SumET(double etx, double ety, double sumet) = 0;
 
   /**
     * Set the permutation object.
@@ -265,7 +265,7 @@ class LikelihoodBase : public BCModel {
     * Initialize the likelihood for the event
     * @return An error code
     */
-  virtual int Initialize() { return 1; }
+  virtual int Initialize() = 0;
 
   /**
    * Adjust parameter ranges
@@ -291,28 +291,28 @@ class LikelihoodBase : public BCModel {
   /**
     * Define the parameters of the fit.
     */
-  virtual void DefineParameters() { ; }
+  virtual void DefineParameters() = 0;
 
   /**
     * The prior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  virtual double LogAPrioriProbability(const std::vector <double> & parameters) = 0;
 
   /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogLikelihood(const std::vector <double> & parameters) { return 0; }
+  virtual double LogLikelihood(const std::vector <double> & parameters) = 0;
 
   /**
     * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
     * @param parameters A vector of parameters (double values).
     * @return A vector with the components of the logarithm of the prior probability.
     */
-  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) { return std::vector<double>(0); }
+  virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) = 0;
 
   /**
     * Return BCH1D histograms calculated inside
@@ -339,13 +339,13 @@ class LikelihoodBase : public BCModel {
     * Remove invariant particle permutations.
     * @return An error code.
     */
-  virtual int RemoveInvariantParticlePermutations() { return 1; }
+  virtual int RemoveInvariantParticlePermutations() = 0;
 
   /**
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  virtual int RemoveForbiddenParticlePermutations() { return 1; }
+  virtual int RemoveForbiddenParticlePermutations() = 0;
 
   /**
    * Build the model particles from the best fit parameters.
@@ -357,13 +357,13 @@ class LikelihoodBase : public BCModel {
     * Get initial values for the parameters.
     * @return vector of initial values.
     */
-  virtual std::vector<double> GetInitialParameters() { std::vector<double> v; return v; }
+  virtual std::vector<double> GetInitialParameters() = 0;
 
   /**
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters) { return true; }
+  virtual bool NoTFProblem(std::vector<double> parameters) = 0;
 
   /**
     * Returns the best fit parameters, overloaded from BCModel

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -453,6 +453,11 @@ class LikelihoodBase : public BCModel {
   virtual int SavePermutedParticles() = 0;
 
   /**
+   * Save resolution functions.
+   */
+  virtual int SaveResolutionFunctions() = 0;
+
+  /**
    * Set model parton mass according to fFlagUseJetMass.
    * @param jetmass The jet mass.
    * @param quarkmass The quark mass.

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -98,8 +98,14 @@ class LikelihoodBase : public BCModel {
     * Return the set of model particles.
     * @return A pointer to the particles.
     */
-  virtual KLFitter::Particles* ParticlesModel() = 0;
-  virtual KLFitter::Particles** PParticlesModel() = 0;
+  KLFitter::Particles* ParticlesModel() {
+    BuildModelParticles();
+    return fParticlesModel;
+  }
+  KLFitter::Particles** PParticlesModel() {
+    BuildModelParticles();
+    return &fParticlesModel;
+  }
 
   /**
     * Return the number of model particles.

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -268,6 +268,12 @@ class LikelihoodBase : public BCModel {
   virtual int AdjustParameterRanges() = 0;
 
   /**
+   * Define the model particles
+   * @return An error code.
+   */
+  virtual int DefineModelParticles() = 0;
+
+  /**
     * Propagate the b-tagging information from the permuted (measured) particles to the model particles.
     */
   void PropagateBTaggingInformation();

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -331,6 +331,12 @@ class LikelihoodBase : public BCModel {
   virtual int RemoveForbiddenParticlePermutations() { return 1; }
 
   /**
+   * Build the model particles from the best fit parameters.
+   * @return An error code.
+   */
+  virtual int BuildModelParticles() = 0;
+
+  /**
     * Get initial values for the parameters.
     * @return vector of initial values.
     */

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -257,6 +257,11 @@ class LikelihoodBase : public BCModel {
   virtual int Initialize() { return 1; }
 
   /**
+   * Adjust parameter ranges
+   */
+  virtual int AdjustParameterRanges() = 0;
+
+  /**
     * Propagate the b-tagging information from the permuted (measured) particles to the model particles.
     */
   void PropagateBTaggingInformation();

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -271,7 +271,7 @@ class LikelihoodBase : public BCModel {
     * Initialize the likelihood for the event
     * @return An error code
     */
-  virtual int Initialize() = 0;
+  virtual int Initialize();
 
   /**
    * Adjust parameter ranges

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -351,7 +351,7 @@ class LikelihoodBase : public BCModel {
     * Remove forbidden particle permutations.
     * @return An error code.
     */
-  virtual int RemoveForbiddenParticlePermutations() = 0;
+  virtual int RemoveForbiddenParticlePermutations();
 
   /**
    * Build the model particles from the best fit parameters.

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -251,6 +251,12 @@ class LikelihoodBase : public BCModel {
   /* @{ */
 
   /**
+   * Update 4-vectors of model particles.
+   * @return An error flag.
+   */
+  virtual int CalculateLorentzVectors(std::vector <double> const& parameters) = 0;
+
+  /**
     * Initialize the likelihood for the event
     * @return An error code
     */

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -249,7 +249,7 @@ class LikelihoodBase : public BCModel {
     * Set flag to use measured jet masses (true) instead of
     * parton masses (false);
     */
-  virtual void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
+  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   /* @} */
   /** \name Member functions (misc)  */

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -304,7 +304,7 @@ class LikelihoodBase : public BCModel {
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) = 0;
+  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -245,6 +245,11 @@ class LikelihoodBase : public BCModel {
     */
   int SetFlagIntegrate(bool flag) { fFlagIntegrate = flag; return 1; }
 
+  /**
+    * Set flag to use measured jet masses (true) instead of
+    * parton masses (false);
+    */
+  virtual void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   /* @} */
   /** \name Member functions (misc)  */
@@ -448,6 +453,18 @@ class LikelihoodBase : public BCModel {
   virtual int SavePermutedParticles() = 0;
 
   /**
+   * Set model parton mass according to fFlagUseJetMass.
+   * @param jetmass The jet mass.
+   * @param quarkmass The quark mass.
+   * @param px The parton px (will be modified, if necessary).
+   * @param py The parton py (will be modified, if necessary).
+   * @param pz The parton pz (will be modified, if necessary).
+   * @param e The parton energy (not modified).
+   * @return The parton mass.
+   */
+  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e);
+
+  /**
     * A pointer to the measured particles.
     */
   KLFitter::Particles** fParticlesPermuted;
@@ -491,6 +508,12 @@ class LikelihoodBase : public BCModel {
     * A flag for knowing that Minuit gave parameters with NaN values to LogLikelihood
     */
   bool fFlagIsNan;
+
+  /**
+   * A flag for using the measured jet masses (true) instead of
+   * parton masses (false);
+   */
+  bool fFlagUseJetMass;
 
   /**
     * Name of btagging enum

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -443,6 +443,11 @@ class LikelihoodBase : public BCModel {
 
  protected:
   /**
+   * Save permuted particles.
+   */
+  virtual int SavePermutedParticles() = 0;
+
+  /**
     * A pointer to the measured particles.
     */
   KLFitter::Particles** fParticlesPermuted;

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -369,7 +369,7 @@ class LikelihoodBase : public BCModel {
     * Check if there are TF problems.
     * @return Return false if TF problem.
     */
-  virtual bool NoTFProblem(std::vector<double> parameters) = 0;
+  virtual bool NoTFProblem(std::vector<double> parameters);
 
   /**
     * Returns the best fit parameters, overloaded from BCModel
@@ -525,6 +525,11 @@ class LikelihoodBase : public BCModel {
    * parton masses (false);
    */
   bool fFlagUseJetMass;
+
+  /**
+   * Global variable for TF problems.
+   */
+  bool fTFgood;
 
   /**
     * Name of btagging enum

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -241,7 +241,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   /**
     * Save permuted particles.
     */
-  int SavePermutedParticles();
+  int SavePermutedParticles() override;
 
   /**
     * Save resolution functions.

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -195,7 +195,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  int AdjustParameterRanges();
+  int AdjustParameterRanges() override;
 
   /**
     * Define the model particles

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -20,7 +20,6 @@
 #ifndef KLFITTER_LIKELIHOODSGTOPWTLJ_H_
 #define KLFITTER_LIKELIHOODSGTOPWTLJ_H_
 
-#include <cmath>
 #include <vector>
 
 namespace KLFitter {
@@ -114,8 +113,6 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * Associate the leptonic leg of the event to the top quark for likelihood calculation.
     */
   void SetLeptonicTop() { fHadronicTop = false; }
-
-  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   /**
     * Set the type of lepton
@@ -226,12 +223,6 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   bool fHadronicTop;
 
   /**
-    * A flag for using the measured jet masses (true) instead of
-    * parton masses (false);
-    */
-  bool fFlagUseJetMass;
-
-  /**
     * Calculates the neutrino pz solutions from the measured values
     * and the W mass.
     * @return A vector with 0, 1 or 2 neutrino pz solutions.
@@ -247,32 +238,6 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * Save resolution functions.
     */
   int SaveResolutionFunctions();
-
-  /**
-    * Set model parton mass according to fFlagUseJetMass.
-    * @param jetmass The jet mass.
-    * @param quarkmass The quark mass.
-    * @param px The parton px (will be modified, if necessary).
-    * @param py The parton py (will be modified, if necessary).
-    * @param pz The parton pz (will be modified, if necessary).
-    * @param e The parton energy (not modified).
-    * @return The parton mass.
-    */
-  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
-    double mass(0.);
-    if (fFlagUseJetMass) {
-      mass = jetmass > 0. ? jetmass : 0.;
-    } else {
-      mass = quarkmass;
-    }
-    double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
-    double p_newmass = sqrt(e * e - mass * mass);
-    double scale = p_newmass / p_orig;
-    *px *= scale;
-    *py *= scale;
-    *pz *= scale;
-    return mass;
-  }
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -185,7 +185,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  int CalculateLorentzVectors(std::vector <double> parameters) override;
+  int CalculateLorentzVectors(const std::vector <double>& parameters) override;
 
   /**
     * Initialize the likelihood for the event

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -237,7 +237,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   /**
     * Save resolution functions.
     */
-  int SaveResolutionFunctions();
+  int SaveResolutionFunctions() override;
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -146,12 +146,6 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     */
   std::vector<double> GetInitialParameters() override;
 
-  /**
-    * Check if there are TF problems.
-    * @return Return false if TF problem.
-    */
-  bool NoTFProblem(std::vector<double> parameters) override;
-
   /* @} */
 
  protected:
@@ -239,11 +233,6 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * jets.
     */
   int fTypeLepton;
-
-  /**
-    * Global variable for TF problems.
-    */
-  bool fTFgood;
 
   /**
     * Save resolution functions since the eta of the partons is not fitted.

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -201,7 +201,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * Define the model particles
     * @return An error code.
     */
-  int DefineModelParticles();
+  int DefineModelParticles() override;
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -185,7 +185,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  int CalculateLorentzVectors(std::vector <double> parameters);
+  int CalculateLorentzVectors(std::vector <double> parameters) override;
 
   /**
     * Initialize the likelihood for the event

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -159,19 +159,6 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     */
   bool NoTFProblem(std::vector<double> parameters) override;
 
-  /**
-    * Return the set of model particles.
-    * @return A pointer to the particles.
-    */
-  KLFitter::Particles* ParticlesModel() override {
-    BuildModelParticles();
-    return fParticlesModel;
-  }
-  KLFitter::Particles** PParticlesModel() override {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
-
   /* @} */
 
  protected:

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -213,7 +213,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */
-  int BuildModelParticles();
+  int BuildModelParticles() override;
 
   /* @} */
 

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -134,13 +134,6 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   void DefineParameters() override;
 
   /**
-    * The prior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
-  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
-
-  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -180,19 +180,6 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     */
   bool NoTFProblem(std::vector<double> parameters) override;
 
-  /**
-    * Return the set of model particles.
-    * @return A pointer to the particles.
-    */
-  KLFitter::Particles* ParticlesModel() override {
-    BuildModelParticles();
-    return fParticlesModel;
-  }
-  KLFitter::Particles** PParticlesModel() override {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
-
   /* @} */
 
  protected:

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -193,11 +193,6 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
-    * Initialize the likelihood for the event
-    */
-  int Initialize() override;
-
-  /**
     * Adjust parameter ranges
     */
   int AdjustParameterRanges() override;

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -210,12 +210,6 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   int RemoveInvariantParticlePermutations() override;
 
   /**
-    * Remove forbidden particle permutations.
-    * @return An error code.
-    */
-  int RemoveForbiddenParticlePermutations() override;
-
-  /**
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -167,12 +167,6 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     */
   std::vector<double> GetInitialParametersWoNeutrinoPz();
 
-  /**
-    * Check if there are TF problems.
-    * @return Return false if TF problem.
-    */
-  bool NoTFProblem(std::vector<double> parameters) override;
-
   /* @} */
 
  protected:
@@ -270,11 +264,6 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * jets.
     */
   LeptonType fTypeLepton;
-
-  /**
-    * Global variable for TF problems.
-    */
-  bool fTFgood;
 
   /**
     * Save resolution functions since the eta of the partons is not fitted.

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -126,13 +126,6 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   void DefineParameters() override;
 
   /**
-    * The prior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
-  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
-
-  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -20,7 +20,6 @@
 #ifndef KLFITTER_LIKELIHOODTTHLEPTONJETS_H_
 #define KLFITTER_LIKELIHOODTTHLEPTONJETS_H_
 
-#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -100,8 +99,6 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * @param flag The flag.
     */
   void SetFlagHiggsMassFixed(bool flag) { fFlagHiggsMassFixed = flag; }
-
-  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   /**
     * Set the type of lepton
@@ -256,12 +253,6 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   bool fFlagHiggsMassFixed;
 
   /**
-    * A flag for using the measured jet masses (true) instead of
-    * parton masses (false);
-    */
-  bool fFlagUseJetMass;
-
-  /**
     * Return the neutrino pz solutions from the measured values
     * and the W mass.
     * @return A vector with 0, 1 or 2 neutrino pz solutions.
@@ -289,32 +280,6 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * Save resolution functions.
     */
   int SaveResolutionFunctions();
-
-  /**
-    * Set model parton mass according to fFlagUseJetMass.
-    * @param jetmass The jet mass.
-    * @param quarkmass The quark mass.
-    * @param px The parton px (will be modified, if necessary).
-    * @param py The parton py (will be modified, if necessary).
-    * @param pz The parton pz (will be modified, if necessary).
-    * @param e The parton energy (not modified).
-    * @return The parton mass.
-    */
-  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
-    double mass(0.);
-    if (fFlagUseJetMass) {
-      mass = jetmass > 0. ? jetmass : 0.;
-    } else {
-      mass = quarkmass;
-    }
-    double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
-    double p_newmass = sqrt(e * e - mass * mass);
-    double scale = p_newmass / p_orig;
-    *px *= scale;
-    *py *= scale;
-    *pz *= scale;
-    return mass;
-  }
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -216,7 +216,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  int AdjustParameterRanges();
+  int AdjustParameterRanges() override;
 
   /**
     * Define the model particles

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -279,7 +279,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Save resolution functions.
     */
-  int SaveResolutionFunctions();
+  int SaveResolutionFunctions() override;
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -222,7 +222,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * Define the model particles
     * @return An error code.
     */
-  int DefineModelParticles();
+  int DefineModelParticles() override;
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -240,7 +240,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */
-  int BuildModelParticles();
+  int BuildModelParticles() override;
 
   /* @} */
 

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -283,7 +283,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Save permuted particles.
     */
-  int SavePermutedParticles();
+  int SavePermutedParticles() override;
 
   /**
     * Save resolution functions.

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -206,7 +206,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
     * Initialize the likelihood for the event

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -244,7 +244,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
     * Initialize the likelihood for the event

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -20,7 +20,6 @@
 #ifndef KLFITTER_LIKELIHOODTTZTRILEPTON_H_
 #define KLFITTER_LIKELIHOODTTZTRILEPTON_H_
 
-#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -112,8 +111,6 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * @param flag The flag.
     */
   void SetFlagTopMassFixed(bool flag) { fFlagTopMassFixed = flag; }
-
-  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   void SetFlagGetParSigmasFromTFs(bool flag) { fFlagGetParSigmasFromTFs = flag; }
 
@@ -289,12 +286,6 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   bool fFlagTopMassFixed;
 
   /**
-    * A flag for using the measured jet masses (true) instead of
-    * parton masses (false);
-    */
-  bool fFlagUseJetMass;
-
-  /**
     *  Flag for using ResolutionBase::GetSigma() to retrieve the parameter ranges
     */
   bool fFlagGetParSigmasFromTFs;
@@ -327,32 +318,6 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * Save resolution functions.
     */
   int SaveResolutionFunctions();
-
-  /**
-    * Set model parton mass according to fFlagUseJetMass.
-    * @param jetmass The jet mass.
-    * @param quarkmass The quark mass.
-    * @param px The parton px (will be modified, if necessary).
-    * @param py The parton py (will be modified, if necessary).
-    * @param pz The parton pz (will be modified, if necessary).
-    * @param e The parton energy (not modified).
-    * @return The parton mass.
-    */
-  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
-    double mass(0.);
-    if (fFlagUseJetMass) {
-      mass = jetmass > 0. ? jetmass : 0.;
-    } else {
-      mass = quarkmass;
-    }
-    double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
-    double p_newmass = sqrt(e * e - mass * mass);
-    double scale = p_newmass / p_orig;
-    *px *= scale;
-    *py *= scale;
-    *pz *= scale;
-    return mass;
-  }
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -317,7 +317,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   /**
     * Save resolution functions.
     */
-  int SaveResolutionFunctions();
+  int SaveResolutionFunctions() override;
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -321,7 +321,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   /**
     * Save permuted particles.
     */
-  int SavePermutedParticles();
+  int SavePermutedParticles() override;
 
   /**
     * Save resolution functions.

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -248,12 +248,6 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   int RemoveInvariantParticlePermutations() override;
 
   /**
-    * Remove forbidden particle permutations.
-    * @return An error code.
-    */
-  int RemoveForbiddenParticlePermutations() override;
-
-  /**
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -181,12 +181,6 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     */
   std::vector<double> GetInitialParametersWoNeutrinoPz();
 
-  /**
-    * Check if there are TF problems.
-    * @return Return false if TF problem.
-    */
-  bool NoTFProblem(std::vector<double> parameters) override;
-
   /* @} */
 
  protected:
@@ -308,11 +302,6 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * jets.
     */
   LeptonType fTypeLepton;
-
-  /**
-    * Global variable for TF problems.
-    */
-  bool fTFgood;
 
   /**
     * Cut-off value for the 1/E^2 distribution (in GeV).

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -278,7 +278,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */
-  int BuildModelParticles();
+  int BuildModelParticles() override;
 
   /* @} */
 

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -260,7 +260,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     * Define the model particles
     * @return An error code.
     */
-  int DefineModelParticles();
+  int DefineModelParticles() override;
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -254,7 +254,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  int AdjustParameterRanges();
+  int AdjustParameterRanges() override;
 
   /**
     * Define the model particles

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -140,13 +140,6 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   void DefineParameters() override;
 
   /**
-    * The prior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
-  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
-
-  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -194,19 +194,6 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     */
   bool NoTFProblem(std::vector<double> parameters) override;
 
-  /**
-    * Return the set of model particles.
-    * @return A pointer to the particles.
-    */
-  KLFitter::Particles* ParticlesModel() override {
-    BuildModelParticles();
-    return fParticlesModel;
-  }
-  KLFitter::Particles** PParticlesModel() override {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
-
   /* @} */
 
  protected:

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -231,11 +231,6 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
-    * Initialize the likelihood for the event
-    */
-  int Initialize() override;
-
-  /**
     * Adjust parameter ranges
     */
   int AdjustParameterRanges() override;

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -161,7 +161,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
     * Initialize the likelihood for the event

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -171,7 +171,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  int AdjustParameterRanges();
+  int AdjustParameterRanges() override;
 
   /**
     * Define the model particles

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -20,7 +20,6 @@
 #ifndef KLFITTER_LIKELIHOODTOPALLHADRONIC_H_
 #define KLFITTER_LIKELIHOODTOPALLHADRONIC_H_
 
-#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -77,8 +76,6 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * @param flag The flag.
     */
   void SetFlagTopMassFixed(bool flag) { fFlagTopMassFixed = flag; }
-
-  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   void SetFlagGetParSigmasFromTFs(bool flag) { fFlagGetParSigmasFromTFs = flag; }
 
@@ -212,12 +209,6 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   bool fFlagTopMassFixed;
 
   /**
-    * A flag for using the measured jet masses (true) instead of
-    * parton masses (false);
-    */
-  bool fFlagUseJetMass;
-
-  /**
     *  Flag for using ResolutionBase::GetSigma() to retrieve the parameter ranges
     */
   bool fFlagGetParSigmasFromTFs;
@@ -231,32 +222,6 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * Save resolution functions.
     */
   int SaveResolutionFunctions();
-
-  /**
-    * Set model parton mass according to fFlagUseJetMass.
-    * @param jetmass The jet mass.
-    * @param quarkmass The quark mass.
-    * @param px The parton px (will be modified, if necessary).
-    * @param py The parton py (will be modified, if necessary).
-    * @param pz The parton pz (will be modified, if necessary).
-    * @param e The parton energy (not modified).
-    * @return The parton mass.
-    */
-  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
-    double mass(0.);
-    if (fFlagUseJetMass) {
-      mass = jetmass > 0. ? jetmass : 0.;
-    } else {
-      mass = quarkmass;
-    }
-    double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
-    double p_newmass = sqrt(e * e - mass * mass);
-    double scale = p_newmass / p_orig;
-    *px *= scale;
-    *py *= scale;
-    *pz *= scale;
-    return mass;
-  }
 
   /**
     * Global variable for TF problems.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -122,12 +122,6 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     */
   std::vector<double> GetInitialParameters() override;
 
-  /**
-    * Check if there are TF problems.
-    * @return Return false if TF problem.
-    */
-  bool NoTFProblem(std::vector<double> parameters) override;
-
   /* @} */
 
  protected:
@@ -191,11 +185,6 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * Save resolution functions.
     */
   int SaveResolutionFunctions() override;
-
-  /**
-    * Global variable for TF problems.
-    */
-  bool fTFgood;
 
   /**
     * Save resolution functions since the eta of the partons is not fitted.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -177,7 +177,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * Define the model particles
     * @return An error code.
     */
-  int DefineModelParticles();
+  int DefineModelParticles() override;
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -221,7 +221,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   /**
     * Save resolution functions.
     */
-  int SaveResolutionFunctions();
+  int SaveResolutionFunctions() override;
 
   /**
     * Global variable for TF problems.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -93,13 +93,6 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   void DefineParameters() override;
 
   /**
-    * The prior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
-  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
-
-  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -201,7 +201,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */
-  int BuildModelParticles();
+  int BuildModelParticles() override;
 
   /* @} */
 

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -135,19 +135,6 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
     */
   bool NoTFProblem(std::vector<double> parameters) override;
 
-  /**
-    * Return the set of model particles.
-    * @return A pointer to the particles.
-    */
-  KLFitter::Particles* ParticlesModel() override {
-    BuildModelParticles();
-    return fParticlesModel;
-  }
-  KLFitter::Particles** PParticlesModel() override {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
-
   /* @} */
 
  protected:

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -165,12 +165,6 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   int RemoveInvariantParticlePermutations() override;
 
   /**
-    * Remove forbidden particle permutations.
-    * @return An error code.
-    */
-  int RemoveForbiddenParticlePermutations() override;
-
-  /**
     * Remove forbidden particle permutations - forcing b-jets on the position of a b parton.
     * @return An error code.
     */

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -225,7 +225,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   /**
     * Save permuted particles.
     */
-  int SavePermutedParticles();
+  int SavePermutedParticles() override;
 
   /**
     * Save resolution functions.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -148,11 +148,6 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
-    * Initialize the likelihood for the event
-    */
-  int Initialize() override;
-
-  /**
     * Adjust parameter ranges
     */
   int AdjustParameterRanges() override;

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -268,7 +268,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  int AdjustParameterRanges();
+  int AdjustParameterRanges() override;
 
   /**
     * Define the model particles

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -334,7 +334,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   /**
     * Save permuted particles.
     */
-  int SavePermutedParticles();
+  int SavePermutedParticles() override;
 
   /**
     * Save resolution functions.

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -292,7 +292,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */
-  int BuildModelParticles();
+  int BuildModelParticles() override;
 
   /**
     * Calculate other variables out of the KLFitter parameters for each MCMCiteration

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -330,7 +330,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   /**
     * Save resolution functions.
     */
-  int SaveResolutionFunctions();
+  int SaveResolutionFunctions() override;
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -172,12 +172,6 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   std::vector<double> GetInitialParameters() override;
 
   /**
-    * Check if there are TF problems.
-    * @return Return false if TF problem.
-    */
-  bool NoTFProblem(std::vector<double> parameters) override;
-
-  /**
     * Return Gaussian term for neutrino
     * pseudorapidity.
     * @return A double.
@@ -340,11 +334,6 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * A flag for using sumloglikelihood option
     */
   bool doSumloglik;
-
-  /**
-    * Global variable for TF problems.
-    */
-  bool fTFgood;
 
  public:
   /**

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -186,19 +186,6 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   bool NoTFProblem(std::vector<double> parameters) override;
 
   /**
-    * Return the set of model particles.
-    * @return A pointer to the particles.
-    */
-  KLFitter::Particles* ParticlesModel() override {
-    BuildModelParticles();
-    return fParticlesModel;
-  }
-  KLFitter::Particles** PParticlesModel() override {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
-
-  /**
     * Return Gaussian term for neutrino
     * pseudorapidity.
     * @return A double.

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -144,14 +144,6 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   void DefineHistograms();
 
   /**
-    * The prior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
-
-  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
-
-  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -274,7 +274,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * Define the model particles
     * @return An error code.
     */
-  int DefineModelParticles();
+  int DefineModelParticles() override;
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -267,12 +267,6 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   int RemoveInvariantParticlePermutations() override;
 
   /**
-    * Remove forbidden particle permutations.
-    * @return An error code.
-    */
-  int RemoveForbiddenParticlePermutations() override;
-
-  /**
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -22,7 +22,6 @@
 
 #include <assert.h>
 
-#include <cmath>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -99,8 +98,6 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * @param flag The flag.
     */
   void SetFlagTopMassFixed(bool flag) { fFlagTopMassFixed = flag; }
-
-  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   /**
     * Set the neutrino pseudorapidity sigma linear dependency on mtop
@@ -326,12 +323,6 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   bool fFlagTopMassFixed;
 
   /**
-    * A flag for using the measured jet masses (true) instead of
-    * parton masses (false);
-    */
-  bool fFlagUseJetMass;
-
-  /**
     * Save permuted particles.
     */
   int SavePermutedParticles() override;
@@ -340,32 +331,6 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * Save resolution functions.
     */
   int SaveResolutionFunctions();
-
-  /**
-    * Set model parton mass according to fFlagUseJetMass.
-    * @param jetmass The jet mass.
-    * @param quarkmass The quark mass.
-    * @param px The parton px (will be modified, if necessary).
-    * @param py The parton py (will be modified, if necessary).
-    * @param pz The parton pz (will be modified, if necessary).
-    * @param e The parton energy (not modified).
-    * @return The parton mass.
-    */
-  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
-    double mass(0.);
-    if (fFlagUseJetMass) {
-      mass = jetmass > 0. ? jetmass : 0.;
-    } else {
-      mass = quarkmass;
-    }
-    double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
-    double p_newmass = sqrt(e * e - mass * mass);
-    double scale = p_newmass / p_orig;
-    *px *= scale;
-    *py *= scale;
-    *pz *= scale;
-    return mass;
-  }
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -258,7 +258,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
     * Initialize the likelihood for the event

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -121,13 +121,6 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   void DefineParameters() override;
 
   /**
-    * The prior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
-  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
-
-  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -202,12 +202,6 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   int RemoveInvariantParticlePermutations() override;
 
   /**
-    * Remove forbidden particle permutations.
-    * @return An error code.
-    */
-  int RemoveForbiddenParticlePermutations() override;
-
-  /**
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -159,12 +159,6 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     */
   std::vector<double> GetInitialParametersWoNeutrinoPz();
 
-  /**
-    * Check if there are TF problems.
-    * @return Return false if TF problem.
-    */
-  bool NoTFProblem(std::vector<double> parameters) override;
-
   /* @} */
 
  protected:
@@ -262,11 +256,6 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * jets.
     */
   LeptonType fTypeLepton;
-
-  /**
-    * Global variable for TF problems.
-    */
-  bool fTFgood;
 
   /**
     * Save resolution functions since the eta of the partons is not fitted.

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -185,11 +185,6 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
-    * Initialize the likelihood for the event
-    */
-  int Initialize() override;
-
-  /**
     * Adjust parameter ranges
     */
   int AdjustParameterRanges() override;

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -198,7 +198,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
     * Initialize the likelihood for the event

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -172,19 +172,6 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     */
   bool NoTFProblem(std::vector<double> parameters) override;
 
-  /**
-    * Return the set of model particles.
-    * @return A pointer to the particles.
-    */
-  KLFitter::Particles* ParticlesModel() override {
-    BuildModelParticles();
-    return fParticlesModel;
-  }
-  KLFitter::Particles** PParticlesModel() override {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
-
   /* @} */
 
  protected:

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -275,7 +275,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Save permuted particles.
     */
-  int SavePermutedParticles();
+  int SavePermutedParticles() override;
 
   /**
     * Save resolution functions.

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -208,7 +208,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  int AdjustParameterRanges();
+  int AdjustParameterRanges() override;
 
   /**
     * Define the model particles

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -232,7 +232,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */
-  int BuildModelParticles();
+  int BuildModelParticles() override;
 
   /* @} */
 

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -214,7 +214,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * Define the model particles
     * @return An error code.
     */
-  virtual int DefineModelParticles();
+  virtual int DefineModelParticles() override;
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -271,7 +271,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   /**
     * Save resolution functions.
     */
-  int SaveResolutionFunctions();
+  int SaveResolutionFunctions() override;
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -20,7 +20,6 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETS_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETS_H_
 
-#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -93,8 +92,6 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * @param flag The flag.
     */
   void SetFlagTopMassFixed(bool flag) { fFlagTopMassFixed = flag; }
-
-  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   void SetFlagGetParSigmasFromTFs(bool flag) { fFlagGetParSigmasFromTFs = flag; }
 
@@ -243,12 +240,6 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   bool fFlagTopMassFixed;
 
   /**
-    * A flag for using the measured jet masses (true) instead of
-    * parton masses (false);
-    */
-  bool fFlagUseJetMass;
-
-  /**
     *  Flag for using ResolutionBase::GetSigma() to retrieve the parameter ranges
     */
   bool fFlagGetParSigmasFromTFs;
@@ -281,32 +272,6 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     * Save resolution functions.
     */
   int SaveResolutionFunctions();
-
-  /**
-    * Set model parton mass according to fFlagUseJetMass.
-    * @param jetmass The jet mass.
-    * @param quarkmass The quark mass.
-    * @param px The parton px (will be modified, if necessary).
-    * @param py The parton py (will be modified, if necessary).
-    * @param pz The parton pz (will be modified, if necessary).
-    * @param e The parton energy (not modified).
-    * @return The parton mass.
-    */
-  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
-    double mass(0.);
-    if (fFlagUseJetMass) {
-      mass = jetmass > 0. ? jetmass : 0.;
-    } else {
-      mass = quarkmass;
-    }
-    double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
-    double p_newmass = sqrt(e * e - mass * mass);
-    double scale = p_newmass / p_orig;
-    *px *= scale;
-    *py *= scale;
-    *pz *= scale;
-    return mass;
-  }
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -183,11 +183,6 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
-    * Initialize the likelihood for the event
-    */
-  int Initialize() override;
-
-  /**
     * Adjust parameter ranges
     */
   int AdjustParameterRanges() override;

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -157,12 +157,6 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     */
   std::vector<double> GetInitialParametersWoNeutrinoPz();
 
-  /**
-    * Check if there are TF problems.
-    * @return Return false if TF problem.
-    */
-  bool NoTFProblem(std::vector<double> parameters) override;
-
   /* @} */
 
  protected:
@@ -255,11 +249,6 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * jets.
     */
   LeptonType fTypeLepton;
-
-  /**
-    * Global variable for TF problems.
-    */
-  bool fTFgood;
 
   /**
     * Save resolution functions since the eta of the partons is not fitted.

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -212,7 +212,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * Define the model particles
     * @return An error code.
     */
-  int DefineModelParticles();
+  int DefineModelParticles() override;
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -206,7 +206,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  int AdjustParameterRanges();
+  int AdjustParameterRanges() override;
 
   /**
     * Define the model particles

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -268,7 +268,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   /**
     * Save permuted particles.
     */
-  int SavePermutedParticles();
+  int SavePermutedParticles() override;
 
   /**
     * Save resolution functions.

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -20,7 +20,6 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETS_ANGULAR_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETS_ANGULAR_H_
 
-#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -93,8 +92,6 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * @param flag The flag.
     */
   void SetFlagTopMassFixed(bool flag) { fFlagTopMassFixed = flag; }
-
-  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   /**
     * Set the type of lepton
@@ -241,12 +238,6 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   bool fFlagTopMassFixed;
 
   /**
-    * A flag for using the measured jet masses (true) instead of
-    * parton masses (false);
-    */
-  bool fFlagUseJetMass;
-
-  /**
     * Return the neutrino pz solutions from the measured values
     * and the W mass.
     * @return A vector with 0, 1 or 2 neutrino pz solutions.
@@ -274,32 +265,6 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * Save resolution functions.
     */
   int SaveResolutionFunctions();
-
-  /**
-    * Set model parton mass according to fFlagUseJetMass.
-    * @param jetmass The jet mass.
-    * @param quarkmass The quark mass.
-    * @param px The parton px (will be modified, if necessary).
-    * @param py The parton py (will be modified, if necessary).
-    * @param pz The parton pz (will be modified, if necessary).
-    * @param e The parton energy (not modified).
-    * @return The parton mass.
-    */
-  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
-    double mass(0.);
-    if (fFlagUseJetMass) {
-      mass = jetmass > 0. ? jetmass : 0.;
-    } else {
-      mass = quarkmass;
-    }
-    double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
-    double p_newmass = sqrt(e * e - mass * mass);
-    double scale = p_newmass / p_orig;
-    *px *= scale;
-    *py *= scale;
-    *pz *= scale;
-    return mass;
-  }
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -119,13 +119,6 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   void DefineParameters() override;
 
   /**
-    * The prior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
-  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
-
-  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -170,19 +170,6 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     */
   bool NoTFProblem(std::vector<double> parameters) override;
 
-  /**
-    * Return the set of model particles.
-    * @return A pointer to the particles.
-    */
-  KLFitter::Particles* ParticlesModel() override {
-    BuildModelParticles();
-    return fParticlesModel;
-  }
-  KLFitter::Particles** PParticlesModel() override {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
-
   /* @} */
 
  protected:

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -264,7 +264,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   /**
     * Save resolution functions.
     */
-  int SaveResolutionFunctions();
+  int SaveResolutionFunctions() override;
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -196,7 +196,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
     * Initialize the likelihood for the event

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -200,12 +200,6 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   int RemoveInvariantParticlePermutations() override;
 
   /**
-    * Remove forbidden particle permutations.
-    * @return An error code.
-    */
-  int RemoveForbiddenParticlePermutations() override;
-
-  /**
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -230,7 +230,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */
-  int BuildModelParticles();
+  int BuildModelParticles() override;
 
   /* @} */
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -20,7 +20,6 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETS_JETANGLES_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETS_JETANGLES_H_
 
-#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -93,8 +92,6 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * @param flag The flag.
     */
   void SetFlagTopMassFixed(bool flag) { fFlagTopMassFixed = flag; }
-
-  void SetFlagUseJetMass(bool flag) { fFlagUseJetMass = flag; }
 
   void SetFlagGetParSigmasFromTFs(bool flag) { fFlagGetParSigmasFromTFs = flag; }
 
@@ -251,12 +248,6 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   bool fFlagTopMassFixed;
 
   /**
-    * A flag for using the measured jet masses (true) instead of
-    * parton masses (false);
-    */
-  bool fFlagUseJetMass;
-
-  /**
     *  Flag for using ResolutionBase::GetSigma() to retrieve the parameter ranges
     */
   bool fFlagGetParSigmasFromTFs;
@@ -294,32 +285,6 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * Save resolution functions.
     */
   int SaveResolutionFunctions();
-
-  /**
-    * Set model parton mass according to fFlagUseJetMass.
-    * @param jetmass The jet mass.
-    * @param quarkmass The quark mass.
-    * @param px The parton px (will be modified, if necessary).
-    * @param py The parton py (will be modified, if necessary).
-    * @param pz The parton pz (will be modified, if necessary).
-    * @param e The parton energy (not modified).
-    * @return The parton mass.
-    */
-  double SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
-    double mass(0.);
-    if (fFlagUseJetMass) {
-      mass = jetmass > 0. ? jetmass : 0.;
-    } else {
-      mass = quarkmass;
-    }
-    double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
-    double p_newmass = sqrt(e * e - mass * mass);
-    double scale = p_newmass / p_orig;
-    *px *= scale;
-    *py *= scale;
-    *pz *= scale;
-    return mass;
-  }
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -284,7 +284,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   /**
     * Save resolution functions.
     */
-  int SaveResolutionFunctions();
+  int SaveResolutionFunctions() override;
 
   /**
     * The values of the x component of the missing ET.

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -167,12 +167,6 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     */
   std::vector<double> GetInitialParametersWoNeutrinoPz();
 
-  /**
-    * Check if there are TF problems.
-    * @return Return false if TF problem.
-    */
-  bool NoTFProblem(std::vector<double> parameters) override;
-
   /* @} */
 
  protected:
@@ -275,11 +269,6 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * jets.
     */
   LeptonType fTypeLepton;
-
-  /**
-    * Global variable for TF problems.
-    */
-  bool fTFgood;
 
   /**
     * Save resolution functions for all particles where the eta is not fitted.

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -121,13 +121,6 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   void DefineParameters() override;
 
   /**
-    * The prior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
-  double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
-
-  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -222,7 +222,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * Define the model particles
     * @return An error code.
     */
-  int DefineModelParticles();
+  int DefineModelParticles() override;
 
   /**
     * Remove invariant particle permutations.

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -288,7 +288,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   /**
     * Save permuted particles.
     */
-  int SavePermutedParticles();
+  int SavePermutedParticles() override;
 
   /**
     * Save resolution functions.

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -210,12 +210,6 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   int RemoveInvariantParticlePermutations() override;
 
   /**
-    * Remove forbidden particle permutations.
-    * @return An error code.
-    */
-  int RemoveForbiddenParticlePermutations() override;
-
-  /**
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -193,11 +193,6 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
-    * Initialize the likelihood for the event
-    */
-  int Initialize() override;
-
-  /**
     * Adjust parameter ranges
     */
   int AdjustParameterRanges() override;

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -206,7 +206,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * Update 4-vectors of model particles.
     * @return An error flag.
     */
-  int CalculateLorentzVectors(std::vector <double> const& parameters);
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 
   /**
     * Initialize the likelihood for the event

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -240,7 +240,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     * Build the model particles from the best fit parameters.
     * @return An error code.
     */
-  int BuildModelParticles();
+  int BuildModelParticles() override;
 
   /* @} */
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -180,19 +180,6 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
     */
   bool NoTFProblem(std::vector<double> parameters) override;
 
-  /**
-    * Return the set of model particles.
-    * @return A pointer to the particles.
-    */
-  KLFitter::Particles* ParticlesModel() override {
-    BuildModelParticles();
-    return fParticlesModel;
-  }
-  KLFitter::Particles** PParticlesModel() override {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
-
   /* @} */
 
  protected:

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -216,7 +216,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   /**
     * Adjust parameter ranges
     */
-  int AdjustParameterRanges();
+  int AdjustParameterRanges() override;
 
   /**
     * Define the model particles

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -34,7 +34,6 @@
 // ---------------------------------------------------------
 KLFitter::BoostedLikelihoodTopLeptonJets::BoostedLikelihoodTopLeptonJets() : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
-  , fFlagUseJetMass(false)
   , fFlagGetParSigmasFromTFs(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -282,41 +282,6 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::RemoveInvariantParticlePermutation
 }
 
 // ---------------------------------------------------------
-int KLFitter::BoostedLikelihoodTopLeptonJets::RemoveForbiddenParticlePermutations() {
-  // error code
-  int err = 1;
-
-  // only in b-tagging type kVetoNoFit
-  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
-    return err;
-
-  // remove all permutations where a b-tagged jet is in the position of a model light quark
-  KLFitter::Particles * particles = (*fPermutations)->Particles();
-  int nPartons = particles->NPartons();
-
-  KLFitter::Particles * particlesModel = fParticlesModel;
-  int nPartonsModel = particlesModel->NPartons();
-  for (int iParton(0); iParton < nPartons; ++iParton) {
-    bool isBtagged = particles->IsBTagged(iParton);
-
-    for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
-      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
-      if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitBoth)&&(((isBtagged)&&(trueFlavor != KLFitter::Particles::kLight)) || ((!isBtagged)&&(trueFlavor != KLFitter::Particles::kB))))
-        continue;
-
-      err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
-    }
-  }
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::BoostedLikelihoodTopLeptonJets::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet    = fFlagGetParSigmasFromTFs ? 10 : 7;

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -244,28 +244,6 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::CalculateLorentzVectors(std::vecto
 }
 
 // ---------------------------------------------------------
-int KLFitter::BoostedLikelihoodTopLeptonJets::Initialize() {
-  // error code
-  int err = 1;
-
-  // save the current permuted particles
-  err *= SavePermutedParticles();
-
-  // save the corresponding resolution functions
-  err *= SaveResolutionFunctions();
-
-  // adjust parameter ranges
-  err *= AdjustParameterRanges();
-
-  // set initial values
-  // (only for Markov chains - initial parameters for other minimisation methods are set in Fitter.cxx)
-  SetInitialParameters(GetInitialParameters());
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::BoostedLikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
   // error code
   int err = 1;

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -38,8 +38,7 @@ KLFitter::BoostedLikelihoodTopLeptonJets::BoostedLikelihoodTopLeptonJets() : KLF
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)
-  , fTypeLepton(kElectron)
-  , fTFgood(true) {
+  , fTypeLepton(kElectron) {
   // define model particles
   this->DefineModelParticles();
 
@@ -519,13 +518,6 @@ std::vector<double> KLFitter::BoostedLikelihoodTopLeptonJets::CalculateNeutrinoP
   }
 
   return pz;
-}
-
-// ---------------------------------------------------------
-bool KLFitter::BoostedLikelihoodTopLeptonJets::NoTFProblem(std::vector<double> parameters) {
-  fTFgood = true;
-  this->LogLikelihood(parameters);
-  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -186,6 +186,28 @@ double KLFitter::LikelihoodBase::ParMax(int index) {
 }
 
 // ---------------------------------------------------------
+int KLFitter::LikelihoodBase::Initialize() {
+  // error code
+  int err = 1;
+
+  // save the current permuted particles
+  err *= SavePermutedParticles();
+
+  // save the corresponding resolution functions
+  err *= SaveResolutionFunctions();
+
+  // adjust parameter ranges
+  err *= AdjustParameterRanges();
+
+  // set initial values
+  // (only for Markov chains - initial parameters for other minimisation methods are set in Fitter.cxx)
+  SetInitialParameters(GetInitialParameters());
+
+  // return error code
+  return err;
+}
+
+// ---------------------------------------------------------
 double KLFitter::LikelihoodBase::LogEventProbability() {
   double logprob = 0;
 

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -19,6 +19,7 @@
 
 #include "KLFitter/LikelihoodBase.h"
 
+#include <cmath>
 #include <iostream>
 #include <string>
 
@@ -40,6 +41,7 @@ KLFitter::LikelihoodBase::LikelihoodBase(Particles** particles) : BCModel(),
                                                                   fEventProbability(std::vector<double>(0)),
                                                                   fFlagIntegrate(0),
                                                                   fFlagIsNan(false),
+                                                                  fFlagUseJetMass(false),
                                                                   fBTagMethod(kNotag) {
   BCLog::SetLogLevel(BCLog::nothing);
   MCMCSetRandomSeed(123456789);
@@ -421,6 +423,23 @@ int KLFitter::LikelihoodBase::ResetCache() {
   fCachedNormalization = 0.;
 
   return 1;
+}
+
+// ---------------------------------------------------------.
+double KLFitter::LikelihoodBase::SetPartonMass(double jetmass, double quarkmass, double *px, double *py, double *pz, double e) {
+  double mass(0.);
+  if (fFlagUseJetMass) {
+    mass = jetmass > 0. ? jetmass : 0.;
+  } else {
+    mass = quarkmass;
+  }
+  double p_orig = sqrt(*px * *px + *py * *py + *pz * *pz);
+  double p_newmass = sqrt(e * e - mass * mass);
+  double scale = p_newmass / p_orig;
+  *px *= scale;
+  *py *= scale;
+  *pz *= scale;
+  return mass;
 }
 
 // ---------------------------------------------------------.

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -368,6 +368,41 @@ std::vector <double> KLFitter::LikelihoodBase::GetBestFitParameterErrors() {
 }
 
 // ---------------------------------------------------------
+int KLFitter::LikelihoodBase::RemoveForbiddenParticlePermutations() {
+  // error code
+  int err = 1;
+
+  // only in b-tagging type kVetoNoFit
+  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
+    return err;
+
+  // remove all permutations where a b-tagged jet is in the position of a model light quark
+  KLFitter::Particles * particles = (*fPermutations)->Particles();
+  int nPartons = particles->NPartons();
+
+  KLFitter::Particles * particlesModel = fParticlesModel;
+  int nPartonsModel = particlesModel->NPartons();
+  for (int iParton(0); iParton < nPartons; ++iParton) {
+    bool isBtagged = particles->IsBTagged(iParton);
+
+    for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
+      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
+      if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
+        continue;
+      if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
+        continue;
+      if ((fBTagMethod == kVetoNoFitBoth)&&(((isBtagged)&&(trueFlavor != KLFitter::Particles::kLight)) || ((!isBtagged)&&(trueFlavor != KLFitter::Particles::kB))))
+        continue;
+
+      err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
+    }
+  }
+
+  // return error code
+  return err;
+}
+
+// ---------------------------------------------------------
 int KLFitter::LikelihoodBase::SetParametersToCache(int iperm, int nperms) {
   // set correct size of cachevector
   if (iperm == 0) {

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -42,6 +42,7 @@ KLFitter::LikelihoodBase::LikelihoodBase(Particles** particles) : BCModel(),
                                                                   fFlagIntegrate(0),
                                                                   fFlagIsNan(false),
                                                                   fFlagUseJetMass(false),
+                                                                  fTFgood(true),
                                                                   fBTagMethod(kNotag) {
   BCLog::SetLogLevel(BCLog::nothing);
   MCMCSetRandomSeed(123456789);
@@ -327,6 +328,13 @@ double KLFitter::LikelihoodBase::LogEventProbabilityBTag() {
   }
 
   return logprob;
+}
+
+// ---------------------------------------------------------
+bool KLFitter::LikelihoodBase::NoTFProblem(std::vector<double> parameters) {
+  fTFgood = true;
+  this->LogLikelihood(parameters);
+  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -154,7 +154,7 @@ void KLFitter::LikelihoodSgTopWtLJ::DefineParameters() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodSgTopWtLJ::CalculateLorentzVectors(std::vector <double> parameters) {
+int KLFitter::LikelihoodSgTopWtLJ::CalculateLorentzVectors(const std::vector <double>& parameters) {
   // variables
   static double scale;
 

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -37,8 +37,7 @@ KLFitter::LikelihoodSgTopWtLJ::LikelihoodSgTopWtLJ(): KLFitter::LikelihoodBase::
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)
-  , fTypeLepton(kElectron)
-  , fTFgood(true) {
+  , fTypeLepton(kElectron) {
   // define model particles
   this->DefineModelParticles();
 
@@ -499,13 +498,6 @@ std::vector<double> KLFitter::LikelihoodSgTopWtLJ::GetNeutrinoPzSolutions() {
   }
 
   return pz;
-}
-
-// ---------------------------------------------------------
-bool KLFitter::LikelihoodSgTopWtLJ::NoTFProblem(std::vector<double> parameters) {
-  fTFgood = true;
-  this->LogLikelihood(parameters);
-  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -34,7 +34,6 @@
 // ---------------------------------------------------------
 KLFitter::LikelihoodSgTopWtLJ::LikelihoodSgTopWtLJ(): KLFitter::LikelihoodBase::LikelihoodBase()
   , fHadronicTop(true)
-  , fFlagUseJetMass(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -38,8 +38,7 @@ KLFitter::LikelihoodTTHLeptonJets::LikelihoodTTHLeptonJets() : KLFitter::Likelih
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)
-  , fTypeLepton(kElectron)
-  , fTFgood(true) {
+  , fTypeLepton(kElectron) {
   // define model particles
   this->DefineModelParticles();
 
@@ -648,13 +647,6 @@ std::vector<double> KLFitter::LikelihoodTTHLeptonJets::CalculateNeutrinoPzSoluti
   }
 
   return pz;
-}
-
-// ---------------------------------------------------------
-bool KLFitter::LikelihoodTTHLeptonJets::NoTFProblem(std::vector<double> parameters) {
-  fTFgood = true;
-  this->LogLikelihood(parameters);
-  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -316,28 +316,6 @@ int KLFitter::LikelihoodTTHLeptonJets::CalculateLorentzVectors(std::vector <doub
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTTHLeptonJets::Initialize() {
-  // error code
-  int err = 1;
-
-  // save the current permuted particles
-  err *= SavePermutedParticles();
-
-  // save the corresponding resolution functions
-  err *= SaveResolutionFunctions();
-
-  // adjust parameter ranges
-  err *= AdjustParameterRanges();
-
-  // set initial values
-  // (only for Markov chains - initial parameters for other minimisation methods are set in Fitter.cxx)
-  SetInitialParameters(GetInitialParameters());
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTTHLeptonJets::RemoveInvariantParticlePermutations() {
   // error code
   int err = 1;

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -364,41 +364,6 @@ int KLFitter::LikelihoodTTHLeptonJets::RemoveInvariantParticlePermutations() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTTHLeptonJets::RemoveForbiddenParticlePermutations() {
-  // error code
-  int err = 1;
-
-  // only in b-tagging type kVetoNoFit
-  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
-    return err;
-
-  // remove all permutations where a b-tagged jet is in the position of a model light quark
-  KLFitter::Particles * particles = (*fPermutations)->Particles();
-  int nPartons = particles->NPartons();
-
-  KLFitter::Particles * particlesModel = fParticlesModel;
-  int nPartonsModel = particlesModel->NPartons();
-  for (int iParton(0); iParton < nPartons; ++iParton) {
-    bool isBtagged = particles->IsBTagged(iParton);
-
-    for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
-      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
-      if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitBoth)&&(((isBtagged)&&(trueFlavor != KLFitter::Particles::kLight)) || ((!isBtagged)&&(trueFlavor != KLFitter::Particles::kB))))
-        continue;
-
-      err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
-    }
-  }
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTTHLeptonJets::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet = 7.0;

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -35,7 +35,6 @@
 KLFitter::LikelihoodTTHLeptonJets::LikelihoodTTHLeptonJets() : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , fFlagHiggsMassFixed(false)
-  , fFlagUseJetMass(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -44,7 +44,7 @@ KLFitter::LikelihoodTTHLeptonJets::LikelihoodTTHLeptonJets() : KLFitter::Likelih
   this->DefineModelParticles();
 
   // define parameters
-  // this->DefineParameters();
+  this->DefineParameters();
 }
 
 // ---------------------------------------------------------
@@ -325,8 +325,6 @@ int KLFitter::LikelihoodTTHLeptonJets::Initialize() {
 
   // save the corresponding resolution functions
   err *= SaveResolutionFunctions();
-
-  this->DefineParameters();
 
   // adjust parameter ranges
   err *= AdjustParameterRanges();

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -39,7 +39,6 @@ KLFitter::LikelihoodTTZTrilepton::LikelihoodTTZTrilepton() : KLFitter::Likelihoo
   , ETmiss_y(0.)
   , SumET(0.)
   , fTypeLepton(kElectron)
-  , fTFgood(true)
   , fInvMassCutoff(5.)
   , fOnShellFraction(0.869) {
   // define model particles
@@ -734,13 +733,6 @@ std::vector<double> KLFitter::LikelihoodTTZTrilepton::CalculateNeutrinoPzSolutio
   }
 
   return pz;
-}
-
-// ---------------------------------------------------------
-bool KLFitter::LikelihoodTTZTrilepton::NoTFProblem(std::vector<double> parameters) {
-  fTFgood = true;
-  this->LogLikelihood(parameters);
-  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -343,28 +343,6 @@ int KLFitter::LikelihoodTTZTrilepton::CalculateLorentzVectors(std::vector <doubl
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTTZTrilepton::Initialize() {
-  // error code
-  int err = 1;
-
-  // save the current permuted particles
-  err *= SavePermutedParticles();
-
-  // save the corresponding resolution functions
-  err *= SaveResolutionFunctions();
-
-  // adjust parameter ranges
-  err *= AdjustParameterRanges();
-
-  // set initial values
-  // (only for Markov chains - initial parameters for other minimisation methods are set in Fitter.cxx)
-  SetInitialParameters(GetInitialParameters());
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTTZTrilepton::RemoveInvariantParticlePermutations() {
   // error code
   int err = 1;

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -34,7 +34,6 @@
 // ---------------------------------------------------------
 KLFitter::LikelihoodTTZTrilepton::LikelihoodTTZTrilepton() : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
-  , fFlagUseJetMass(false)
   , fFlagGetParSigmasFromTFs(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -397,41 +397,6 @@ int KLFitter::LikelihoodTTZTrilepton::RemoveInvariantParticlePermutations() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTTZTrilepton::RemoveForbiddenParticlePermutations() {
-  // error code
-  int err = 1;
-
-  // only in b-tagging type kVetoNoFit
-  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
-    return err;
-
-  // remove all permutations where a b-tagged jet is in the position of a model light quark
-  KLFitter::Particles * particles = (*fPermutations)->Particles();
-  int nPartons = particles->NPartons();
-
-  KLFitter::Particles * particlesModel = fParticlesModel;
-  int nPartonsModel = particlesModel->NPartons();
-  for (int iParton(0); iParton < nPartons; ++iParton) {
-    bool isBtagged = particles->IsBTagged(iParton);
-
-    for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
-      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
-      if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitBoth)&&(((isBtagged)&&(trueFlavor != KLFitter::Particles::kLight)) || ((!isBtagged)&&(trueFlavor != KLFitter::Particles::kB))))
-        continue;
-
-      err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
-    }
-  }
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTTZTrilepton::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet    = fFlagGetParSigmasFromTFs ? 10 : 7;

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -268,41 +268,6 @@ int KLFitter::LikelihoodTopAllHadronic::RemoveInvariantParticlePermutations() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopAllHadronic::RemoveForbiddenParticlePermutations() {
-  // error code
-  int err = 1;
-
-  // only in kVetoNoFitAndSoOn mode...
-  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
-    return err;
-
-  // remove all permutations where a b-tagged jet/non-tagged jet is on a wrong position
-  KLFitter::Particles * particles = (*fPermutations)->Particles();
-  int nPartons = particles->NPartons();
-
-  KLFitter::Particles * particlesModel = fParticlesModel;
-  int nPartonsModel = particlesModel->NPartons();
-  for (int iParton(0); iParton < nPartons; ++iParton) {
-    bool isBtagged = particles->IsBTagged(iParton);
-
-    for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
-      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
-      if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitBoth)&&(((isBtagged)&&(trueFlavor != KLFitter::Particles::kLight)) || ((!isBtagged)&&(trueFlavor != KLFitter::Particles::kB))))
-        continue;
-
-      err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
-    }
-  }
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTopAllHadronic::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet = fFlagGetParSigmasFromTFs ? 10 : 7;

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -35,7 +35,6 @@
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopAllHadronic::LikelihoodTopAllHadronic() : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
-  , fFlagUseJetMass(false)
   , fFlagGetParSigmasFromTFs(false)
   , fTFgood(true) {
   // define model particles

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -228,28 +228,6 @@ int KLFitter::LikelihoodTopAllHadronic::CalculateLorentzVectors(std::vector <dou
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopAllHadronic::Initialize() {
-  // error code
-  int err = 1;
-
-  // save the current permuted particles
-  err *= SavePermutedParticles();
-
-  // save the corresponding resolution functions
-  err *= SaveResolutionFunctions();
-
-  // adjust parameter ranges
-  err *= AdjustParameterRanges();
-
-  // set initial values
-  // (only for Markov chains - initial parameters for other minimisation methods are set in Fitter.cxx)
-  SetInitialParameters(GetInitialParameters());
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTopAllHadronic::RemoveInvariantParticlePermutations() {
   // error code
   int err = 1;

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -35,8 +35,7 @@
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopAllHadronic::LikelihoodTopAllHadronic() : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
-  , fFlagGetParSigmasFromTFs(false)
-  , fTFgood(true) {
+  , fFlagGetParSigmasFromTFs(false) {
   // define model particles
   DefineModelParticles();
 
@@ -411,13 +410,6 @@ std::vector<double> KLFitter::LikelihoodTopAllHadronic::GetInitialParameters() {
 
   // return the vector
   return values;
-}
-
-// ---------------------------------------------------------
-bool KLFitter::LikelihoodTopAllHadronic::NoTFProblem(std::vector<double> parameters) {
-  fTFgood = true;
-  this->LogLikelihood(parameters);
-  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -326,42 +326,6 @@ int KLFitter::LikelihoodTopDilepton::RemoveInvariantParticlePermutations() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopDilepton::RemoveForbiddenParticlePermutations() {
-  // error code
-  int err = 1;
-
-  // only in b-tagging type kVetoNoFit
-  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
-    return err;
-
-  // remove all permutations where a b-tagged jet is in the position of a model light quark
-  KLFitter::Particles * particles = (*fPermutations)->Particles();
-  int nPartons = particles->NPartons();
-
-  KLFitter::Particles * particlesModel = fParticlesModel;
-  int nPartonsModel = particlesModel->NPartons();
-
-  for (int iParton(0); iParton < nPartons; ++iParton) {
-    bool isBtagged = particles->IsBTagged(iParton);
-
-    for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
-      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
-      if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitBoth)&&(((isBtagged)&&(trueFlavor != KLFitter::Particles::kLight)) || ((!isBtagged)&&(trueFlavor != KLFitter::Particles::kB))))
-        continue;
-
-      err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
-    }
-  }
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTopDilepton::AdjustParameterRanges() {
   // adjust limits
   if (fFlagTopMassFixed)

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -47,7 +47,6 @@ public:
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopDilepton::LikelihoodTopDilepton() : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
-  , fFlagUseJetMass(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -54,7 +54,6 @@ KLFitter::LikelihoodTopDilepton::LikelihoodTopDilepton() : KLFitter::LikelihoodB
   , fTypeLepton_2(kElectron)
   , nueta_params(0.)
   , doSumloglik(false)
-  , fTFgood(true)
   , hist_mttbar(new TH1D())
   , hist_costheta(new TH1D())
   , fHistMttbar(new BCH1D())
@@ -835,13 +834,6 @@ std::vector<double> KLFitter::LikelihoodTopDilepton::GetInitialParameters() {
   values[parNuEta] = 0.;
 
   return values;
-}
-
-// ---------------------------------------------------------
-bool KLFitter::LikelihoodTopDilepton::NoTFProblem(std::vector<double> parameters) {
-  fTFgood = true;
-  this->LogLikelihood(parameters);
-  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -34,7 +34,6 @@
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets() : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
-  , fFlagUseJetMass(false)
   , fFlagGetParSigmasFromTFs(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -272,28 +272,6 @@ int KLFitter::LikelihoodTopLeptonJets::CalculateLorentzVectors(std::vector <doub
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::Initialize() {
-  // error code
-  int err = 1;
-
-  // save the current permuted particles
-  err *= SavePermutedParticles();
-
-  // save the corresponding resolution functions
-  err *= SaveResolutionFunctions();
-
-  // adjust parameter ranges
-  err *= AdjustParameterRanges();
-
-  // set initial values
-  // (only for Markov chains - initial parameters for other minimisation methods are set in Fitter.cxx)
-  SetInitialParameters(GetInitialParameters());
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
   // error code
   int err = 1;

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -313,41 +313,6 @@ int KLFitter::LikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::RemoveForbiddenParticlePermutations() {
-  // error code
-  int err = 1;
-
-  // only in b-tagging type kVetoNoFit
-  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
-    return err;
-
-  // remove all permutations where a b-tagged jet is in the position of a model light quark
-  KLFitter::Particles * particles = (*fPermutations)->Particles();
-  int nPartons = particles->NPartons();
-
-  KLFitter::Particles * particlesModel = fParticlesModel;
-  int nPartonsModel = particlesModel->NPartons();
-  for (int iParton(0); iParton < nPartons; ++iParton) {
-    bool isBtagged = particles->IsBTagged(iParton);
-
-    for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
-      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
-      if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitBoth)&&(((isBtagged)&&(trueFlavor != KLFitter::Particles::kLight)) || ((!isBtagged)&&(trueFlavor != KLFitter::Particles::kB))))
-        continue;
-
-      err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
-    }
-  }
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet    = fFlagGetParSigmasFromTFs ? 10 : 7;

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -38,8 +38,7 @@ KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets() : KLFitter::Likelih
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)
-  , fTypeLepton(kElectron)
-  , fTFgood(true) {
+  , fTypeLepton(kElectron) {
   // define model particles
   this->DefineModelParticles();
 
@@ -567,13 +566,6 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets::CalculateNeutrinoPzSoluti
   }
 
   return pz;
-}
-
-// ---------------------------------------------------------
-bool KLFitter::LikelihoodTopLeptonJets::NoTFProblem(std::vector<double> parameters) {
-  fTFgood = true;
-  this->LogLikelihood(parameters);
-  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -34,7 +34,6 @@
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopLeptonJets_Angular::LikelihoodTopLeptonJets_Angular() : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
-  , fFlagUseJetMass(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -304,41 +304,6 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::RemoveInvariantParticlePermutatio
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets_Angular::RemoveForbiddenParticlePermutations() {
-  // error code
-  int err = 1;
-
-  // only in b-tagging type kVetoNoFit
-  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
-    return err;
-
-  // remove all permutations where a b-tagged jet is in the position of a model light quark
-  KLFitter::Particles * particles = (*fPermutations)->Particles();
-  int nPartons = particles->NPartons();
-
-  KLFitter::Particles * particlesModel = fParticlesModel;
-  int nPartonsModel = particlesModel->NPartons();
-  for (int iParton(0); iParton < nPartons; ++iParton) {
-    bool isBtagged = particles->IsBTagged(iParton);
-
-    for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
-      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
-      if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitBoth)&&(((isBtagged)&&(trueFlavor != KLFitter::Particles::kLight)) || ((!isBtagged)&&(trueFlavor != KLFitter::Particles::kB))))
-        continue;
-
-      err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
-    }
-  }
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet = 7.0;

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -37,8 +37,7 @@ KLFitter::LikelihoodTopLeptonJets_Angular::LikelihoodTopLeptonJets_Angular() : K
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)
-  , fTypeLepton(kElectron)
-  , fTFgood(true) {
+  , fTypeLepton(kElectron) {
   // define model particles
   this->DefineModelParticles();
 
@@ -608,13 +607,6 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets_Angular::CalculateNeutrino
   }
 
   return pz;
-}
-
-// ---------------------------------------------------------
-bool KLFitter::LikelihoodTopLeptonJets_Angular::NoTFProblem(std::vector<double> parameters) {
-  fTFgood = true;
-  this->LogLikelihood(parameters);
-  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -263,28 +263,6 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::CalculateLorentzVectors(std::vect
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets_Angular::Initialize() {
-  // error code
-  int err = 1;
-
-  // save the current permuted particles
-  err *= SavePermutedParticles();
-
-  // save the corresponding resolution functions
-  err *= SaveResolutionFunctions();
-
-  // adjust parameter ranges
-  err *= AdjustParameterRanges();
-
-  // set initial values
-  // (only for Markov chains - initial parameters for other minimisation methods are set in Fitter.cxx)
-  SetInitialParameters(GetInitialParameters());
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets_Angular::RemoveInvariantParticlePermutations() {
   // error code
   int err = 1;

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -39,8 +39,7 @@ KLFitter::LikelihoodTopLeptonJets_JetAngles::LikelihoodTopLeptonJets_JetAngles()
   , ETmiss_x(0.)
   , ETmiss_y(0.)
   , SumET(0.)
-  , fTypeLepton(kElectron)
-  , fTFgood(true) {
+  , fTypeLepton(kElectron) {
   // define model particles
   this->DefineModelParticles();
 
@@ -654,13 +653,6 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets_JetAngles::CalculateNeutri
   }
 
   return pz;
-}
-
-// ---------------------------------------------------------
-bool KLFitter::LikelihoodTopLeptonJets_JetAngles::NoTFProblem(std::vector<double> parameters) {
-  fTFgood = true;
-  this->LogLikelihood(parameters);
-  return fTFgood;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -324,41 +324,6 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::RemoveInvariantParticlePermutat
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets_JetAngles::RemoveForbiddenParticlePermutations() {
-  // error code
-  int err = 1;
-
-  // only in b-tagging type kVetoNoFit
-  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
-    return err;
-
-  // remove all permutations where a b-tagged jet is in the position of a model light quark
-  KLFitter::Particles * particles = (*fPermutations)->Particles();
-  int nPartons = particles->NPartons();
-
-  KLFitter::Particles * particlesModel = fParticlesModel;
-  int nPartonsModel = particlesModel->NPartons();
-  for (int iParton(0); iParton < nPartons; ++iParton) {
-    bool isBtagged = particles->IsBTagged(iParton);
-
-    for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
-      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
-      if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
-        continue;
-      if ((fBTagMethod == kVetoNoFitBoth)&&(((isBtagged)&&(trueFlavor != KLFitter::Particles::kLight)) || ((!isBtagged)&&(trueFlavor != KLFitter::Particles::kB))))
-        continue;
-
-      err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
-    }
-  }
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet    = fFlagGetParSigmasFromTFs ? 10 : 7;

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -35,7 +35,6 @@
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopLeptonJets_JetAngles::LikelihoodTopLeptonJets_JetAngles() : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
-  , fFlagUseJetMass(false)
   , fFlagGetParSigmasFromTFs(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -283,28 +283,6 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::CalculateLorentzVectors(std::ve
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets_JetAngles::Initialize() {
-  // error code
-  int err = 1;
-
-  // save the current permuted particles
-  err *= SavePermutedParticles();
-
-  // save the corresponding resolution functions
-  err *= SaveResolutionFunctions();
-
-  // adjust parameter ranges
-  err *= AdjustParameterRanges();
-
-  // set initial values
-  // (only for Markov chains - initial parameters for other minimisation methods are set in Fitter.cxx)
-  SetInitialParameters(GetInitialParameters());
-
-  // return error code
-  return err;
-}
-
-// ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets_JetAngles::RemoveInvariantParticlePermutations() {
   // error code
   int err = 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was a great deal of overlap between the individual likelihood class implementations, and lots of methods were implemented identically, without using the concept of inheritance. This PR addresses those issues and cleans up the methods in the likelihood classes thoroughly:
1. The following methods were implemented and used in every likelihood class (with varying implementations). They were therefore implemented as purely virtual methods in LikelihoodBase, and their counterparts in the derived classes were marked with `override`:

```c++
virtual int AdjustParameterRanges() = 0;
virtual int BuildModelParticles() = 0;
virtual int CalculateLorentzVectors(std::vector <double> const& parameters) = 0;
virtual int DefineModelParticles() = 0;
virtual int SavePermutedParticles() = 0;
virtual int SaveResolutionFunctions() = 0;
```

2. Fix for a parameter mismatch in `LikelihoodSgTopWtLJ::CalculateLorentzVectors()` with respect to all other likelihoods.
3. The flag `fFlagUseJetMass` was present in all likelihoods and was initialised to `false` in all of them by default. It was now implemented in LikelihoodBase instead. This also allowed to declare and implement `LikelihoodBase::SetPartonMass()`, a function that all likelihoods had in common as well. As this function was implemented in the _headers_ of the derived likelihoods, those headers now also lost their dependencies on the cmath std library.
4. A lot of functions in LikelihoodBase were not purely virtual, but had dummy implementations, although all of them are reimplemented in all derived classes. To ensure that this reimplementation actually happens, the dummy implementation in the base class was removed and those functions were declared purely virtual instead. This affects:

```c++
virtual KLFitter::Particles* ParticlesModel() = 0;
virtual KLFitter::Particles** PParticlesModel() = 0;
virtual int Initialize() = 0;
virtual void DefineParameters() = 0;
virtual double LogAPrioriProbability(const std::vector <double> & parameters) = 0;
virtual double LogLikelihood(const std::vector <double> & parameters) = 0;
virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) = 0;
virtual int RemoveInvariantParticlePermutations() = 0;
virtual RemoveForbiddenParticlePermutations() = 0;
virtual std::vector<double> GetInitialParameters() = 0;
virtual bool NoTFProblem(std::vector<double> parameters) = 0;
```

5. A few of the functions addressed in (1) and (4) had implementations in _all_ likelihoods, but those implementations were identical. To avoid duplication, the purely virtual definition in the base class was removed and the function was properly implemented on base class level instead. This allowed to remove the reimplementation in all derived classes entirely. This affects:
```c++
KLFitter::Particles* ParticlesModel();
KLFitter::Particles** PParticlesModel();
int Initialize();  // only reimplemented in single-top likelihood
RemoveForbiddenParticlePermutations();
double LogAPrioriProbability(const std::vector <double> & parameters);
bool NoTFProblem(std::vector<double> parameters);
```
as well as the member variable `bool fTFgood`. In particular, the centralised implementation of the function to remove particle permutations could be helpful for #11 as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
By moving some of the declarations and implementations into the class LikelihoodBase, lots of code redundancy and duplication can be avoided. This PR alone reduces the code size by ~1000 lines.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled and tested with example binaries as usual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
