### PR TITLE
Clean-up of the classes Particles and Permutations

### DIFF
--- a/include/KLFitter/Fitter.h
+++ b/include/KLFitter/Fitter.h
@@ -71,21 +71,18 @@ class Fitter final {
     * @return A pointer to the particles.
     */
   KLFitter::Particles * Particles() { return fParticles; }
-  KLFitter::Particles ** PParticles() { return &fParticles; }
 
   /**
     * Return the permutation object.
     * @return A pointer to the permutation object.
     **/
   KLFitter::Permutations * Permutations() { return fPermutations; }
-  KLFitter::Permutations ** PPermutations() { return &fPermutations; }
 
   /**
     * Return the lieklihood .
     * @return A pointer to the likelihood object.
     **/
   KLFitter::LikelihoodBase * Likelihood() { return fLikelihood; }
-  KLFitter::LikelihoodBase ** PLikelihood() { return &fLikelihood; }
 
   /**
     * Return the Minuit status

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -163,13 +163,6 @@ class LikelihoodBase : public BCModel {
   int SetParticlesPermuted(KLFitter::Particles** particles);
 
   /**
-    * Set the truth particles.
-    * @param particles The truth particles.
-    * @return An error flag.
-    */
-  int SetMyParticlesTruth(KLFitter::Particles** particles);
-
-  /**
     * Set the values for the missing ET x and y components and the SumET.
     * @param etx missing ET x component.
     * @param ety missing ET y component.
@@ -478,11 +471,6 @@ class LikelihoodBase : public BCModel {
     * A pointer to the model particles.
     */
   std::unique_ptr<KLFitter::Particles> fParticlesModel;
-
-  /**
-    * A pointer to the measured particles.
-    */
-  KLFitter::Particles** fMyParticlesTruth;
 
   /**
     * A pointer to the table of physics constants

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -65,6 +65,11 @@ class Particles final {
   Particles();
 
   /**
+    * The copy constructor.
+    */
+  explicit Particles(const Particles& o);
+
+  /**
     * The default destructor.
     */
   ~Particles();

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -74,6 +74,11 @@ class Particles final {
     */
   ~Particles();
 
+  /**
+   * The assignment operator.
+   */
+  Particles& operator=(const Particles& o);
+
   /* @} */
   /** \name Member functions (Get)  */
   /* @{ */

--- a/include/KLFitter/Permutations.h
+++ b/include/KLFitter/Permutations.h
@@ -77,7 +77,7 @@ class Permutations final {
     * Return the permutation table.
     * @return A pointer to the permutation table.
     */
-  std::vector<std::vector<int>* >* PermutationTable();
+  std::vector<std::vector<int> >* PermutationTable();
 
   /**
     * Return the number of permutations.
@@ -208,7 +208,7 @@ class Permutations final {
   /**
     * A table of permutations. Needed for the math.
     */
-  std::vector < std::vector <int>*>* fPermutationTable;
+  std::vector<std::vector<int> > fPermutationTable;
 
   /**
     * The permutation index

--- a/include/KLFitter/Permutations.h
+++ b/include/KLFitter/Permutations.h
@@ -55,7 +55,7 @@ class Permutations final {
   /**
     * The (defaulted) copy constructor.
     */
-  explicit Permutations(const Permutations& o) = default;
+  explicit Permutations(const Permutations& o);
 
   /**
     * The (defaulted) destructor.
@@ -65,7 +65,7 @@ class Permutations final {
   /**
     * The (defaulted) assignment operator.
     */
-  Permutations& operator=(const Permutations& obj) = default;
+  Permutations& operator=(const Permutations& obj);
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/Permutations.h
+++ b/include/KLFitter/Permutations.h
@@ -90,13 +90,13 @@ class Permutations final {
     */
   int PermutationIndex() { return fPermutationIndex; }
 
-  std::vector<std::vector<int>*>* TablePartons() { return fTablePartons; }
+  std::vector<std::vector<int> >* TablePartons() { return &fTablePartons; }
 
-  std::vector<std::vector<int>*>* TableElectrons() { return fTableElectrons; }
+  std::vector<std::vector<int> >* TableElectrons() { return &fTableElectrons; }
 
-  std::vector<std::vector<int>*>* TableMuons() { return fTableMuons; }
+  std::vector<std::vector<int> >* TableMuons() { return &fTableMuons; }
 
-  std::vector<std::vector<int>*>* TablePhotons() { return fTablePhotons; }
+  std::vector<std::vector<int> >* TablePhotons() { return &fTablePhotons; }
 
   /* @} */
   /** \name Member functions (Set)  */
@@ -171,7 +171,7 @@ class Permutations final {
   /**
     * Creates table of permutations.
     */
-  int CreateSubTable(int Nobj,  std::vector<std::vector<int>*>* table, int Nmax = -1);
+  int CreateSubTable(int Nobj, std::vector<std::vector<int> >* table, int Nmax = -1);
 
   /* @} */
 
@@ -215,10 +215,10 @@ class Permutations final {
     */
   int fPermutationIndex;
 
-  std::vector<std::vector<int>*>* fTablePartons;
-  std::vector<std::vector<int>*>* fTableElectrons;
-  std::vector<std::vector<int>*>* fTableMuons;
-  std::vector<std::vector<int>*>* fTablePhotons;
+  std::vector<std::vector<int> > fTablePartons;
+  std::vector<std::vector<int> > fTableElectrons;
+  std::vector<std::vector<int> > fTableMuons;
+  std::vector<std::vector<int> > fTablePhotons;
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/Permutations.h
+++ b/include/KLFitter/Permutations.h
@@ -53,9 +53,19 @@ class Permutations final {
   Permutations(KLFitter::Particles** p, KLFitter::Particles** pp);
 
   /**
+    * The (defaulted) copy constructor.
+    */
+  explicit Permutations(const Permutations& o) = default;
+
+  /**
     * The default destructor.
     */
   ~Permutations();
+
+  /**
+    * The (defaulted) assignment operator.
+    */
+  Permutations& operator=(const Permutations& obj) = default;
 
   /* @} */
   /** \name Member functions (Get)  */

--- a/include/KLFitter/Permutations.h
+++ b/include/KLFitter/Permutations.h
@@ -58,7 +58,7 @@ class Permutations final {
   explicit Permutations(const Permutations& o) = default;
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~Permutations();
 

--- a/include/KLFitter/Permutations.h
+++ b/include/KLFitter/Permutations.h
@@ -82,7 +82,7 @@ class Permutations final {
   /**
     * Return the number of permutations.
     */
-  int NPermutations() { return static_cast<int>(fParticlesTable -> size()); }
+  int NPermutations() { return static_cast<int>(fParticlesTable.size()); }
 
   /**
     * Return the current permutation index.
@@ -183,7 +183,7 @@ class Permutations final {
 
  private:
   /**
-    * Helper functions to efficienctly create permutations of N particles of only M selected particles.
+    * Helper functions to efficiently create permutations of N particles of only M selected particles.
     */
 
   std::vector<int> Get_int_vector(int i);
@@ -203,7 +203,7 @@ class Permutations final {
   /**
     * A table of permuted particles (jets and leptons).
     */
-  std::vector <KLFitter::Particles*>* fParticlesTable;
+  std::vector<KLFitter::Particles> fParticlesTable;
 
   /**
     * A table of permutations. Needed for the math.

--- a/src/Fitter.cxx
+++ b/src/Fitter.cxx
@@ -84,9 +84,6 @@ int KLFitter::Fitter::SetParticles(KLFitter::Particles * particles, int nPartons
 int KLFitter::Fitter::SetMyParticlesTruth(KLFitter::Particles * particles) {
   fMyParticlesTruth = particles;
 
-  // set pointer to truth particles
-  fLikelihood->SetMyParticlesTruth(&fMyParticlesTruth);
-
   // no error
   return 1;
 }

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -34,7 +34,6 @@
 KLFitter::LikelihoodBase::LikelihoodBase(Particles** particles) : BCModel(),
                                                                   fParticlesPermuted(particles),
                                                                   fPermutations(0),
-                                                                  fMyParticlesTruth(0),
                                                                   fDetector(0),
                                                                   fEventProbability(std::vector<double>(0)),
                                                                   fFlagIntegrate(0),
@@ -128,15 +127,6 @@ int KLFitter::LikelihoodBase::SetDetector(KLFitter::DetectorBase** detector) {
 int KLFitter::LikelihoodBase::SetParticlesPermuted(KLFitter::Particles** particles) {
   // set pointer to pointer of permuted particles
   fParticlesPermuted  = particles;
-
-  // no error
-  return 1;
-}
-
-// ---------------------------------------------------------
-int KLFitter::LikelihoodBase::SetMyParticlesTruth(KLFitter::Particles** particles) {
-  // set pointer to pointer of truth particles
-  fMyParticlesTruth  = particles;
 
   // no error
   return 1;

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -28,14 +28,6 @@ KLFitter::Particles::Particles() = default;
 
 // ---------------------------------------------------------
 KLFitter::Particles::Particles(const KLFitter::Particles& o) :
-    fPartons(std::vector<std::unique_ptr<TLorentzVector> >{}),
-    fElectrons(std::vector<std::unique_ptr<TLorentzVector> >{}),
-    fMuons(std::vector<std::unique_ptr<TLorentzVector> >{}),
-    fTaus(std::vector<std::unique_ptr<TLorentzVector> >{}),
-    fNeutrinos(std::vector<std::unique_ptr<TLorentzVector> >{}),
-    fBosons(std::vector<std::unique_ptr<TLorentzVector> >{}),
-    fPhotons(std::vector<std::unique_ptr<TLorentzVector> >{}),
-
     fNamePartons(std::vector<std::string>{o.fNamePartons}),
     fNameElectrons(std::vector<std::string>{o.fNameElectrons}),
     fNameMuons(std::vector<std::string>{o.fNameMuons}),

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -28,6 +28,70 @@ KLFitter::Particles::Particles() {
 }
 
 // ---------------------------------------------------------
+KLFitter::Particles::Particles(const KLFitter::Particles& o) :
+    fPartons(std::vector<std::unique_ptr<TLorentzVector> >{}),
+    fElectrons(std::vector<std::unique_ptr<TLorentzVector> >{}),
+    fMuons(std::vector<std::unique_ptr<TLorentzVector> >{}),
+    fTaus(std::vector<std::unique_ptr<TLorentzVector> >{}),
+    fNeutrinos(std::vector<std::unique_ptr<TLorentzVector> >{}),
+    fBosons(std::vector<std::unique_ptr<TLorentzVector> >{}),
+    fPhotons(std::vector<std::unique_ptr<TLorentzVector> >{}),
+
+    fNamePartons(std::vector<std::string>{o.fNamePartons}),
+    fNameElectrons(std::vector<std::string>{o.fNameElectrons}),
+    fNameMuons(std::vector<std::string>{o.fNameMuons}),
+    fNameTaus(std::vector<std::string>{o.fNameTaus}),
+    fNameNeutrinos(std::vector<std::string>{o.fNameNeutrinos}),
+    fNameBosons(std::vector<std::string>{o.fNameBosons}),
+    fNamePhotons(std::vector<std::string>{o.fNamePhotons}),
+    fJetIndex(std::vector<int>{o.fJetIndex}),
+    fElectronIndex(std::vector<int>{o.fElectronIndex}),
+    fMuonIndex(std::vector<int>{o.fMuonIndex}),
+    fPhotonIndex(std::vector<int>{o.fPhotonIndex}),
+    fTrueFlavor(std::vector<TrueFlavorType>{o.fTrueFlavor}),
+    fIsBTagged(std::vector<bool>{o.fIsBTagged}),
+    fBTaggingEfficiency(std::vector<double>{o.fBTaggingEfficiency}),
+    fBTaggingRejection(std::vector<double>{o.fBTaggingRejection}),
+    fBTagWeight(std::vector<double>{o.fBTagWeight}),
+    fBTagWeightSet(std::vector<bool>{o.fBTagWeightSet}),
+    fElectronDetEta(std::vector<double>{o.fElectronDetEta}),
+    fMuonDetEta(std::vector<double>{o.fMuonDetEta}),
+    fJetDetEta(std::vector<double>{o.fJetDetEta}),
+    fPhotonDetEta(std::vector<double>{o.fPhotonDetEta}),
+    fElectronCharge(std::vector<float>{o.fElectronCharge}),
+    fMuonCharge(std::vector<float>{o.fMuonCharge}) {
+
+  // Make deep copies of the vectors of unique pointers.
+  for (const auto& i : o.fPartons) {
+    fPartons.emplace_back(new TLorentzVector{*i});
+  }
+
+  for (const auto& i : o.fElectrons) {
+    fElectrons.emplace_back(new TLorentzVector{*i});
+  }
+
+  for (const auto& i : o.fMuons) {
+    fMuons.emplace_back(new TLorentzVector{*i});
+  }
+
+  for (const auto& i : o.fTaus) {
+    fTaus.emplace_back(new TLorentzVector{*i});
+  }
+
+  for (const auto& i : o.fNeutrinos) {
+    fNeutrinos.emplace_back(new TLorentzVector{*i});
+  }
+
+  for (const auto& i : o.fBosons) {
+    fBosons.emplace_back(new TLorentzVector{*i});
+  }
+
+  for (const auto& i : o.fPhotons) {
+    fPhotons.emplace_back(new TLorentzVector{*i});
+  }
+}
+
+// ---------------------------------------------------------
 KLFitter::Particles::~Particles() {
 }
 

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -96,6 +96,72 @@ KLFitter::Particles::~Particles() {
 }
 
 // ---------------------------------------------------------
+KLFitter::Particles& KLFitter::Particles::operator=(const KLFitter::Particles& o) {
+  fNamePartons = o.fNamePartons;
+  fNameElectrons = o.fNameElectrons;
+  fNameMuons = o.fNameMuons;
+  fNameTaus = o.fNameTaus;
+  fNameNeutrinos = o.fNameNeutrinos;
+  fNameBosons = o.fNameBosons;
+  fNamePhotons = o.fNamePhotons;
+
+  fJetIndex = o.fJetIndex;
+  fElectronIndex = o.fElectronIndex;
+  fMuonIndex = o.fMuonIndex;
+  fPhotonIndex = o.fPhotonIndex;
+  fTrueFlavor = o.fTrueFlavor;
+  fIsBTagged = o.fIsBTagged;
+  fBTaggingEfficiency = o.fBTaggingEfficiency;
+  fBTaggingRejection = o.fBTaggingRejection;
+  fBTagWeight = o.fBTagWeight;
+  fBTagWeightSet = o.fBTagWeightSet;
+  fElectronDetEta = o.fElectronDetEta;
+  fMuonDetEta = o.fMuonDetEta;
+  fJetDetEta = o.fJetDetEta;
+  fPhotonDetEta = o.fPhotonDetEta;
+  fElectronCharge = o.fElectronCharge;
+  fMuonCharge = o.fMuonCharge;
+
+  // Make deep copies of the vectors of unique pointers.
+  fPartons = std::vector<std::unique_ptr<TLorentzVector> >(o.fPartons.size());
+  for (const auto& i : o.fPartons) {
+    fPartons.emplace_back(new TLorentzVector{*i});
+  }
+
+  fElectrons = std::vector<std::unique_ptr<TLorentzVector> >(o.fElectrons.size());
+  for (const auto& i : o.fElectrons) {
+    fElectrons.emplace_back(new TLorentzVector{*i});
+  }
+
+  fMuons = std::vector<std::unique_ptr<TLorentzVector> >(o.fMuons.size());
+  for (const auto& i : o.fMuons) {
+    fMuons.emplace_back(new TLorentzVector{*i});
+  }
+
+  fTaus = std::vector<std::unique_ptr<TLorentzVector> >(o.fTaus.size());
+  for (const auto& i : o.fTaus) {
+    fTaus.emplace_back(new TLorentzVector{*i});
+  }
+
+  fNeutrinos = std::vector<std::unique_ptr<TLorentzVector> >(o.fNeutrinos.size());
+  for (const auto& i : o.fNeutrinos) {
+    fNeutrinos.emplace_back(new TLorentzVector{*i});
+  }
+
+  fBosons = std::vector<std::unique_ptr<TLorentzVector> >(o.fBosons.size());
+  for (const auto& i : o.fBosons) {
+    fBosons.emplace_back(new TLorentzVector{*i});
+  }
+
+  fPhotons = std::vector<std::unique_ptr<TLorentzVector> >(o.fPhotons.size());
+  for (const auto& i : o.fPhotons) {
+    fPhotons.emplace_back(new TLorentzVector{*i});
+  }
+
+  return *this;
+}
+
+// ---------------------------------------------------------
 int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex) {
   // get particle container
   auto container = ParticleContainer(ptype);

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -113,37 +113,44 @@ KLFitter::Particles& KLFitter::Particles::operator=(const KLFitter::Particles& o
   fMuonCharge = o.fMuonCharge;
 
   // Make deep copies of the vectors of unique pointers.
-  fPartons = std::vector<std::unique_ptr<TLorentzVector> >(o.fPartons.size());
+  fPartons = std::vector<std::unique_ptr<TLorentzVector> >{};
+  fPartons.reserve(o.fPartons.size());
   for (const auto& i : o.fPartons) {
     fPartons.emplace_back(new TLorentzVector{*i});
   }
 
-  fElectrons = std::vector<std::unique_ptr<TLorentzVector> >(o.fElectrons.size());
+  fElectrons = std::vector<std::unique_ptr<TLorentzVector> >{};
+  fElectrons.reserve(o.fElectrons.size());
   for (const auto& i : o.fElectrons) {
     fElectrons.emplace_back(new TLorentzVector{*i});
   }
 
-  fMuons = std::vector<std::unique_ptr<TLorentzVector> >(o.fMuons.size());
+  fMuons = std::vector<std::unique_ptr<TLorentzVector> >{};
+  fMuons.reserve(o.fMuons.size());
   for (const auto& i : o.fMuons) {
     fMuons.emplace_back(new TLorentzVector{*i});
   }
 
-  fTaus = std::vector<std::unique_ptr<TLorentzVector> >(o.fTaus.size());
+  fTaus = std::vector<std::unique_ptr<TLorentzVector> >{};
+  fTaus.reserve(o.fTaus.size());
   for (const auto& i : o.fTaus) {
     fTaus.emplace_back(new TLorentzVector{*i});
   }
 
-  fNeutrinos = std::vector<std::unique_ptr<TLorentzVector> >(o.fNeutrinos.size());
+  fNeutrinos = std::vector<std::unique_ptr<TLorentzVector> >{};
+  fNeutrinos.reserve(o.fNeutrinos.size());
   for (const auto& i : o.fNeutrinos) {
     fNeutrinos.emplace_back(new TLorentzVector{*i});
   }
 
-  fBosons = std::vector<std::unique_ptr<TLorentzVector> >(o.fBosons.size());
+  fBosons = std::vector<std::unique_ptr<TLorentzVector> >{};
+  fBosons.reserve(o.fBosons.size());
   for (const auto& i : o.fBosons) {
     fBosons.emplace_back(new TLorentzVector{*i});
   }
 
-  fPhotons = std::vector<std::unique_ptr<TLorentzVector> >(o.fPhotons.size());
+  fPhotons = std::vector<std::unique_ptr<TLorentzVector> >{};
+  fPhotons.reserve(o.fPhotons.size());
   for (const auto& i : o.fPhotons) {
     fPhotons.emplace_back(new TLorentzVector{*i});
   }

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -24,8 +24,7 @@
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------
-KLFitter::Particles::Particles() {
-}
+KLFitter::Particles::Particles() = default;
 
 // ---------------------------------------------------------
 KLFitter::Particles::Particles(const KLFitter::Particles& o) :
@@ -92,8 +91,7 @@ KLFitter::Particles::Particles(const KLFitter::Particles& o) :
 }
 
 // ---------------------------------------------------------
-KLFitter::Particles::~Particles() {
-}
+KLFitter::Particles::~Particles() = default;
 
 // ---------------------------------------------------------
 KLFitter::Particles& KLFitter::Particles::operator=(const KLFitter::Particles& o) {

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -53,30 +53,37 @@ KLFitter::Particles::Particles(const KLFitter::Particles& o) :
     fMuonCharge(std::vector<float>{o.fMuonCharge}) {
 
   // Make deep copies of the vectors of unique pointers.
+  fPartons.reserve(o.fPartons.size());
   for (const auto& i : o.fPartons) {
     fPartons.emplace_back(new TLorentzVector{*i});
   }
 
+  fElectrons.reserve(o.fElectrons.size());
   for (const auto& i : o.fElectrons) {
     fElectrons.emplace_back(new TLorentzVector{*i});
   }
 
+  fMuons.reserve(o.fMuons.size());
   for (const auto& i : o.fMuons) {
     fMuons.emplace_back(new TLorentzVector{*i});
   }
 
+  fTaus.reserve(o.fTaus.size());
   for (const auto& i : o.fTaus) {
     fTaus.emplace_back(new TLorentzVector{*i});
   }
 
+  fNeutrinos.reserve(o.fNeutrinos.size());
   for (const auto& i : o.fNeutrinos) {
     fNeutrinos.emplace_back(new TLorentzVector{*i});
   }
 
+  fBosons.reserve(o.fBosons.size());
   for (const auto& i : o.fBosons) {
     fBosons.emplace_back(new TLorentzVector{*i});
   }
 
+  fPhotons.reserve(o.fPhotons.size());
   for (const auto& i : o.fPhotons) {
     fPhotons.emplace_back(new TLorentzVector{*i});
   }

--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -32,7 +32,13 @@ KLFitter::Permutations::Permutations(KLFitter::Particles ** p, KLFitter::Particl
 }
 
 // ---------------------------------------------------------
+KLFitter::Permutations::Permutations(const Permutations& o) = default;
+
+// ---------------------------------------------------------
 KLFitter::Permutations::~Permutations() = default;
+
+// ---------------------------------------------------------
+KLFitter::Permutations& KLFitter::Permutations::operator=(const KLFitter::Permutations& obj) = default;
 
 // ---------------------------------------------------------
 int KLFitter::Permutations::SetPermutation(int index) {

--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -32,8 +32,6 @@ KLFitter::Permutations::Permutations(KLFitter::Particles ** p, KLFitter::Particl
 
 // ---------------------------------------------------------
 KLFitter::Permutations::~Permutations() {
-  // delete particles and permutations tables
-  Reset();
 }
 
 // ---------------------------------------------------------
@@ -238,10 +236,8 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
 
 // ---------------------------------------------------------
 int KLFitter::Permutations::Reset() {
-  // delete table of particles
+  // Clear particle and permutation tables.
   fParticlesTable.clear();
-
-  // delete permutation table
   fPermutationTable.clear();
 
   // no error

--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -24,15 +24,15 @@
 #include <set>
 
 // ---------------------------------------------------------
-KLFitter::Permutations::Permutations(KLFitter::Particles ** p, KLFitter::Particles ** pp) {
-  fParticles = p;
-  fParticlesPermuted = pp;
-  fPermutationIndex = -1;
+KLFitter::Permutations::Permutations(KLFitter::Particles ** p, KLFitter::Particles ** pp) :
+    fParticles(p),
+    fParticlesPermuted(pp),
+    fPermutationIndex(-1) {
+  // empty
 }
 
 // ---------------------------------------------------------
-KLFitter::Permutations::~Permutations() {
-}
+KLFitter::Permutations::~Permutations() = default;
 
 // ---------------------------------------------------------
 int KLFitter::Permutations::SetPermutation(int index) {

--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -27,7 +27,6 @@
 KLFitter::Permutations::Permutations(KLFitter::Particles ** p, KLFitter::Particles ** pp) {
   fParticles = p;
   fParticlesPermuted = pp;
-  fParticlesTable = new std::vector <KLFitter::Particles *>(0);
   fPermutationIndex = -1;
 }
 
@@ -40,7 +39,7 @@ KLFitter::Permutations::~Permutations() {
 // ---------------------------------------------------------
 int KLFitter::Permutations::SetPermutation(int index) {
   // check if permutation table exists
-  if (!fParticlesTable) {
+  if (fParticlesTable.empty()) {
     std::cout << "KLFitter::Permutations::SetPermutation(). Table does not exist yet." << std::endl;
     return 0;
   }
@@ -57,7 +56,7 @@ int KLFitter::Permutations::SetPermutation(int index) {
   }
 
   // set permutation
-  (*fParticlesPermuted) = (*fParticlesTable)[index];
+  (*fParticlesPermuted) = &fParticlesTable[index];
 
   // set permutation index
   fPermutationIndex = index;
@@ -72,8 +71,7 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
   Reset();
 
   // create new table of particles
-  if (!fParticlesTable)
-    fParticlesTable = new std::vector <KLFitter::Particles *>(0);
+  fParticlesTable = std::vector<KLFitter::Particles>{};
 
   // create new table of permutations
   fPermutationTable = std::vector<std::vector<int> >{};
@@ -128,7 +126,7 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
         // loop over all photon permutations
         for (int ipermphoton = 0; ipermphoton < npermphotons; ++ipermphoton) {
           // create new particles
-          KLFitter::Particles * particles = new KLFitter::Particles();
+          KLFitter::Particles particles{};
 
           // create new permutation
           std::vector<int> permutation(npermoverall);
@@ -139,16 +137,16 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
             int index = fTablePartons[ipermparton][i];
 
             // add parton
-            particles->AddParticle((*fParticles)->Parton(index),
-                                   (*fParticles)->DetEta(index, KLFitter::Particles::kParton),
-                                   KLFitter::Particles::kParton,
-                                   (*fParticles)->NameParticle(index, KLFitter::Particles::kParton),
-                                   (*fParticles)->JetIndex(index),
-                                   (*fParticles)->IsBTagged(index),
-                                   (*fParticles)->BTaggingEfficiency(index),
-                                   (*fParticles)->BTaggingRejection(index),
-                                   (*fParticles)->TrueFlavor(index),
-                                   (*fParticles)->BTagWeight(index));
+            particles.AddParticle((*fParticles)->Parton(index),
+                                  (*fParticles)->DetEta(index, KLFitter::Particles::kParton),
+                                  KLFitter::Particles::kParton,
+                                  (*fParticles)->NameParticle(index, KLFitter::Particles::kParton),
+                                  (*fParticles)->JetIndex(index),
+                                  (*fParticles)->IsBTagged(index),
+                                  (*fParticles)->BTaggingEfficiency(index),
+                                  (*fParticles)->BTaggingRejection(index),
+                                  (*fParticles)->TrueFlavor(index),
+                                  (*fParticles)->BTagWeight(index));
 
             // set permutation
             permutation[i] = index;
@@ -162,19 +160,19 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
             // if isDilepton include charge of the lepton
             if (isDilepton) {
               // add electron
-              particles->AddParticle((*fParticles)->Electron(index),
-                                     (*fParticles)->DetEta(index, KLFitter::Particles::kElectron),
-                                     (*fParticles)->LeptonCharge(index, KLFitter::Particles::kElectron),
-                                     KLFitter::Particles::kElectron,
-                                     (*fParticles)->NameParticle(index, KLFitter::Particles::kElectron),
-                                     (*fParticles)->ElectronIndex(index));
+              particles.AddParticle((*fParticles)->Electron(index),
+                                    (*fParticles)->DetEta(index, KLFitter::Particles::kElectron),
+                                    (*fParticles)->LeptonCharge(index, KLFitter::Particles::kElectron),
+                                    KLFitter::Particles::kElectron,
+                                    (*fParticles)->NameParticle(index, KLFitter::Particles::kElectron),
+                                    (*fParticles)->ElectronIndex(index));
             } else {
               // add electron
-              particles->AddParticle((*fParticles)->Electron(index),
-                                     (*fParticles)->DetEta(index, KLFitter::Particles::kElectron),
-                                     KLFitter::Particles::kElectron,
-                                     (*fParticles)->NameParticle(index, KLFitter::Particles::kElectron),
-                                     (*fParticles)->ElectronIndex(index));
+              particles.AddParticle((*fParticles)->Electron(index),
+                                    (*fParticles)->DetEta(index, KLFitter::Particles::kElectron),
+                                    KLFitter::Particles::kElectron,
+                                    (*fParticles)->NameParticle(index, KLFitter::Particles::kElectron),
+                                    (*fParticles)->ElectronIndex(index));
             }
 
             // set permutation
@@ -189,19 +187,19 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
             // if isDilepton include charge of the lepton
             if (isDilepton) {
               // add muon
-              particles->AddParticle((*fParticles)->Muon(index),
-                                     (*fParticles)->DetEta(index, KLFitter::Particles::kMuon),
-                                     (*fParticles)->LeptonCharge(index, KLFitter::Particles::kMuon),
-                                     KLFitter::Particles::kMuon,
-                                     (*fParticles)->NameParticle(index, KLFitter::Particles::kMuon),
-                                     (*fParticles)->MuonIndex(index));
+              particles.AddParticle((*fParticles)->Muon(index),
+                                    (*fParticles)->DetEta(index, KLFitter::Particles::kMuon),
+                                    (*fParticles)->LeptonCharge(index, KLFitter::Particles::kMuon),
+                                    KLFitter::Particles::kMuon,
+                                    (*fParticles)->NameParticle(index, KLFitter::Particles::kMuon),
+                                    (*fParticles)->MuonIndex(index));
             } else {
               // add muon
-              particles->AddParticle((*fParticles)->Muon(index),
-                                     (*fParticles)->DetEta(index, KLFitter::Particles::kMuon),
-                                     KLFitter::Particles::kMuon,
-                                     (*fParticles)->NameParticle(index, KLFitter::Particles::kMuon),
-                                     (*fParticles)->MuonIndex(index));
+              particles.AddParticle((*fParticles)->Muon(index),
+                                    (*fParticles)->DetEta(index, KLFitter::Particles::kMuon),
+                                    KLFitter::Particles::kMuon,
+                                    (*fParticles)->NameParticle(index, KLFitter::Particles::kMuon),
+                                    (*fParticles)->MuonIndex(index));
             }
 
             // set permutation
@@ -214,18 +212,18 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
             int index = fTablePhotons[ipermphoton][i];
 
             // add photon
-            particles->AddParticle((*fParticles)->Photon(index),
-                                   (*fParticles)->DetEta(index, KLFitter::Particles::kPhoton),
-                                   KLFitter::Particles::kPhoton,
-                                   (*fParticles)->NameParticle(index, KLFitter::Particles::kPhoton),
-                                   (*fParticles)->PhotonIndex(index));
+            particles.AddParticle((*fParticles)->Photon(index),
+                                  (*fParticles)->DetEta(index, KLFitter::Particles::kPhoton),
+                                  KLFitter::Particles::kPhoton,
+                                  (*fParticles)->NameParticle(index, KLFitter::Particles::kPhoton),
+                                  (*fParticles)->PhotonIndex(index));
 
             // set permutation
             permutation[npartonsPerm + nelectrons + nmuons + i] = index;
           }
 
           // add particles to table
-          fParticlesTable->push_back(particles);
+          fParticlesTable.emplace_back(particles);
 
           // add permutation to table
           fPermutationTable.emplace_back(permutation);
@@ -241,15 +239,7 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
 // ---------------------------------------------------------
 int KLFitter::Permutations::Reset() {
   // delete table of particles
-  if (fParticlesTable) {
-    while (!fParticlesTable->empty()) {
-      KLFitter::Particles * p = fParticlesTable->front();
-      fParticlesTable->erase(fParticlesTable->begin());
-      delete p;
-    }
-    delete fParticlesTable;
-    fParticlesTable = 0;
-  }
+  fParticlesTable.clear();
 
   // delete permutation table
   fPermutationTable.clear();
@@ -317,7 +307,7 @@ int KLFitter::Permutations::InvariantParticlePermutations(KLFitter::Particles::P
     indexVector.push_back(*it_indexSetBegin);
 
   // check particles table
-  if (!fParticlesTable) {
+  if (fParticlesTable.empty()) {
     std::cout << "KLFitter::Permutations::InvariantParticlePermutations(). Table does not exist yet." << std::endl;
     return 0;
   }
@@ -350,9 +340,7 @@ int KLFitter::Permutations::InvariantParticlePermutations(KLFitter::Particles::P
       if (permutation[index1] >= permutation[index2]) {
         fPermutationTable.erase(fPermutationTable.begin() + iperm);
 
-        KLFitter::Particles * p = (*fParticlesTable)[iperm];
-        fParticlesTable->erase(fParticlesTable->begin() + iperm);
-        delete p;
+        fParticlesTable.erase(fParticlesTable.begin() + iperm);
       }
     }
   } else {
@@ -426,7 +414,7 @@ int KLFitter::Permutations::InvariantParticleGroupPermutations(KLFitter::Particl
     indexVectorPosition1.push_back(*it_indexSetPosition1Begin);
 
   // check particles table
-  if (!fParticlesTable) {
+  if (fParticlesTable.empty()) {
     std::cout << "KLFitter::Permutations::InvariantParticleGroupPermutations(). Table does not exist yet." << std::endl;
     return 0;
   }
@@ -471,9 +459,7 @@ int KLFitter::Permutations::InvariantParticleGroupPermutations(KLFitter::Particl
       if (numberOfInvariantMatches == indexVectorPosition1.size()) {
         fPermutationTable.erase(fPermutationTable.begin() + iperm2);
 
-        KLFitter::Particles * p = (*fParticlesTable)[iperm2];
-        fParticlesTable->erase(fParticlesTable->begin() + iperm2);
-        delete p;
+        fParticlesTable.erase(fParticlesTable.begin() + iperm2);
       }
     }  // second permutation
   }  // first permutation
@@ -495,7 +481,7 @@ int KLFitter::Permutations::RemoveParticlePermutations(KLFitter::Particles::Part
   }
 
   // check particles table
-  if (!fParticlesTable) {
+  if (fParticlesTable.empty()) {
     std::cout << "KLFitter::Permutations::RemoveParticlePermutations(). Table does not exist yet." << std::endl;
     return 0;
   }
@@ -519,9 +505,7 @@ int KLFitter::Permutations::RemoveParticlePermutations(KLFitter::Particles::Part
     if (permutation[position] == index) {
       fPermutationTable.erase(fPermutationTable.begin() + iPerm);
 
-      KLFitter::Particles * p = (*fParticlesTable)[iPerm];
-      fParticlesTable->erase(fParticlesTable->begin() + iPerm);
-      delete p;
+      fParticlesTable.erase(fParticlesTable.begin() + iPerm);
     }
   }
 

--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -30,10 +30,6 @@ KLFitter::Permutations::Permutations(KLFitter::Particles ** p, KLFitter::Particl
   fParticlesTable = new std::vector <KLFitter::Particles *>(0);
   fPermutationTable = new std::vector < std::vector<int> *>(0);
   fPermutationIndex = -1;
-  fTablePartons = 0;
-  fTableElectrons = 0;
-  fTableMuons = 0;
-  fTablePhotons = 0;
 }
 
 // ---------------------------------------------------------
@@ -102,27 +98,27 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
     isDilepton = true;
 
   // create table for parton, electron, muon and photons permutations
-  fTablePartons = new std::vector < std::vector<int> * >(0);
-  CreateSubTable(npartons, fTablePartons, nPartonsInPermutations);
+  fTablePartons = std::vector<std::vector<int> >{};
+  CreateSubTable(npartons, &fTablePartons, nPartonsInPermutations);
 
-  fTableElectrons = new std::vector < std::vector<int> * >(0);
-  CreateSubTable(nelectrons, fTableElectrons);
+  fTableElectrons = std::vector<std::vector<int> >{};
+  CreateSubTable(nelectrons, &fTableElectrons);
 
-  fTableMuons = new std::vector < std::vector<int> * >(0);
-  CreateSubTable(nmuons, fTableMuons);
+  fTableMuons = std::vector<std::vector<int> >{};
+  CreateSubTable(nmuons, &fTableMuons);
 
-  fTablePhotons = new std::vector < std::vector<int> * >(0);
-  CreateSubTable(nphotons, fTablePhotons);
+  fTablePhotons = std::vector<std::vector<int> >{};
+  CreateSubTable(nphotons, &fTablePhotons);
 
   int npartonsPerm = npartons;
   if (nPartonsInPermutations >= 0)
     npartonsPerm = nPartonsInPermutations;
 
   // get number of possible permutations for each category
-  int npermpartons   = fTablePartons->size() <= 0 ? 1 : fTablePartons->size();
-  int npermelectrons = fTableElectrons->size() <= 0 ? 1 : fTableElectrons->size();
-  int npermmuons     = fTableMuons->size() <= 0 ? 1 : fTableMuons->size();
-  int npermphotons     = fTablePhotons->size() <= 0 ? 1 : fTablePhotons->size();
+  int npermpartons   = fTablePartons.size() <= 0 ? 1 : fTablePartons.size();
+  int npermelectrons = fTableElectrons.size() <= 0 ? 1 : fTableElectrons.size();
+  int npermmuons     = fTableMuons.size() <= 0 ? 1 : fTableMuons.size();
+  int npermphotons     = fTablePhotons.size() <= 0 ? 1 : fTablePhotons.size();
   int npermoverall   = npartonsPerm + nelectrons + nmuons + nphotons;
 
   // loop over all parton permutations
@@ -142,7 +138,7 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
           // loop over all partons
           for (int i = 0; i < npartonsPerm; ++i) {
             // get index
-            int index = (*(*fTablePartons)[ipermparton])[i];
+            int index = fTablePartons[ipermparton][i];
 
             // add parton
             particles->AddParticle((*fParticles)->Parton(index),
@@ -163,7 +159,7 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
           // loop over all electrons
           for (int i = 0; i < nelectrons; ++i) {
             // get index
-            int index = (*(*fTableElectrons)[ipermelectron])[i];
+            int index = fTableElectrons[ipermelectron][i];
 
             // if isDilepton include charge of the lepton
             if (isDilepton) {
@@ -190,7 +186,7 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
           // loop over all muons
           for (int i = 0; i < nmuons; ++i) {
             // get index
-            int index = (*(*fTableMuons)[ipermmuon])[i];
+            int index = fTableMuons[ipermmuon][i];
 
             // if isDilepton include charge of the lepton
             if (isDilepton) {
@@ -217,7 +213,7 @@ int KLFitter::Permutations::CreatePermutations(int nPartonsInPermutations) {
           // loop over all photons
           for (int i = 0; i < nphotons; ++i) {
             // get index
-            int index = (*(*fTablePhotons)[ipermphoton])[i];
+            int index = fTablePhotons[ipermphoton][i];
 
             // add photon
             particles->AddParticle((*fParticles)->Photon(index),
@@ -268,57 +264,12 @@ int KLFitter::Permutations::Reset() {
     fPermutationTable = 0;
   }
 
-  // free memory
-  if (fTablePartons) {
-    while (!fTablePartons->empty()) {
-      std::vector<int> * l = fTablePartons->front();
-      fTablePartons->erase(fTablePartons->begin());
-      l->clear();
-      delete l;
-    }
-    delete fTablePartons;
-    fTablePartons = 0;
-  }
-
-  if (fTableElectrons) {
-    while (!fTableElectrons->empty()) {
-      std::vector<int> * l = fTableElectrons->front();
-      fTableElectrons->erase(fTableElectrons->begin());
-      l->clear();
-      delete l;
-    }
-    delete fTableElectrons;
-    fTableElectrons = 0;
-  }
-
-  if (fTableMuons) {
-    while (!fTableMuons->empty()) {
-      std::vector<int> * l = fTableMuons->front();
-      fTableMuons->erase(fTableMuons->begin());
-      l->clear();
-      delete l;
-    }
-    delete fTableMuons;
-    fTableMuons = 0;
-  }
-
-  if (fTablePhotons) {
-    while (!fTablePhotons->empty()) {
-      std::vector<int> * l = fTablePhotons->front();
-      fTablePhotons->erase(fTablePhotons->begin());
-      l->clear();
-      delete l;
-    }
-    delete fTablePhotons;
-    fTablePhotons = 0;
-  }
-
   // no error
   return 1;
 }
 
 // ---------------------------------------------------------
-int KLFitter::Permutations::CreateSubTable(int Nobj, std::vector < std::vector<int> * > * table, int Nmax) {
+int KLFitter::Permutations::CreateSubTable(int Nobj, std::vector<std::vector<int> >* table, int Nmax) {
   if (Nmax < 0) {
     std::vector<int> vidx;
     for (int i(0); i < Nobj; ++i) {
@@ -326,7 +277,7 @@ int KLFitter::Permutations::CreateSubTable(int Nobj, std::vector < std::vector<i
     }
 
     do {
-      table->push_back(new std::vector<int>(vidx));
+      table->emplace_back(std::vector<int>(vidx));
     } while (std::next_permutation(vidx.begin(), vidx.end()));
   } else {
     std::vector<std::vector<int> > v = Get_M_from_N(Nobj, Nmax);
@@ -334,7 +285,7 @@ int KLFitter::Permutations::CreateSubTable(int Nobj, std::vector < std::vector<i
     for (unsigned int i(0), n(v.size()); i < n; ++i) {
       std::vector<int> vidx = v[i];
       do {
-        table->push_back(new std::vector<int>(vidx));
+        table->emplace_back(std::vector<int>(vidx));
       } while (std::next_permutation(vidx.begin(), vidx.end()));
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
General clean-up of the classes Particles and Permutations:
- Raw pointers removed, which makes the destructors defaultable
- Copy constructors added
- Assignment operators added
- Unnecessary/unused double pointers removed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#16 (removing all raw pointers)
#30 (new b-tagging option which will need copy/assignment)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Copy and assignment operators will be needed for the new b-tagging option #30. Ongoing efforts to remove all raw pointers from the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
