### PR TITLE
New btagging option

### DIFF
--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -53,6 +53,7 @@ class LikelihoodBase : public BCModel {
     kVetoNoFit,
     kVetoNoFitLight,
     kVetoNoFitBoth,
+    kVetoHybridNoFit,
     kWorkingPoint,
     kVetoLight,
     kVetoBoth

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -65,6 +65,11 @@ class Particles final {
   Particles();
 
   /**
+    * The copy constructor
+    */
+  Particles(const Particles& obj);
+
+  /**
     * The default destructor.
     */
   ~Particles();

--- a/include/KLFitter/Permutations.h
+++ b/include/KLFitter/Permutations.h
@@ -53,9 +53,19 @@ class Permutations final {
   Permutations(KLFitter::Particles** p, KLFitter::Particles** pp);
 
   /**
+    * Copy constructor
+    */
+  Permutations(const Permutations& obj);
+
+  /**
     * The default destructor.
     */
   ~Permutations();
+
+  /**
+    * Assignment operator
+    */
+  Permutations& operator=(const Permutations& obj);
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -28,6 +28,72 @@ KLFitter::Particles::Particles() {
 }
 
 // ---------------------------------------------------------
+KLFitter::Particles::Particles(const KLFitter::Particles& obj) :
+  fPartons(std::vector<std::unique_ptr<TLorentzVector> >(0)),
+  fElectrons(std::vector<std::unique_ptr<TLorentzVector> >(0)),
+  fMuons(std::vector<std::unique_ptr<TLorentzVector> >(0)),
+  fTaus(std::vector<std::unique_ptr<TLorentzVector> >(0)),
+  fNeutrinos(std::vector<std::unique_ptr<TLorentzVector> >(0)),
+  fBosons(std::vector<std::unique_ptr<TLorentzVector> >(0)),
+  fPhotons(std::vector<std::unique_ptr<TLorentzVector> >(0)),
+
+  fNamePartons(std::vector<std::string>(obj.fNamePartons)),
+  fNameElectrons(std::vector<std::string>(obj.fNameElectrons)),
+  fNameMuons(std::vector<std::string>(obj.fNameMuons)),
+  fNameTaus(std::vector<std::string>(obj.fNameTaus)),
+  fNameNeutrinos(std::vector<std::string>(obj.fNameNeutrinos)),
+  fNameBosons(std::vector<std::string>(obj.fNameBosons)),
+  fNamePhotons(std::vector<std::string>(obj.fNamePhotons)),
+
+  fJetIndex(std::vector<int>(obj.fJetIndex)),
+  fElectronIndex(std::vector<int>(obj.fElectronIndex)),
+  fMuonIndex(std::vector<int>(obj.fMuonIndex)),
+  fPhotonIndex(std::vector<int>(obj.fPhotonIndex)),
+
+  fTrueFlavor(std::vector<TrueFlavorType>(obj.fTrueFlavor)),
+  fIsBTagged(std::vector<bool>(obj.fIsBTagged)),
+  fBTaggingEfficiency(std::vector<double>(obj.fBTaggingEfficiency)),
+  fBTaggingRejection(std::vector<double>(obj.fBTaggingRejection)),
+
+  fBTagWeight(std::vector<double>(obj.fBTagWeight)),
+  fBTagWeightSet(std::vector<bool>(obj.fBTagWeightSet)),
+
+  fElectronDetEta(std::vector<double>(obj.fElectronDetEta)),
+  fMuonDetEta(std::vector<double>(obj.fMuonDetEta)),
+  fJetDetEta(std::vector<double>(obj.fJetDetEta)),
+  fPhotonDetEta(std::vector<double>(obj.fPhotonDetEta)),
+  fElectronCharge(std::vector<float>(obj.fElectronCharge)),
+  fMuonCharge(std::vector<float>(obj.fMuonCharge)) {
+  for (const auto& ipar : obj.fPartons){
+    fPartons.emplace_back(new TLorentzVector(*ipar));
+  }
+
+  for (const auto& ipar : obj.fElectrons){
+    fElectrons.emplace_back(new TLorentzVector(*ipar));
+  }
+
+  for (const auto& ipar : obj.fMuons){
+    fMuons.emplace_back(new TLorentzVector(*ipar));
+  }
+
+  for (const auto& ipar : obj.fTaus){
+    fTaus.emplace_back(new TLorentzVector(*ipar));
+  }
+
+  for (const auto& ipar : obj.fNeutrinos){
+    fNeutrinos.emplace_back(new TLorentzVector(*ipar));
+  }
+
+  for (const auto& ipar : obj.fBosons){
+    fBosons.emplace_back(new TLorentzVector(*ipar));
+  }
+
+  for (const auto& ipar : obj.fPhotons){
+    fPhotons.emplace_back(new TLorentzVector(*ipar));
+  }
+}
+
+// ---------------------------------------------------------
 KLFitter::Particles::~Particles() {
 }
 

--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -37,9 +37,94 @@ KLFitter::Permutations::Permutations(KLFitter::Particles ** p, KLFitter::Particl
 }
 
 // ---------------------------------------------------------
+KLFitter::Permutations::Permutations(const KLFitter::Permutations& obj)
+  : fParticles(obj.fParticles),
+    fParticlesPermuted(obj.fParticlesPermuted),
+    fParticlesTable(new std::vector<KLFitter::Particles*>(0)),
+    fPermutationTable(new std::vector<std::vector<int>*>(0)),
+    fPermutationIndex(obj.fPermutationIndex),
+    fTablePartons(new std::vector<std::vector<int>*>(0)),
+    fTableElectrons(new std::vector<std::vector<int>*>(0)),
+    fTableMuons(new std::vector<std::vector<int>*>(0)),
+    fTablePhotons(new std::vector<std::vector<int>*>(0)) {
+  for (const auto& ivec : *obj.fParticlesTable) {
+    fParticlesTable->emplace_back(new KLFitter::Particles(*ivec));
+  }
+
+  for (const auto& ivec : *obj.fPermutationTable) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fPermutationTable->emplace_back(tmp);
+  }
+
+  for (const auto& ivec : *obj.fTablePartons) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fTablePartons->emplace_back(tmp);
+  }
+
+  for (const auto& ivec : *obj.fTableElectrons) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fTableElectrons->emplace_back(tmp);
+  }
+
+  for (const auto& ivec : *obj.fTableMuons) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fTableMuons->emplace_back(tmp);
+  }
+
+  for (const auto& ivec : *obj.fTablePhotons) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fTablePhotons->emplace_back(tmp);
+  }
+}
+
+// ---------------------------------------------------------
 KLFitter::Permutations::~Permutations() {
   // delete particles and permutations tables
   Reset();
+}
+
+// ---------------------------------------------------------
+KLFitter::Permutations& KLFitter::Permutations::operator=(const KLFitter::Permutations& obj) {
+  fParticles = obj.fParticles;
+  fParticlesPermuted = obj.fParticlesPermuted;
+  fPermutationIndex = obj.fPermutationIndex;
+
+  fParticlesTable = new std::vector<KLFitter::Particles*>(0);
+  for (const auto& ivec : *obj.fParticlesTable) {
+    fParticlesTable->emplace_back(new KLFitter::Particles(*ivec));
+  }
+
+  fPermutationTable = new std::vector<std::vector<int>*>(0);
+  for (const auto& ivec : *obj.fPermutationTable) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fPermutationTable->emplace_back(tmp);
+  }
+
+  fTablePartons = new std::vector<std::vector<int>*>(0);
+  for (const auto& ivec : *obj.fTablePartons) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fTablePartons->emplace_back(tmp);
+  }
+
+  fTableElectrons = new std::vector<std::vector<int>*>(0);
+  for (const auto& ivec : *obj.fTableElectrons) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fTableElectrons->emplace_back(tmp);
+  }
+
+  fTableMuons = new std::vector<std::vector<int>*>(0);
+  for (const auto& ivec : *obj.fTableMuons) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fTableMuons->emplace_back(tmp);
+  }
+
+  fTablePhotons = new std::vector<std::vector<int>*>(0);
+  for (const auto& ivec : *obj.fTablePhotons) {
+    std::vector<int> *tmp = new std::vector<int>(*ivec);
+    fTablePhotons->emplace_back(tmp);
+  }
+
+  return *this;
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
New b-tagging option: kVetoHybridNoFit

## Description
Added new option for btagging, works like kVetoNoFit unless there are 0 allowed permutations, then it switches to kVetoNoFitLight. This will work on all events.

Technically copy constructors and assignment operators had to be introduced for Particles and Permutations classes.

## How Has This Been Tested?
Tested on the standard example code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
