### PR TITLE
Better handling of events with no allowed permutations

### DIFF
--- a/src/Fitter.cxx
+++ b/src/Fitter.cxx
@@ -69,6 +69,12 @@ int KLFitter::Fitter::SetParticles(KLFitter::Particles * particles, int nPartons
   if (fLikelihood)
     fLikelihood->RemoveForbiddenParticlePermutations();
 
+  // check if any permutations are left
+  if (fPermutations->NPermutations() == 0) {
+    std::cout << "KLFitter::Fitter::SetParticles(). No permutations left to fit. Are you vetoing?" << std::endl;
+    return 0;
+  }
+
   // set first permutation
   if (!fPermutations->SetPermutation(0))
     return 0;

--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -42,12 +42,6 @@ KLFitter::Permutations& KLFitter::Permutations::operator=(const KLFitter::Permut
 
 // ---------------------------------------------------------
 int KLFitter::Permutations::SetPermutation(int index) {
-  // check if permutation table exists
-  if (fParticlesTable.empty()) {
-    std::cout << "KLFitter::Permutations::SetPermutation(). Table does not exist yet." << std::endl;
-    return 0;
-  }
-
   // check index
   if (index < 0 || index >= NPermutations()) {
     std::cout << "KLFitter::Permutations::SetPermutation(). Index out of range." << std::endl;
@@ -308,18 +302,6 @@ int KLFitter::Permutations::InvariantParticlePermutations(KLFitter::Particles::P
   for (; it_indexSetBegin != it_indexSetEnd; it_indexSetBegin++)
     indexVector.push_back(*it_indexSetBegin);
 
-  // check particles table
-  if (fParticlesTable.empty()) {
-    std::cout << "KLFitter::Permutations::InvariantParticlePermutations(). Table does not exist yet." << std::endl;
-    return 0;
-  }
-
-  // check permutation table
-  if (fPermutationTable.empty()) {
-    std::cout << "KLFitter::Permutations::InvariantParticlePermutations(). Table of parton permutations doesn ot exist." << std::endl;
-    return 0;
-  }
-
   // no error
   int err = 1;
 
@@ -415,18 +397,6 @@ int KLFitter::Permutations::InvariantParticleGroupPermutations(KLFitter::Particl
   for (; it_indexSetPosition1Begin != it_indexSetPosition1End; it_indexSetPosition1Begin++)
     indexVectorPosition1.push_back(*it_indexSetPosition1Begin);
 
-  // check particles table
-  if (fParticlesTable.empty()) {
-    std::cout << "KLFitter::Permutations::InvariantParticleGroupPermutations(). Table does not exist yet." << std::endl;
-    return 0;
-  }
-
-  // check permutation table
-  if (fPermutationTable.empty()) {
-    std::cout << "KLFitter::Permutations::InvariantParticleGroupPermutations(). Table of parton permutations doesn ot exist." << std::endl;
-    return 0;
-  }
-
   // no error
   int err = 1;
 
@@ -479,18 +449,6 @@ int KLFitter::Permutations::RemoveParticlePermutations(KLFitter::Particles::Part
   // check index
   if (index < 0 || index >= (*fParticles)->NParticles(ptype)) {
     std::cout << "KLFitter::Permutations::RemoveParticlePermutations(). Index out of range." << std::endl;
-    return 0;
-  }
-
-  // check particles table
-  if (fParticlesTable.empty()) {
-    std::cout << "KLFitter::Permutations::RemoveParticlePermutations(). Table does not exist yet." << std::endl;
-    return 0;
-  }
-
-  // check permutation table
-  if (fPermutationTable.empty()) {
-    std::cout << "KLFitter::Permutations::RemoveParticlePermutations(). Table of parton permutations does not exist." << std::endl;
     return 0;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR aims to improve the handling of events that are left with no allowed permutations (using the `kVeto` or `kVetoNoFit` b-tagging methods). Basically two changes are implemented:
1. With the switch from pointers to objects in #31 in the Permutations class, the lines checking `if (fPermutationsTable) return;` were changed to `if (fPermutationsTable.empty()) return;` which is not the identical requirement. While the former only makes sure that the object is accessible, the latter checks the actual content. There are cases where the permutations table might be empty, and we would still like the code to continue as usual. Therefore, the `std::vector<T>::empty()` checks are removed.
2. When using one of the above b-tagging methods, there are events where _all_ permutations are vetoed. Those cases were not handled very gracefully: only the particles class issued an error eventually, which did not really point out the problem to the user. This is now improved by directly adding a check within the Fitter class, whether the permutations object has zero permutations or not. This is then pointed out to the user accordingly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#11 (implementation of hybrid b-tagging veto option)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This removes confusing warnings that appeared for some events, where all permutations were vetoed and the user received a "table does not exist yet" message. It also adds a more explicit message for the user that all permutations are vetoed and KLFitter doesn't know what to do.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled and tested with the example as usual. Also tested in combination with the hybrid b-tagging option, to be implemented in #32.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
