### PR TITLE
Implementing kVetoHybridNoFit

### DIFF
--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -53,6 +53,7 @@ class LikelihoodBase : public BCModel {
     kVetoNoFit,
     kVetoNoFitLight,
     kVetoNoFitBoth,
+    kVetoHybridNoFit,
     kWorkingPoint,
     kVetoLight,
     kVetoBoth

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -363,7 +363,7 @@ int KLFitter::LikelihoodBase::RemoveForbiddenParticlePermutations() {
   int err = 1;
 
   // only in b-tagging type kVetoNoFit
-  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth)))
+  if (!((fBTagMethod == kVetoNoFit) || (fBTagMethod == kVetoNoFitLight) || (fBTagMethod == kVetoNoFitBoth || (fBTagMethod == kVetoHybridNoFit))))
     return err;
 
   // remove all permutations where a b-tagged jet is in the position of a model light quark
@@ -371,11 +371,35 @@ int KLFitter::LikelihoodBase::RemoveForbiddenParticlePermutations() {
   int nPartons = particles->NPartons();
 
   int nPartonsModel = fParticlesModel->NPartons();
+  //When using kVetoHybridNoFit copy the Permutations object and try to run with kVetoNoFit option
+  //if there are no allowed permutations left then use the backup Permutations object and run with
+  //kVetoNoFitLight option - this will never fail
+  if (fBTagMethod == kVetoHybridNoFit) {
+    KLFitter::Permutations permutationsCopy(**fPermutations);
+    for (int iParton(0); iParton < nPartons; ++iParton){
+      bool isBtagged = particles->IsBTagged(iParton);
+
+      for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
+        KLFitter::Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(iPartonModel);
+        if ((!isBtagged)||(trueFlavor != KLFitter::Particles::kLight)) continue;
+        err *= (*fPermutations)->RemoveParticlePermutations(KLFitter::Particles::kParton, iParton, iPartonModel);
+      }
+    }
+
+    if ((*fPermutations)->NPermutations() != 0) {
+      return err;
+    } else {
+      **fPermutations = permutationsCopy;
+    }
+  }
+
   for (int iParton(0); iParton < nPartons; ++iParton) {
     bool isBtagged = particles->IsBTagged(iParton);
 
     for (int iPartonModel(0); iPartonModel < nPartonsModel; ++iPartonModel) {
       KLFitter::Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(iPartonModel);
+      if ((fBTagMethod == kVetoHybridNoFit)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))
+        continue;
       if ((fBTagMethod == kVetoNoFit)&&((!isBtagged) || (trueFlavor != KLFitter::Particles::kLight)))
         continue;
       if ((fBTagMethod == kVetoNoFitLight)&&((isBtagged) || (trueFlavor != KLFitter::Particles::kB)))


### PR DESCRIPTION
Implementation of kVetoHybdridNoFit

## Description
This PR implement the kVetoHybridNoFit option in LikelihoodBase and thus for every likelihood. 
It uses information from btagging in a same way as kVetoNoFit unless there are no allowed permutations left, then it switches to kVetoNoFitLight. This ensures that there are always allowed permutations and the code doesn't exit.  

## How Has This Been Tested?
Tested on special sample that crashes with kVetoNoFit but doesn't crash with this option

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
