### PR TITLE
Removing raw pointers from likelihood classes

### DIFF
--- a/doc/WhatIsKLF.md
+++ b/doc/WhatIsKLF.md
@@ -206,11 +206,11 @@ range is set to 3 times this LHC uncertainty:
 
 ```c++
 if (fFlagTopMassFixed) {
-  SetPriorGauss(0, fPhysicsConstants->MassTop(), fPhysicsConstants->MassTopUnc());
+  SetPriorGauss(0, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTopUnc());
 }
 
 if (fFlagTopMassFixed) {
-  SetParameterRange(parTopM, fPhysicsConstants->MassTop() - 3 * fPhysicsConstants->MassTopUnc(), fPhysicsConstants->MassTop() + 3 * fPhysicsConstants->MassTopUnc());
+  SetParameterRange(parTopM, fPhysicsConstants.MassTop() - 3 * fPhysicsConstants.MassTopUnc(), fPhysicsConstants.MassTop() + 3 * fPhysicsConstants.MassTopUnc());
 }
 ```
 

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -26,6 +26,7 @@
 #include "BAT/BCLog.h"
 #include "BAT/BCModel.h"
 #include "KLFitter/Particles.h"
+#include "KLFitter/PhysicsConstants.h"
 
 // ---------------------------------------------------------
 
@@ -34,7 +35,6 @@
  * \brief The KLFitter namespace
  */
 namespace KLFitter {
-class PhysicsConstants;
 class Permutations;
 class DetectorBase;
 
@@ -80,7 +80,7 @@ class LikelihoodBase : public BCModel {
     * Return the table of physics constants.
     * @return A pointer to the physics constants.
     */
-  KLFitter::PhysicsConstants* PhysicsConstants() { return fPhysicsConstants; }
+  KLFitter::PhysicsConstants* PhysicsConstants() { return &fPhysicsConstants; }
 
   /**
     * Return the detector.
@@ -498,7 +498,7 @@ class LikelihoodBase : public BCModel {
   /**
     * A pointer to the table of physics constants
     */
-  KLFitter::PhysicsConstants* fPhysicsConstants;
+  KLFitter::PhysicsConstants fPhysicsConstants;
 
   /**
     * A pointer to the detector

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -102,10 +102,6 @@ class LikelihoodBase : public BCModel {
     BuildModelParticles();
     return fParticlesModel;
   }
-  KLFitter::Particles** PParticlesModel() {
-    BuildModelParticles();
-    return &fParticlesModel;
-  }
 
   /**
     * Return the number of model particles.

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -317,13 +317,6 @@ class LikelihoodBase : public BCModel {
   virtual std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) = 0;
 
   /**
-    * Return BCH1D histograms calculated inside
-    * LikelihoodTopDilepton::MCMCIterationsInterface per event
-    */
-  virtual BCH1D * GetHistMttbar() { BCH1D * h(0); return h; }
-  virtual BCH1D * GetHistCosTheta() { BCH1D * h(0); return h; }
-
-  /**
     * Return the log of the event probability fof the current
     * combination
     * @return The event probability

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -100,7 +100,7 @@ class LikelihoodBase : public BCModel {
     */
   KLFitter::Particles* ParticlesModel() {
     BuildModelParticles();
-    return fParticlesModel;
+    return fParticlesModel.get();
   }
 
   /**
@@ -484,7 +484,7 @@ class LikelihoodBase : public BCModel {
   /**
     * A pointer to the model particles.
     */
-  KLFitter::Particles* fParticlesModel;
+  std::unique_ptr<KLFitter::Particles> fParticlesModel;
 
   /**
     * A pointer to the measured particles.

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -268,13 +268,13 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * Get BAT BCH1D histograms of Mttbar
     * @return BCH1D histograms
     */
-  BCH1D * GetHistMttbar() override { return fHistMttbar; }
+  BCH1D * GetHistMttbar() { return fHistMttbar; }
 
   /**
     * Get BAT BCH1D histograms of CosTheta
     * @return BCH1D histograms
     */
-  BCH1D * GetHistCosTheta() override { return fHistCosTheta;  }
+  BCH1D * GetHistCosTheta() { return fHistCosTheta; }
 
   /**
     * calculate cos(theta*) for both top and antitop

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -23,6 +23,7 @@
 #include <assert.h>
 
 #include <iostream>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -268,13 +269,13 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * Get BAT BCH1D histograms of Mttbar
     * @return BCH1D histograms
     */
-  BCH1D * GetHistMttbar() { return fHistMttbar; }
+  BCH1D * GetHistMttbar() { return fHistMttbar.get(); }
 
   /**
     * Get BAT BCH1D histograms of CosTheta
     * @return BCH1D histograms
     */
-  BCH1D * GetHistCosTheta() { return fHistCosTheta; }
+  BCH1D * GetHistCosTheta() { return fHistCosTheta.get(); }
 
   /**
     * calculate cos(theta*) for both top and antitop
@@ -348,12 +349,12 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   /**
     * BAT BCH1D Histogram for mttbar
     */
-  BCH1D * fHistMttbar;
+  std::unique_ptr<BCH1D> fHistMttbar;
 
   /**
     * BAT BCH1D Histogram cos(theta*)
     */
-  BCH1D * fHistCosTheta;
+  std::unique_ptr<BCH1D> fHistCosTheta;
 
   /**
     * BAT BCH1D Histogram for dR(truth top, fit top)

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -90,14 +90,8 @@ void KLFitter::BoostedLikelihoodTopLeptonJets::SetLeptonType(int leptontype) {
 
 // ---------------------------------------------------------
 int KLFitter::BoostedLikelihoodTopLeptonJets::DefineModelParticles() {
-  // check if model particles and lorentz vector container exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // add model particles
   // create dummy TLorentzVector

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -101,54 +101,51 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::DefineModelParticles() {
 
   // add model particles
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);  // 4-vector
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,  // type
                                "hadronic b quark",            // name
                                0,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic b quark",
                                1,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quarks",
                                2,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // merged light jet (truth)
 
   if (fTypeLepton == kElectron) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron");
   } else if (fTypeLepton == kMuon) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon");
   }
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kNeutrino,
                                "neutrino");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "leptonic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic top");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic top");
-
-  // free memory
-  delete dummy;
 
   // no error
   return 1;

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -157,9 +157,9 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::DefineModelParticles() {
 // ---------------------------------------------------------
 void KLFitter::BoostedLikelihoodTopLeptonJets::DefineParameters() {
   // add parameters of model
-  AddParameter("energy hadronic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBhadE
-  AddParameter("energy leptonic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBlepE
-  AddParameter("energy light quarks",     fPhysicsConstants->MassW(), 1000.0);       // parLQE
+  AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
+  AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
+  AddParameter("energy light quarks",     fPhysicsConstants.MassW(), 1000.0);       // parLQE
   AddParameter("energy lepton",           0.0, 1000.0);                              // parLepE
   AddParameter("p_x neutrino",        -1000.0, 1000.0);                              // parNuPx
   AddParameter("p_y neutrino",        -1000.0, 1000.0);                              // parNuPy
@@ -288,7 +288,7 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::AdjustParameterRanges() {
   double nsigmas_met    = fFlagGetParSigmasFromTFs ? 10 : 1;
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
-  double m = fPhysicsConstants->MassBottom();
+  double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double sigma = fFlagGetParSigmasFromTFs ? fResEnergyBhad->GetSigma(E) : sqrt(E);
@@ -297,7 +297,7 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::AdjustParameterRanges() {
   SetParameterRange(parBhadE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyBlep->GetSigma(E) : sqrt(E);
@@ -306,7 +306,7 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::AdjustParameterRanges() {
   SetParameterRange(parBlepE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(2)->E();
-  m = fPhysicsConstants->MassW();
+  m = fPhysicsConstants.MassW();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(2)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyLQ->GetSigma(E) : sqrt(E);
@@ -336,7 +336,7 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::AdjustParameterRanges() {
   SetParameterRange(parNuPy, ETmiss_y-sigrange, ETmiss_y+sigrange);
 
   if (fFlagTopMassFixed)
-    SetParameterRange(parTopM, fPhysicsConstants->MassTop(), fPhysicsConstants->MassTop());
+    SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
   // no error
   return 1;
@@ -379,12 +379,12 @@ double KLFitter::BoostedLikelihoodTopLeptonJets::LogLikelihood(const std::vector
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of leptonically decaying W-boson
   logprob += BCMath::LogBreitWignerRel(wlep_fit_m, massW, gammaW);
@@ -527,7 +527,7 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::SavePermutedParticles() {
   bhad_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   bhad_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   bhad_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants->MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
+  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
   bhad_meas_p      = sqrt(bhad_meas_e*bhad_meas_e - bhad_meas_m*bhad_meas_m);
 
   blep_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
@@ -535,7 +535,7 @@ int KLFitter::BoostedLikelihoodTopLeptonJets::SavePermutedParticles() {
   blep_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
   blep_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
   blep_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
-  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants->MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
+  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
   blep_meas_p      = sqrt(blep_meas_e*blep_meas_e - blep_meas_m*blep_meas_m);
 
   lq_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
@@ -649,12 +649,12 @@ std::vector<double> KLFitter::BoostedLikelihoodTopLeptonJets::LogLikelihoodCompo
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of leptonically decaying W-boson
   vecci.push_back(BCMath::LogBreitWignerRel(wlep_fit_m, massW, gammaW));  // comp6

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -36,7 +36,6 @@ KLFitter::LikelihoodBase::LikelihoodBase(Particles** particles) : BCModel(),
                                                                   fPermutations(0),
                                                                   fParticlesModel(0),
                                                                   fMyParticlesTruth(0),
-                                                                  fPhysicsConstants(new KLFitter::PhysicsConstants()),
                                                                   fDetector(0),
                                                                   fEventProbability(std::vector<double>(0)),
                                                                   fFlagIntegrate(0),
@@ -56,14 +55,11 @@ KLFitter::LikelihoodBase::~LikelihoodBase() {
 
   if (fParticlesModel)
     delete fParticlesModel;
-
-  if (fPhysicsConstants)
-    delete fPhysicsConstants;
 }
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodBase::SetPhysicsConstants(KLFitter::PhysicsConstants* physicsconstants) {
-  fPhysicsConstants = physicsconstants;
+  fPhysicsConstants = *physicsconstants;
 
   // no error
   return 1;

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -34,7 +34,6 @@
 KLFitter::LikelihoodBase::LikelihoodBase(Particles** particles) : BCModel(),
                                                                   fParticlesPermuted(particles),
                                                                   fPermutations(0),
-                                                                  fParticlesModel(0),
                                                                   fMyParticlesTruth(0),
                                                                   fDetector(0),
                                                                   fEventProbability(std::vector<double>(0)),
@@ -52,9 +51,6 @@ KLFitter::LikelihoodBase::~LikelihoodBase() {
   // Clear the parameters container in the BCModel to circumvent
   // BAT-internal memory leak (known issue in 0.9.4.1).
   ClearParameters(true);
-
-  if (fParticlesModel)
-    delete fParticlesModel;
 }
 
 // ---------------------------------------------------------
@@ -384,13 +380,12 @@ int KLFitter::LikelihoodBase::RemoveForbiddenParticlePermutations() {
   KLFitter::Particles * particles = (*fPermutations)->Particles();
   int nPartons = particles->NPartons();
 
-  KLFitter::Particles * particlesModel = fParticlesModel;
-  int nPartonsModel = particlesModel->NPartons();
+  int nPartonsModel = fParticlesModel->NPartons();
   for (int iParton(0); iParton < nPartons; ++iParton) {
     bool isBtagged = particles->IsBTagged(iParton);
 
     for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
-      KLFitter::Particles::TrueFlavorType trueFlavor = particlesModel->TrueFlavor(iPartonModel);
+      KLFitter::Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(iPartonModel);
       if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
         continue;
       if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -98,14 +98,8 @@ void KLFitter::LikelihoodSgTopWtLJ::SetLeptonType(int leptontype) {
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodSgTopWtLJ::DefineModelParticles() {
-  // check if model particles exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // create dummy TLorentzVector
   TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
@@ -565,7 +559,7 @@ int KLFitter::LikelihoodSgTopWtLJ::BuildModelParticles() {
   TLorentzVector * b = fParticlesModel->Parton(0);
   TLorentzVector * lq1  = fParticlesModel->Parton(1);
   TLorentzVector * lq2  = fParticlesModel->Parton(2);
-  TLorentzVector * lep = GetLepton(fParticlesModel);
+  TLorentzVector * lep = GetLepton(fParticlesModel.get());
   TLorentzVector * nu   = fParticlesModel->Neutrino(0);
   TLorentzVector * whad  = fParticlesModel->Boson(0);
   TLorentzVector * wlep  = fParticlesModel->Boson(1);

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -108,32 +108,29 @@ int KLFitter::LikelihoodSgTopWtLJ::DefineModelParticles() {
   fParticlesModel = new KLFitter::Particles();
 
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);  // 4-vector
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
 
-  fParticlesModel->AddParticle(dummy, KLFitter::Particles::kParton,  "b quark", 0, KLFitter::Particles::kB);
+  fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kParton,  "b quark", 0, KLFitter::Particles::kB);
 
-  fParticlesModel->AddParticle(dummy, KLFitter::Particles::kParton, "light quark 1", 1, KLFitter::Particles::kLight);
+  fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kParton, "light quark 1", 1, KLFitter::Particles::kLight);
 
-  fParticlesModel->AddParticle(dummy, KLFitter::Particles::kParton, "light quark 2", 2, KLFitter::Particles::kLight);
+  fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kParton, "light quark 2", 2, KLFitter::Particles::kLight);
 
   if (fTypeLepton == kElectron) {
-    fParticlesModel->AddParticle(dummy, KLFitter::Particles::kElectron, "electron");
+    fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kElectron, "electron");
   } else if (fTypeLepton == kMuon) {
-    fParticlesModel->AddParticle(dummy, KLFitter::Particles::kMuon, "muon");
+    fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kMuon, "muon");
   }
 
-  fParticlesModel->AddParticle(dummy, KLFitter::Particles::kNeutrino, "neutrino");
+  fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kNeutrino, "neutrino");
 
-  fParticlesModel->AddParticle(dummy, KLFitter::Particles::kBoson, "hadronic W");
+  fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kBoson, "hadronic W");
 
-  fParticlesModel->AddParticle(dummy, KLFitter::Particles::kBoson, "leptonic W");
+  fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kBoson, "leptonic W");
 
-  fParticlesModel->AddParticle(dummy, KLFitter::Particles::kParton, "hadronic top");
+  fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kParton, "hadronic top");
 
-  fParticlesModel->AddParticle(dummy, KLFitter::Particles::kParton, "leptonic top");
-
-  // free memory
-  delete dummy;
+  fParticlesModel->AddParticle(&dummy, KLFitter::Particles::kParton, "leptonic top");
 
   // no error
   return 1;

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -142,7 +142,7 @@ int KLFitter::LikelihoodSgTopWtLJ::DefineModelParticles() {
 // ---------------------------------------------------------
 void KLFitter::LikelihoodSgTopWtLJ::DefineParameters() {
   // add parameters of model
-  this->AddParameter("energy b",                fPhysicsConstants->MassBottom(), 1000.0);   // parBE
+  this->AddParameter("energy b",                fPhysicsConstants.MassBottom(), 1000.0);   // parBE
   this->AddParameter("energy light quark 1",    0.0, 1000.0);                               // parLQ1E
   this->AddParameter("energy light quark 2",    0.0, 1000.0);                               // parLQ2E
   this->AddParameter("energy lepton",           0.0, 1000.0);                               // parLepE
@@ -297,7 +297,7 @@ int KLFitter::LikelihoodSgTopWtLJ::AdjustParameterRanges() {
 
   // energy of b quark
   double E = (*fParticlesPermuted)->Parton(0)->E();
-  double m = fPhysicsConstants->MassBottom();
+  double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = TMath::Max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double Emin = TMath::Max(m, E - nsigmas_jet * sqrt(E));
@@ -380,10 +380,10 @@ double KLFitter::LikelihoodSgTopWtLJ::LogLikelihood(const std::vector<double> & 
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
-  double massTop = fPhysicsConstants->MassTop();
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
+  double massTop = fPhysicsConstants.MassTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
   logprob += BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW);
@@ -507,7 +507,7 @@ int KLFitter::LikelihoodSgTopWtLJ::SavePermutedParticles() {
   b_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   b_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   b_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  b_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants->MassBottom(), &b_meas_px, &b_meas_py, &b_meas_pz, b_meas_e);
+  b_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &b_meas_px, &b_meas_py, &b_meas_pz, b_meas_e);
   b_meas_p      = sqrt(b_meas_e*b_meas_e - b_meas_m*b_meas_m);
 
   lq1_meas_e      = (*fParticlesPermuted)->Parton(1)->E();

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -101,79 +101,76 @@ int KLFitter::LikelihoodTTHLeptonJets::DefineModelParticles() {
 
   // add model particles
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);  // 4-vector
-  fParticlesModel->AddParticle(dummy,
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,  // type
                                "hadronic b quark",            // name
                                0,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic b quark",
                                1,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 1",
                                2,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 2",
                                3,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,  // type
                                "Higgs b quark 1",             // name
                                4,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "Higgs b quark 2",
                                5,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
   if (fTypeLepton == kElectron) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron");
   } else if (fTypeLepton == kMuon) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon");
   }
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kNeutrino,
                                "neutrino");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "hadronic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "leptonic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic top");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic top");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "Higgs");
-
-  // free memory
-  delete dummy;
 
   // no error
   return 1;

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -182,8 +182,8 @@ int KLFitter::LikelihoodTTHLeptonJets::DefineModelParticles() {
 // ---------------------------------------------------------
 void KLFitter::LikelihoodTTHLeptonJets::DefineParameters() {
   // add parameters of model
-  AddParameter("energy hadronic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBhadE
-  AddParameter("energy leptonic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBlepE
+  AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
+  AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
   AddParameter("energy light quark 1",    0.0, 1000.0);                              // parLQ1E
   AddParameter("energy light quark 2",    0.0, 1000.0);                              // parLQ2E
   AddParameter("energy lepton",           0.0, 1000.0);                              // parLepE
@@ -191,8 +191,8 @@ void KLFitter::LikelihoodTTHLeptonJets::DefineParameters() {
   AddParameter("p_y neutrino",        -1000.0, 1000.0);                              // parNuPy
   AddParameter("p_z neutrino",        -1000.0, 1000.0);                              // parNuPz
   AddParameter("top mass",              100.0, 1000.0);                              // parTopM
-  AddParameter("energy Higgs b quark 1",  fPhysicsConstants->MassBottom(), 1000.0);  // parBHiggs1E
-  AddParameter("energy Higgs b quark 2",  fPhysicsConstants->MassBottom(), 1000.0);  // parBHiggs2E
+  AddParameter("energy Higgs b quark 1",  fPhysicsConstants.MassBottom(), 1000.0);  // parBHiggs1E
+  AddParameter("energy Higgs b quark 2",  fPhysicsConstants.MassBottom(), 1000.0);  // parBHiggs2E
   if (fFlagHiggsMassFixed)  AddParameter("Higgs mass",              100.0, 1000.0);  // parHiggsM
 }
 
@@ -369,7 +369,7 @@ int KLFitter::LikelihoodTTHLeptonJets::AdjustParameterRanges() {
   double nsigmas_lepton = 2.0;
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
-  double m = fPhysicsConstants->MassBottom();
+  double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double Emin = std::max(m, E - nsigmas_jet* sqrt(E));
@@ -377,7 +377,7 @@ int KLFitter::LikelihoodTTHLeptonJets::AdjustParameterRanges() {
   SetParameterRange(parBhadE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   Emin = std::max(m, E - nsigmas_jet* sqrt(E));
@@ -401,7 +401,7 @@ int KLFitter::LikelihoodTTHLeptonJets::AdjustParameterRanges() {
   SetParameterRange(parLQ2E, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(4)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(4)->M());
   Emin = std::max(m, E - nsigmas_jet* sqrt(E));
@@ -409,7 +409,7 @@ int KLFitter::LikelihoodTTHLeptonJets::AdjustParameterRanges() {
   SetParameterRange(parBHiggs1E, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(5)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(5)->M());
   Emin = std::max(m, E - nsigmas_jet* sqrt(E));
@@ -435,10 +435,10 @@ int KLFitter::LikelihoodTTHLeptonJets::AdjustParameterRanges() {
   SetParameterRange(parNuPy, ETmiss_y-100.0, ETmiss_y+100);
 
   if (fFlagTopMassFixed)
-    SetParameterRange(parTopM, fPhysicsConstants->MassTop(), fPhysicsConstants->MassTop());
+    SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
   if (fFlagHiggsMassFixed)
-    SetParameterRange(parHiggsM, fPhysicsConstants->MassHiggs(), fPhysicsConstants->MassHiggs());
+    SetParameterRange(parHiggsM, fPhysicsConstants.MassHiggs(), fPhysicsConstants.MassHiggs());
 
   // no error
   return 1;
@@ -490,10 +490,10 @@ double KLFitter::LikelihoodTTHLeptonJets::LogLikelihood(const std::vector<double
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
-  double gammaTop = fPhysicsConstants->GammaTop();
-  double gammaHiggs = fPhysicsConstants->GammaHiggs();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
+  double gammaTop = fPhysicsConstants.GammaTop();
+  double gammaHiggs = fPhysicsConstants.GammaHiggs();
 
   // Breit-Wigner of hadronically decaying W-boson
   logprob += BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW);
@@ -656,7 +656,7 @@ int KLFitter::LikelihoodTTHLeptonJets::SavePermutedParticles() {
   bhad_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   bhad_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   bhad_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants->MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
+  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
   bhad_meas_p      = sqrt(bhad_meas_e*bhad_meas_e - bhad_meas_m*bhad_meas_m);
 
   blep_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
@@ -664,7 +664,7 @@ int KLFitter::LikelihoodTTHLeptonJets::SavePermutedParticles() {
   blep_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
   blep_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
   blep_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
-  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants->MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
+  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
   blep_meas_p      = sqrt(blep_meas_e*blep_meas_e - blep_meas_m*blep_meas_m);
 
   lq1_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
@@ -688,7 +688,7 @@ int KLFitter::LikelihoodTTHLeptonJets::SavePermutedParticles() {
   BHiggs1_meas_px     = (*fParticlesPermuted)->Parton(4)->Px();
   BHiggs1_meas_py     = (*fParticlesPermuted)->Parton(4)->Py();
   BHiggs1_meas_pz     = (*fParticlesPermuted)->Parton(4)->Pz();
-  BHiggs1_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(4)->M(), fPhysicsConstants->MassBottom(), &BHiggs1_meas_px, &BHiggs1_meas_py, &BHiggs1_meas_pz, BHiggs1_meas_e);
+  BHiggs1_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(4)->M(), fPhysicsConstants.MassBottom(), &BHiggs1_meas_px, &BHiggs1_meas_py, &BHiggs1_meas_pz, BHiggs1_meas_e);
   BHiggs1_meas_p      = sqrt(BHiggs1_meas_e*BHiggs1_meas_e - BHiggs1_meas_m*BHiggs1_meas_m);
 
   BHiggs2_meas_e      = (*fParticlesPermuted)->Parton(5)->E();
@@ -696,7 +696,7 @@ int KLFitter::LikelihoodTTHLeptonJets::SavePermutedParticles() {
   BHiggs2_meas_px     = (*fParticlesPermuted)->Parton(5)->Px();
   BHiggs2_meas_py     = (*fParticlesPermuted)->Parton(5)->Py();
   BHiggs2_meas_pz     = (*fParticlesPermuted)->Parton(5)->Pz();
-  BHiggs2_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(5)->M(), fPhysicsConstants->MassBottom(), &BHiggs2_meas_px, &BHiggs2_meas_py, &BHiggs2_meas_pz, BHiggs2_meas_e);
+  BHiggs2_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(5)->M(), fPhysicsConstants.MassBottom(), &BHiggs2_meas_px, &BHiggs2_meas_py, &BHiggs2_meas_pz, BHiggs2_meas_e);
   BHiggs2_meas_p      = sqrt(BHiggs2_meas_e*BHiggs2_meas_e - BHiggs2_meas_m*BHiggs2_meas_m);
 
   TLorentzVector * lepton(0);
@@ -829,10 +829,10 @@ std::vector<double> KLFitter::LikelihoodTTHLeptonJets::LogLikelihoodComponents(s
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
-  double gammaTop = fPhysicsConstants->GammaTop();
-  double gammaHiggs = fPhysicsConstants->GammaHiggs();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
+  double gammaTop = fPhysicsConstants.GammaTop();
+  double gammaHiggs = fPhysicsConstants.GammaHiggs();
 
   // Breit-Wigner of hadronically decaying W-boson
   vecci.push_back(BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW));  // comp9

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -90,14 +90,8 @@ void KLFitter::LikelihoodTTHLeptonJets::SetLeptonType(int leptontype) {
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTTHLeptonJets::DefineModelParticles() {
-  // check if model particles and lorentz vector container exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // add model particles
   // create dummy TLorentzVector

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -103,79 +103,76 @@ int KLFitter::LikelihoodTTZTrilepton::DefineModelParticles() {
 
   // add model particles
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);  // 4-vector
-  fParticlesModel->AddParticle(dummy,
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,  // type
                                "hadronic b quark",            // name
                                0,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic b quark",
                                1,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 1",
                                2,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 2",
                                3,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
   if (fTypeLepton == kElectron) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron");
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron Z1");
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron Z2");
   } else if (fTypeLepton == kMuon) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon");
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon Z1");
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon Z2");
   }
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kNeutrino,
                                "neutrino");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "hadronic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "leptonic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic top");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic top");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "Z boson");
-
-  // free memory
-  delete dummy;
 
   // no error
   return 1;

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -184,8 +184,8 @@ int KLFitter::LikelihoodTTZTrilepton::DefineModelParticles() {
 // ---------------------------------------------------------
 void KLFitter::LikelihoodTTZTrilepton::DefineParameters() {
   // add parameters of model
-  AddParameter("energy hadronic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBhadE
-  AddParameter("energy leptonic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBlepE
+  AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
+  AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
   AddParameter("energy light quark 1",    0.0, 1000.0);                              // parLQ1E
   AddParameter("energy light quark 2",    0.0, 1000.0);                              // parLQ2E
   AddParameter("energy lepton",           0.0, 1000.0);                              // parLepE
@@ -403,7 +403,7 @@ int KLFitter::LikelihoodTTZTrilepton::AdjustParameterRanges() {
   double nsigmas_met    = fFlagGetParSigmasFromTFs ? 10 : 1;
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
-  double m = fPhysicsConstants->MassBottom();
+  double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double sigma = fFlagGetParSigmasFromTFs ? fResEnergyBhad->GetSigma(E) : sqrt(E);
@@ -412,7 +412,7 @@ int KLFitter::LikelihoodTTZTrilepton::AdjustParameterRanges() {
   SetParameterRange(parBhadE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyBlep->GetSigma(E) : sqrt(E);
@@ -491,9 +491,9 @@ int KLFitter::LikelihoodTTZTrilepton::AdjustParameterRanges() {
   SetParameterRange(parNuPy, ETmiss_y-sigrange, ETmiss_y+sigrange);
 
   if (fFlagTopMassFixed)
-    SetParameterRange(parTopM, fPhysicsConstants->MassTop(), fPhysicsConstants->MassTop());
+    SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
-  SetParameterRange(parZM, fPhysicsConstants->MassZ(), fPhysicsConstants->MassZ());
+  SetParameterRange(parZM, fPhysicsConstants.MassZ(), fPhysicsConstants.MassZ());
 
   // no error
   return 1;
@@ -553,14 +553,14 @@ double KLFitter::LikelihoodTTZTrilepton::LogLikelihood(const std::vector<double>
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
-  double gammaZ = fPhysicsConstants->GammaZ();
+  double gammaZ = fPhysicsConstants.GammaZ();
 
   // note: as opposed to the LikelihoodTopLeptonJets class, we use a normalised
   // version of the Breit-Wigner here to make sure that weightings between
@@ -742,7 +742,7 @@ int KLFitter::LikelihoodTTZTrilepton::SavePermutedParticles() {
   bhad_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   bhad_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   bhad_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants->MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
+  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
   bhad_meas_p      = sqrt(bhad_meas_e*bhad_meas_e - bhad_meas_m*bhad_meas_m);
 
   blep_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
@@ -750,7 +750,7 @@ int KLFitter::LikelihoodTTZTrilepton::SavePermutedParticles() {
   blep_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
   blep_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
   blep_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
-  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants->MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
+  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
   blep_meas_p      = sqrt(blep_meas_e*blep_meas_e - blep_meas_m*blep_meas_m);
 
   lq1_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
@@ -953,14 +953,14 @@ std::vector<double> KLFitter::LikelihoodTTZTrilepton::LogLikelihoodComponents(st
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
-  double gammaZ = fPhysicsConstants->GammaZ();
+  double gammaZ = fPhysicsConstants.GammaZ();
 
   // note: as opposed to the LikelihoodTopLeptonJets class, we use a normalised
   // version of the Breit-Wigner here to make sure that weightings between

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -92,14 +92,8 @@ void KLFitter::LikelihoodTTZTrilepton::SetLeptonType(int leptontype) {
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTTZTrilepton::DefineModelParticles() {
-  // check if model particles and lorentz vector container exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // add model particles
   // create dummy TLorentzVector

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -49,14 +49,8 @@ KLFitter::LikelihoodTopAllHadronic::~LikelihoodTopAllHadronic() {
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopAllHadronic::DefineModelParticles() {
-  // check if model particles and lorentz vector container exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // add model particles
   // create dummy TLorentzVector

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -60,61 +60,58 @@ int KLFitter::LikelihoodTopAllHadronic::DefineModelParticles() {
 
   // add model particles
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);    // 4-vector
-  fParticlesModel->AddParticle(dummy,
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,  // type
                                "hadronic b quark 1",          // name
                                0,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic b quark 2",
                                1,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 1",
                                2,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 2",
                                3,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 3",
                                4,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 4",
                                5,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "hadronic W 1");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "hadronic W 2");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic top 1");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic top 2");
-
-  // free memory
-  delete dummy;
 
   // no error
   return 1;

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -123,8 +123,8 @@ int KLFitter::LikelihoodTopAllHadronic::DefineModelParticles() {
 // ---------------------------------------------------------
 void KLFitter::LikelihoodTopAllHadronic::DefineParameters() {
   // add parameters of model
-  AddParameter("energy hadronic b 1",       fPhysicsConstants->MassBottom(), 1000.0);  // parBhad1E
-  AddParameter("energy hadronic b 2",       fPhysicsConstants->MassBottom(), 1000.0);  // parBhad2E
+  AddParameter("energy hadronic b 1",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhad1E
+  AddParameter("energy hadronic b 2",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhad2E
   AddParameter("energy light quark 1",    0.0, 1000.0);                                // parLQ1E
   AddParameter("energy light quark 2",    0.0, 1000.0);                                // parLQ2E
   AddParameter("energy light quark 3",    0.0, 1000.0);                                // parLQ3E
@@ -272,7 +272,7 @@ int KLFitter::LikelihoodTopAllHadronic::AdjustParameterRanges() {
   double nsigmas_jet = fFlagGetParSigmasFromTFs ? 10 : 7;
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
-  double m = fPhysicsConstants->MassBottom();
+  double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double sigma = fFlagGetParSigmasFromTFs ? fResEnergyBhad1->GetSigma(E) : sqrt(E);
@@ -281,7 +281,7 @@ int KLFitter::LikelihoodTopAllHadronic::AdjustParameterRanges() {
   SetParameterRange(parBhad1E, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyBhad2->GetSigma(E) : sqrt(E);
@@ -326,7 +326,7 @@ int KLFitter::LikelihoodTopAllHadronic::AdjustParameterRanges() {
   SetParameterRange(parLQ4E, Emin, Emax);
 
   if (fFlagTopMassFixed)
-    SetParameterRange(parTopM, fPhysicsConstants->MassTop(), fPhysicsConstants->MassTop());
+    SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
   // no error
   return 1;
@@ -363,12 +363,12 @@ double KLFitter::LikelihoodTopAllHadronic::LogLikelihood(const std::vector<doubl
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
   logprob += BCMath::LogBreitWignerRel(whad1_fit_m, massW, gammaW);
@@ -419,7 +419,7 @@ int KLFitter::LikelihoodTopAllHadronic::SavePermutedParticles() {
   bhad1_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   bhad1_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   bhad1_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  bhad1_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants->MassBottom(), &bhad1_meas_px, &bhad1_meas_py, &bhad1_meas_pz, bhad1_meas_e);
+  bhad1_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &bhad1_meas_px, &bhad1_meas_py, &bhad1_meas_pz, bhad1_meas_e);
   bhad1_meas_p      = sqrt(bhad1_meas_e*bhad1_meas_e - bhad1_meas_m*bhad1_meas_m);
 
   bhad2_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
@@ -427,7 +427,7 @@ int KLFitter::LikelihoodTopAllHadronic::SavePermutedParticles() {
   bhad2_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
   bhad2_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
   bhad2_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
-  bhad2_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants->MassBottom(), &bhad2_meas_px, &bhad2_meas_py, &bhad2_meas_pz, bhad2_meas_e);
+  bhad2_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &bhad2_meas_px, &bhad2_meas_py, &bhad2_meas_pz, bhad2_meas_e);
   bhad2_meas_p      = sqrt(bhad2_meas_e*bhad2_meas_e - bhad2_meas_m*bhad2_meas_m);
 
   lq1_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
@@ -541,12 +541,12 @@ std::vector<double> KLFitter::LikelihoodTopAllHadronic::LogLikelihoodComponents(
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson1
   vecci.push_back(BCMath::LogBreitWignerRel(whad1_fit_m, massW, gammaW));  // comp6

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -184,8 +184,8 @@ void KLFitter::LikelihoodTopDilepton::DefineParameters() {
   // add parameters of model
 
   AddParameter("top mass",              100.0, 700.0);                             // parTopM
-  AddParameter("energy b1",       fPhysicsConstants->MassBottom(), 1000.0);        // parB1E
-  AddParameter("energy b2",       fPhysicsConstants->MassBottom(), 1000.0);        // parB2E
+  AddParameter("energy b1",       fPhysicsConstants.MassBottom(), 1000.0);        // parB1E
+  AddParameter("energy b2",       fPhysicsConstants.MassBottom(), 1000.0);        // parB2E
   AddParameter("energy lepton1",           0.0, 1000.0);                           // parLep1E
   AddParameter("energy lepton2",           0.0, 1000.0);                           // parLep2E
   AddParameter("antinueta",               -5.0, 5.0);                              // parAntiNuEta
@@ -196,7 +196,7 @@ void KLFitter::LikelihoodTopDilepton::DefineParameters() {
 void KLFitter::LikelihoodTopDilepton::DefinePrior() {
   // define sharp Gaussian prior for mtop
   if (fFlagTopMassFixed)
-    SetPriorGauss(0, fPhysicsConstants->MassTop(), fPhysicsConstants->MassTopUnc());
+    SetPriorGauss(0, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTopUnc());
 }
 
 // ---------------------------------------------------------
@@ -328,7 +328,7 @@ int KLFitter::LikelihoodTopDilepton::RemoveInvariantParticlePermutations() {
 int KLFitter::LikelihoodTopDilepton::AdjustParameterRanges() {
   // adjust limits
   if (fFlagTopMassFixed)
-    SetParameterRange(parTopM, fPhysicsConstants->MassTop()-3*fPhysicsConstants->MassTopUnc(), fPhysicsConstants->MassTop()+3*fPhysicsConstants->MassTopUnc());
+    SetParameterRange(parTopM, fPhysicsConstants.MassTop()-3*fPhysicsConstants.MassTopUnc(), fPhysicsConstants.MassTop()+3*fPhysicsConstants.MassTopUnc());
 
   double nsigmas_jet = 7.0;
   double nsigmas_lepton = 7.0;
@@ -346,7 +346,7 @@ int KLFitter::LikelihoodTopDilepton::AdjustParameterRanges() {
   fResLepton2->Par(3, &par3_2);
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
-  double m = fPhysicsConstants->MassBottom();
+  double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double Emin = std::max(m, E - nsigmas_jet* sqrt(E));
@@ -354,7 +354,7 @@ int KLFitter::LikelihoodTopDilepton::AdjustParameterRanges() {
   SetParameterRange(parB1E, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   Emin = std::max(m, E - nsigmas_jet* sqrt(E));
@@ -711,10 +711,10 @@ double KLFitter::LikelihoodTopDilepton::GaussAntiNuEta(std::vector<double> param
 // ---------------------------------------------------------
 KLFitter::NuSolutions KLFitter::LikelihoodTopDilepton::SolveForNuMom(TLorentzVector * l, TLorentzVector * b, double mtop, double nueta) {
   NuSolutions ret;
-  double Wmass = fPhysicsConstants->MassW();
+  double Wmass = fPhysicsConstants.MassW();
   double Wmass2 = Wmass*Wmass;
 
-  double bmass = fPhysicsConstants->MassBottom();
+  double bmass = fPhysicsConstants.MassBottom();
 
   double coshnueta;
   double sinhnueta;
@@ -812,7 +812,7 @@ std::vector<double> KLFitter::LikelihoodTopDilepton::GetInitialParameters() {
   std::vector<double> values(GetNParameters());
 
   // mtop
-  values[parTopM] = fPhysicsConstants->MassTop();
+  values[parTopM] = fPhysicsConstants.MassTop();
 
   // energies of the quarks
   values[parB1E] = b1_meas_e;
@@ -843,7 +843,7 @@ int KLFitter::LikelihoodTopDilepton::SavePermutedParticles() {
   b1_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   b1_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   b1_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  b1_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants->MassBottom(), &b1_meas_px, &b1_meas_py, &b1_meas_pz, b1_meas_e);
+  b1_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &b1_meas_px, &b1_meas_py, &b1_meas_pz, b1_meas_e);
   b1_meas_p      = sqrt(b1_meas_e*b1_meas_e - b1_meas_m*b1_meas_m);
 
   b2_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
@@ -851,7 +851,7 @@ int KLFitter::LikelihoodTopDilepton::SavePermutedParticles() {
   b2_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
   b2_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
   b2_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
-  b2_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants->MassBottom(), &b2_meas_px, &b2_meas_py, &b2_meas_pz, b2_meas_e);
+  b2_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &b2_meas_px, &b2_meas_py, &b2_meas_pz, b2_meas_e);
   b2_meas_p      = sqrt(b2_meas_e*b2_meas_e - b2_meas_m*b2_meas_m);
 
   TLorentzVector * lepton_1(0);

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -70,8 +70,6 @@ KLFitter::LikelihoodTopDilepton::LikelihoodTopDilepton() : KLFitter::LikelihoodB
 
 // ---------------------------------------------------------
 KLFitter::LikelihoodTopDilepton::~LikelihoodTopDilepton() {
-  delete fHistMttbar;
-  delete fHistCosTheta;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -1062,7 +1062,7 @@ void KLFitter::LikelihoodTopDilepton::MCMCIterationInterface() {
 
   // for costheta
   std::pair<float, float> costheta(0., 0.);
-  std::vector <TLorentzVector> * help_ParticleVector  = new std::vector<TLorentzVector>(0);
+  auto help_ParticleVector = std::unique_ptr<std::vector<TLorentzVector> >(new std::vector<TLorentzVector>{});
 
   // get number of chains
   int nchains = MCMCGetNChains();
@@ -1122,7 +1122,7 @@ void KLFitter::LikelihoodTopDilepton::MCMCIterationInterface() {
         help_ParticleVector -> push_back(nubars.nu1);
         help_ParticleVector -> push_back(MCMC_b1);
         help_ParticleVector -> push_back(MCMC_b2);
-        costheta = CalculateCosTheta(help_ParticleVector);
+        costheta = CalculateCosTheta(help_ParticleVector.get());
         fHistCosTheta->GetHistogram()->Fill(costheta.first);
         fHistCosTheta->GetHistogram()->Fill(costheta.second);
       }
@@ -1140,7 +1140,7 @@ void KLFitter::LikelihoodTopDilepton::MCMCIterationInterface() {
           help_ParticleVector -> push_back(nubars.nu2);
           help_ParticleVector -> push_back(MCMC_b1);
           help_ParticleVector -> push_back(MCMC_b2);
-          costheta = CalculateCosTheta(help_ParticleVector);
+          costheta = CalculateCosTheta(help_ParticleVector.get());
           fHistCosTheta->GetHistogram()->Fill(costheta.first);
           fHistCosTheta->GetHistogram()->Fill(costheta.second);
         }
@@ -1157,7 +1157,7 @@ void KLFitter::LikelihoodTopDilepton::MCMCIterationInterface() {
           help_ParticleVector -> push_back(nubars.nu1);
           help_ParticleVector -> push_back(MCMC_b1);
           help_ParticleVector -> push_back(MCMC_b2);
-          costheta = CalculateCosTheta(help_ParticleVector);
+          costheta = CalculateCosTheta(help_ParticleVector.get());
           fHistCosTheta->GetHistogram()->Fill(costheta.first);
           fHistCosTheta->GetHistogram()->Fill(costheta.second);
         }
@@ -1174,7 +1174,7 @@ void KLFitter::LikelihoodTopDilepton::MCMCIterationInterface() {
           help_ParticleVector -> push_back(nubars.nu2);
           help_ParticleVector -> push_back(MCMC_b1);
           help_ParticleVector -> push_back(MCMC_b2);
-          costheta = CalculateCosTheta(help_ParticleVector);
+          costheta = CalculateCosTheta(help_ParticleVector.get());
           fHistCosTheta->GetHistogram()->Fill(costheta.first);
           fHistCosTheta->GetHistogram()->Fill(costheta.second);
         }
@@ -1191,7 +1191,7 @@ void KLFitter::LikelihoodTopDilepton::MCMCIterationInterface() {
           help_ParticleVector -> push_back(nubars.nu1);
           help_ParticleVector -> push_back(MCMC_b1);
           help_ParticleVector -> push_back(MCMC_b2);
-          costheta = CalculateCosTheta(help_ParticleVector);
+          costheta = CalculateCosTheta(help_ParticleVector.get());
           fHistCosTheta->GetHistogram()->Fill(costheta.first);
           fHistCosTheta->GetHistogram()->Fill(costheta.second);
         }
@@ -1208,14 +1208,13 @@ void KLFitter::LikelihoodTopDilepton::MCMCIterationInterface() {
           help_ParticleVector -> push_back(nubars.nu2);
           help_ParticleVector -> push_back(MCMC_b1);
           help_ParticleVector -> push_back(MCMC_b2);
-          costheta = CalculateCosTheta(help_ParticleVector);
+          costheta = CalculateCosTheta(help_ParticleVector.get());
           fHistCosTheta->GetHistogram()->Fill(costheta.first);
           fHistCosTheta->GetHistogram()->Fill(costheta.second);
         }
       }  // 2 nu 2 nubar
     }  // Nsol
   }  // Nchains
-  delete help_ParticleVector;
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -135,45 +135,42 @@ int KLFitter::LikelihoodTopDilepton::DefineModelParticles() {
 
   // add model particles
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);    // 4-vector
-  fParticlesModel->AddParticle(dummy,
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,  // type
                                "b quark 1",                   // name
                                0,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "b quark 2",
                                1,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
   if (fTypeLepton_1 == kElectron && fTypeLepton_2 == kMuon) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron");
 
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon");
   } else if (fTypeLepton_1 == kElectron && fTypeLepton_2 == kElectron) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron 1");
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron 2");
   } else if (fTypeLepton_1 == kMuon && fTypeLepton_2 == kMuon) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon 1");
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon 2");
   }
-
-  // free memory
-  delete dummy;
 
   // no error
   return 1;

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -124,14 +124,8 @@ void KLFitter::LikelihoodTopDilepton::SetLeptonType(int leptontype_1, int lepton
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopDilepton::DefineModelParticles() {
-  // check if model particles and lorentz vector container exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // add model particles
   // create dummy TLorentzVector

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -586,31 +586,26 @@ double KLFitter::LikelihoodTopDilepton::CalculateWeight(const std::vector<double
   double Weight = 0.;
 
   // charged leptons
-  TLorentzVector * l1 = new TLorentzVector();
-  TLorentzVector * l2 = new TLorentzVector();
+  TLorentzVector l1{};
+  TLorentzVector l2{};
 
   // include parLep1E, parLep2E
-  l1->SetPxPyPzE(lep1_fit_px,  lep1_fit_py,  lep1_fit_pz,  lep1_fit_e);
-  l2->SetPxPyPzE(lep2_fit_px,  lep2_fit_py,  lep2_fit_pz,  lep2_fit_e);
+  l1.SetPxPyPzE(lep1_fit_px,  lep1_fit_py,  lep1_fit_pz,  lep1_fit_e);
+  l2.SetPxPyPzE(lep2_fit_px,  lep2_fit_py,  lep2_fit_pz,  lep2_fit_e);
 
   // jet1 and jet2:
-  TLorentzVector * j1 = new TLorentzVector();
-  TLorentzVector * j2 = new TLorentzVector();
+  TLorentzVector j1{};
+  TLorentzVector j2{};
 
   // include parB1E, parB2E
-  j1->SetPxPyPzE(b1_fit_px, b1_fit_py, b1_fit_pz, b1_fit_e);
-  j2->SetPxPyPzE(b2_fit_px, b2_fit_py, b2_fit_pz, b2_fit_e);
+  j1.SetPxPyPzE(b1_fit_px, b1_fit_py, b1_fit_pz, b1_fit_e);
+  j2.SetPxPyPzE(b2_fit_px, b2_fit_py, b2_fit_pz, b2_fit_e);
 
-  Weight += CalculateWeightPerm(l1, l2, j1, j2, parameters);
+  Weight += CalculateWeightPerm(&l1, &l2, &j1, &j2, parameters);
 
   // if sumloglik option, sum over jet permutations
   if (doSumloglik)
-    Weight += CalculateWeightPerm(l1, l2, j2, j1, parameters);
-
-  delete l1;
-  delete l2;
-  delete j1;
-  delete j2;
+    Weight += CalculateWeightPerm(&l1, &l2, &j2, &j1, parameters);
 
   return Weight;
 }

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -90,14 +90,8 @@ void KLFitter::LikelihoodTopLeptonJets::SetLeptonType(int leptontype) {
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets::DefineModelParticles() {
-  // check if model particles and lorentz vector container exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // add model particles
   // create dummy TLorentzVector

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -101,63 +101,60 @@ int KLFitter::LikelihoodTopLeptonJets::DefineModelParticles() {
 
   // add model particles
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);    // 4-vector
-  fParticlesModel->AddParticle(dummy,
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,  // type
                                "hadronic b quark",            // name
                                0,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic b quark",
                                1,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 1",
                                2,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 2",
                                3,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
   if (fTypeLepton == kElectron) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron");
   } else if (fTypeLepton == kMuon) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon");
   }
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kNeutrino,
                                "neutrino");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "hadronic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "leptonic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic top");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic top");
-
-  // free memory
-  delete dummy;
 
   // no error
   return 1;

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -166,8 +166,8 @@ int KLFitter::LikelihoodTopLeptonJets::DefineModelParticles() {
 // ---------------------------------------------------------
 void KLFitter::LikelihoodTopLeptonJets::DefineParameters() {
   // add parameters of model
-  AddParameter("energy hadronic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBhadE
-  AddParameter("energy leptonic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBlepE
+  AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
+  AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
   AddParameter("energy light quark 1",    0.0, 1000.0);                              // parLQ1E
   AddParameter("energy light quark 2",    0.0, 1000.0);                              // parLQ2E
   AddParameter("energy lepton",           0.0, 1000.0);                              // parLepE
@@ -319,7 +319,7 @@ int KLFitter::LikelihoodTopLeptonJets::AdjustParameterRanges() {
   double nsigmas_met    = fFlagGetParSigmasFromTFs ? 10 : 1;
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
-  double m = fPhysicsConstants->MassBottom();
+  double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double sigma = fFlagGetParSigmasFromTFs ? fResEnergyBhad->GetSigma(E) : sqrt(E);
@@ -328,7 +328,7 @@ int KLFitter::LikelihoodTopLeptonJets::AdjustParameterRanges() {
   SetParameterRange(parBhadE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyBlep->GetSigma(E) : sqrt(E);
@@ -377,7 +377,7 @@ int KLFitter::LikelihoodTopLeptonJets::AdjustParameterRanges() {
   SetParameterRange(parNuPy, ETmiss_y-sigrange, ETmiss_y+sigrange);
 
   if (fFlagTopMassFixed)
-    SetParameterRange(parTopM, fPhysicsConstants->MassTop(), fPhysicsConstants->MassTop());
+    SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
   // no error
   return 1;
@@ -423,12 +423,12 @@ double KLFitter::LikelihoodTopLeptonJets::LogLikelihood(const std::vector<double
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
   logprob += BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW);
@@ -575,7 +575,7 @@ int KLFitter::LikelihoodTopLeptonJets::SavePermutedParticles() {
   bhad_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   bhad_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   bhad_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants->MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
+  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
   bhad_meas_p      = sqrt(bhad_meas_e*bhad_meas_e - bhad_meas_m*bhad_meas_m);
 
   blep_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
@@ -583,7 +583,7 @@ int KLFitter::LikelihoodTopLeptonJets::SavePermutedParticles() {
   blep_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
   blep_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
   blep_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
-  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants->MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
+  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
   blep_meas_p      = sqrt(blep_meas_e*blep_meas_e - blep_meas_m*blep_meas_m);
 
   lq1_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
@@ -713,12 +713,12 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets::LogLikelihoodComponents(s
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
   vecci.push_back(BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW));  // comp7

--- a/src/LikelihoodTopLeptonJetsUDSep.cxx
+++ b/src/LikelihoodTopLeptonJetsUDSep.cxx
@@ -60,63 +60,60 @@ int KLFitter::LikelihoodTopLeptonJetsUDSep::DefineModelParticles() {
 
   // add model particles
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);        // 4-vector
-  fParticlesModel->AddParticle(dummy,
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,      // type
                                "hadronic b quark",                // name
                                0,                                 // index of corresponding particle
                                KLFitter::Particles::kB);          // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic b quark",
                                1,                                 // index of corresponding particle
                                KLFitter::Particles::kB);          // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light up type quark",
                                2,                                 // index of corresponding particle
                                KLFitter::Particles::kLightUp);    // light up type jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light down type quark",
                                3,                                 // index of corresponding particle
                                KLFitter::Particles::kLightDown);  // light down type jet (truth)
 
   if (fTypeLepton == kElectron) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron");
   } else if (fTypeLepton == kMuon) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon");
   }
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kNeutrino,
                                "neutrino");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "hadronic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "leptonic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic top");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic top");
-
-  // free memory
-  delete dummy;
 
   // no error
   return 1;

--- a/src/LikelihoodTopLeptonJetsUDSep.cxx
+++ b/src/LikelihoodTopLeptonJetsUDSep.cxx
@@ -49,14 +49,8 @@ KLFitter::LikelihoodTopLeptonJetsUDSep::~LikelihoodTopLeptonJetsUDSep() {
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJetsUDSep::DefineModelParticles() {
-  // check if model particles and lorentz vector container exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // add model particles
   // create dummy TLorentzVector

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -100,63 +100,60 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::DefineModelParticles() {
 
   // add model particles
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);    // 4-vector
-  fParticlesModel->AddParticle(dummy,
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,  // type
                                "hadronic b quark",            // name
                                0,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic b quark",
                                1,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 1",
                                2,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 2",
                                3,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
   if (fTypeLepton == kElectron) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron");
   } else if (fTypeLepton == kMuon) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon");
   }
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kNeutrino,
                                "neutrino");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "hadronic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "leptonic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic top");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic top");
-
-  // free memory
-  delete dummy;
 
   // no error
   return 1;

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -89,14 +89,8 @@ void KLFitter::LikelihoodTopLeptonJets_Angular::SetLeptonType(int leptontype) {
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets_Angular::DefineModelParticles() {
-  // check if model particles and lorentz vector container exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // add model particles
   // create dummy TLorentzVector

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -165,8 +165,8 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::DefineModelParticles() {
 // ---------------------------------------------------------
 void KLFitter::LikelihoodTopLeptonJets_Angular::DefineParameters() {
   // add parameters of model
-  AddParameter("energy hadronic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBhadE
-  AddParameter("energy leptonic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBlepE
+  AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
+  AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
   AddParameter("energy light quark 1",    0.0, 1000.0);                              // parLQ1E
   AddParameter("energy light quark 2",    0.0, 1000.0);                              // parLQ2E
   AddParameter("energy lepton",           0.0, 1000.0);                              // parLepE
@@ -309,7 +309,7 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
   double nsigmas_lepton = 2.0;
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
-  double m = fPhysicsConstants->MassBottom();
+  double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double Emin = std::max(m, E - nsigmas_jet* sqrt(E));
@@ -317,7 +317,7 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
   SetParameterRange(parBhadE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   Emin = std::max(m, E - nsigmas_jet* sqrt(E));
@@ -359,7 +359,7 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
   SetParameterRange(parNuPy, ETmiss_y-100.0, ETmiss_y+100);
 
   if (fFlagTopMassFixed)
-    SetParameterRange(parTopM, fPhysicsConstants->MassTop(), fPhysicsConstants->MassTop());
+    SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
   // no error
   return 1;
@@ -405,12 +405,12 @@ double KLFitter::LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vecto
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
   logprob += BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW);
@@ -616,7 +616,7 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::SavePermutedParticles() {
   bhad_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   bhad_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   bhad_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants->MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
+  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
   bhad_meas_p      = sqrt(bhad_meas_e*bhad_meas_e - bhad_meas_m*bhad_meas_m);
 
   blep_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
@@ -624,7 +624,7 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::SavePermutedParticles() {
   blep_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
   blep_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
   blep_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
-  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants->MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
+  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
   blep_meas_p      = sqrt(blep_meas_e*blep_meas_e - blep_meas_m*blep_meas_m);
 
   lq1_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
@@ -754,12 +754,12 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets_Angular::LogLikelihoodComp
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
   vecci.push_back(BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW));  // comp7

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -102,63 +102,60 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::DefineModelParticles() {
 
   // add model particles
   // create dummy TLorentzVector
-  TLorentzVector * dummy = new TLorentzVector(0, 0, 0, 0);    // 4-vector
-  fParticlesModel->AddParticle(dummy,
+  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,  // type
                                "hadronic b quark",            // name
                                0,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic b quark",
                                1,                             // index of corresponding particle
                                KLFitter::Particles::kB);      // b jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 1",
                                2,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "light quark 2",
                                3,                             // index of corresponding particle
                                KLFitter::Particles::kLight);  // light jet (truth)
 
   if (fTypeLepton == kElectron) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron");
   } else if (fTypeLepton == kMuon) {
-    fParticlesModel->AddParticle(dummy,
+    fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon");
   }
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kNeutrino,
                                "neutrino");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "hadronic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kBoson,
                                "leptonic W");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "hadronic top");
 
-  fParticlesModel->AddParticle(dummy,
+  fParticlesModel->AddParticle(&dummy,
                                KLFitter::Particles::kParton,
                                "leptonic top");
-
-  // free memory
-  delete dummy;
 
   // no error
   return 1;

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -91,14 +91,8 @@ void KLFitter::LikelihoodTopLeptonJets_JetAngles::SetLeptonType(int leptontype) 
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets_JetAngles::DefineModelParticles() {
-  // check if model particles and lorentz vector container exist and delete
-  if (fParticlesModel) {
-    delete fParticlesModel;
-    fParticlesModel = 0;
-  }
-
   // create the particles of the model
-  fParticlesModel = new KLFitter::Particles();
+  fParticlesModel.reset(new KLFitter::Particles{});
 
   // add model particles
   // create dummy TLorentzVector

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -167,8 +167,8 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::DefineModelParticles() {
 // ---------------------------------------------------------
 void KLFitter::LikelihoodTopLeptonJets_JetAngles::DefineParameters() {
   // add parameters of model
-  AddParameter("energy hadronic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBhadE
-  AddParameter("energy leptonic b",       fPhysicsConstants->MassBottom(), 1000.0);  // parBlepE
+  AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
+  AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
   AddParameter("energy light quark 1",    0.0, 1000.0);                              // parLQ1E
   AddParameter("energy light quark 2",    0.0, 1000.0);                              // parLQ2E
   AddParameter("energy lepton",           0.0, 1000.0);                              // parLepE
@@ -330,7 +330,7 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   double nsigmas_met    = fFlagGetParSigmasFromTFs ? 10 : 1;
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
-  double m = fPhysicsConstants->MassBottom();
+  double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double sigma = fFlagGetParSigmasFromTFs ? (*fDetector)->ResEnergyBJet((*fParticlesPermuted)->DetEta(0, KLFitter::Particles::kParton))->GetSigma(E) : sqrt(E);
@@ -339,7 +339,7 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   SetParameterRange(parBhadE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
-  m = fPhysicsConstants->MassBottom();
+  m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass)
     m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   sigma = fFlagGetParSigmasFromTFs ? (*fDetector)->ResEnergyBJet((*fParticlesPermuted)->DetEta(1, KLFitter::Particles::kParton))->GetSigma(E) : sqrt(E);
@@ -430,7 +430,7 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   SetParameterRange(parLQ2Phi, phimin, phimax);
 
   if (fFlagTopMassFixed)
-    SetParameterRange(parTopM, fPhysicsConstants->MassTop(), fPhysicsConstants->MassTop());
+    SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
   // no error
   return 1;
@@ -498,12 +498,12 @@ double KLFitter::LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vec
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
   logprob += BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW);
@@ -662,7 +662,7 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::SavePermutedParticles() {
   bhad_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   bhad_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   bhad_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants->MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
+  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
   bhad_meas_p      = sqrt(bhad_meas_e*bhad_meas_e - bhad_meas_m*bhad_meas_m);
 
   blep_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
@@ -670,7 +670,7 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::SavePermutedParticles() {
   blep_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
   blep_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
   blep_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
-  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants->MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
+  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
   blep_meas_p      = sqrt(blep_meas_e*blep_meas_e - blep_meas_m*blep_meas_m);
 
   lq1_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
@@ -816,12 +816,12 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets_JetAngles::LogLikelihoodCo
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
-  double massW = fPhysicsConstants->MassW();
-  double gammaW = fPhysicsConstants->GammaW();
+  double massW = fPhysicsConstants.MassW();
+  double gammaW = fPhysicsConstants.GammaW();
   // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants->SetMassTop(parameters[parTopM]);
+  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
   // (this will also set the correct width for the top)
-  double gammaTop = fPhysicsConstants->GammaTop();
+  double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
   vecci.push_back(BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW));  // comp7


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As e.g. #24 did before, this PR removes all raw pointers from the likelihood classes (that is, raw pointers allocating heap memory, not _all_ raw pointers). In particular, the `fPhysicsConstants` object, member of LikelihoodBase, now became a "proper" object, instead of a pointer, because it only gets initialised once during run time. `fParticlesModel` was converted from a raw pointer into a unique pointer that takes care of memory management automatically. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#16 (remove all raw pointers from the code)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Less dereferencing necessary, clearer ownership and memory management rules.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled and tested with example binaries.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
