### PR TITLE
Default destructors and unified formatting for initialiser lists

### DIFF
--- a/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
+++ b/include/KLFitter/BoostedLikelihoodTopLeptonJets.h
@@ -55,7 +55,7 @@ class BoostedLikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   BoostedLikelihoodTopLeptonJets();
 
   /**
-   * The default destructor.
+   * The (defaulted) destructor.
    */
   ~BoostedLikelihoodTopLeptonJets();
 

--- a/include/KLFitter/DetectorAtlas_7TeV.h
+++ b/include/KLFitter/DetectorAtlas_7TeV.h
@@ -50,7 +50,7 @@ class DetectorAtlas_7TeV : public DetectorBase {
   explicit DetectorAtlas_7TeV(std::string folder = "");
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~DetectorAtlas_7TeV();
 

--- a/include/KLFitter/DetectorAtlas_8TeV.h
+++ b/include/KLFitter/DetectorAtlas_8TeV.h
@@ -50,7 +50,7 @@ class DetectorAtlas_8TeV : public DetectorBase {
   explicit DetectorAtlas_8TeV(std::string folder = "");
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~DetectorAtlas_8TeV();
 

--- a/include/KLFitter/DetectorBase.h
+++ b/include/KLFitter/DetectorBase.h
@@ -61,7 +61,7 @@ class DetectorBase {
   explicit DetectorBase(std::string folder = "");
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   virtual ~DetectorBase();
 

--- a/include/KLFitter/DetectorSnowmass.h
+++ b/include/KLFitter/DetectorSnowmass.h
@@ -50,7 +50,7 @@ class DetectorSnowmass : public DetectorBase {
   explicit DetectorSnowmass(std::string folder = "");
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~DetectorSnowmass();
 

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -54,7 +54,7 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
   LikelihoodSgTopWtLJ();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~LikelihoodSgTopWtLJ();
 

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -56,7 +56,7 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
   LikelihoodTTHLeptonJets();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~LikelihoodTTHLeptonJets();
 

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -54,7 +54,7 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
   LikelihoodTTZTrilepton();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~LikelihoodTTZTrilepton();
 

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -53,7 +53,7 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
   LikelihoodTopAllHadronic();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~LikelihoodTopAllHadronic();
 

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -62,7 +62,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
   LikelihoodTopDilepton();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~LikelihoodTopDilepton();
 

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -55,7 +55,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   LikelihoodTopLeptonJets();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~LikelihoodTopLeptonJets();
 

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -65,7 +65,7 @@ class LikelihoodTopLeptonJetsUDSep : public KLFitter::LikelihoodTopLeptonJets {
   LikelihoodTopLeptonJetsUDSep();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~LikelihoodTopLeptonJetsUDSep();
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -55,7 +55,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodBase {
   LikelihoodTopLeptonJets_Angular();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~LikelihoodTopLeptonJets_Angular();
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -55,7 +55,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodBase {
   LikelihoodTopLeptonJets_JetAngles();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~LikelihoodTopLeptonJets_JetAngles();
 

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -70,7 +70,7 @@ class Particles final {
   explicit Particles(const Particles& o);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~Particles();
 

--- a/include/KLFitter/PhysicsConstants.h
+++ b/include/KLFitter/PhysicsConstants.h
@@ -44,7 +44,7 @@ class PhysicsConstants final {
   PhysicsConstants();
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~PhysicsConstants();
 

--- a/include/KLFitter/ResDoubleGaussBase.h
+++ b/include/KLFitter/ResDoubleGaussBase.h
@@ -57,7 +57,7 @@ class ResDoubleGaussBase : public ResolutionBase {
   explicit ResDoubleGaussBase(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   virtual ~ResDoubleGaussBase();
 

--- a/include/KLFitter/ResDoubleGaussE_1.h
+++ b/include/KLFitter/ResDoubleGaussE_1.h
@@ -57,7 +57,7 @@ class ResDoubleGaussE_1 : public ResDoubleGaussBase {
   explicit ResDoubleGaussE_1(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResDoubleGaussE_1();
 

--- a/include/KLFitter/ResDoubleGaussE_2.h
+++ b/include/KLFitter/ResDoubleGaussE_2.h
@@ -56,7 +56,7 @@ class ResDoubleGaussE_2 : public ResDoubleGaussBase {
   explicit ResDoubleGaussE_2(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResDoubleGaussE_2();
 

--- a/include/KLFitter/ResDoubleGaussE_3.h
+++ b/include/KLFitter/ResDoubleGaussE_3.h
@@ -56,7 +56,7 @@ class ResDoubleGaussE_3 : public ResDoubleGaussBase {
   explicit ResDoubleGaussE_3(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResDoubleGaussE_3();
 

--- a/include/KLFitter/ResDoubleGaussE_4.h
+++ b/include/KLFitter/ResDoubleGaussE_4.h
@@ -56,7 +56,7 @@ class ResDoubleGaussE_4 : public ResDoubleGaussBase {
   explicit ResDoubleGaussE_4(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResDoubleGaussE_4();
 

--- a/include/KLFitter/ResDoubleGaussE_5.h
+++ b/include/KLFitter/ResDoubleGaussE_5.h
@@ -56,7 +56,7 @@ class ResDoubleGaussE_5 : public ResDoubleGaussBase {
   explicit ResDoubleGaussE_5(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResDoubleGaussE_5();
 

--- a/include/KLFitter/ResDoubleGaussPt.h
+++ b/include/KLFitter/ResDoubleGaussPt.h
@@ -56,7 +56,7 @@ class ResDoubleGaussPt : public ResDoubleGaussBase {
   explicit ResDoubleGaussPt(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResDoubleGaussPt();
 

--- a/include/KLFitter/ResGauss.h
+++ b/include/KLFitter/ResGauss.h
@@ -54,7 +54,7 @@ class ResGauss : public ResolutionBase {
   explicit ResGauss(double sigma);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResGauss();
 

--- a/include/KLFitter/ResGaussE.h
+++ b/include/KLFitter/ResGaussE.h
@@ -61,7 +61,7 @@ class ResGaussE : public ResolutionBase {
   explicit ResGaussE(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResGaussE();
 

--- a/include/KLFitter/ResGaussPt.h
+++ b/include/KLFitter/ResGaussPt.h
@@ -61,7 +61,7 @@ class ResGaussPt : public ResolutionBase {
   explicit ResGaussPt(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResGaussPt();
 

--- a/include/KLFitter/ResGauss_MET.h
+++ b/include/KLFitter/ResGauss_MET.h
@@ -56,7 +56,7 @@ class ResGauss_MET : public ResolutionBase {
   explicit ResGauss_MET(std::vector<double> const& parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   ~ResGauss_MET();
 

--- a/include/KLFitter/ResolutionBase.h
+++ b/include/KLFitter/ResolutionBase.h
@@ -53,7 +53,7 @@ class ResolutionBase {
   explicit ResolutionBase(std::vector<double> parameters);
 
   /**
-    * The default destructor.
+    * The (defaulted) destructor.
     */
   virtual ~ResolutionBase();
 

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -32,7 +32,8 @@
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------
-KLFitter::BoostedLikelihoodTopLeptonJets::BoostedLikelihoodTopLeptonJets() : KLFitter::LikelihoodBase::LikelihoodBase()
+KLFitter::BoostedLikelihoodTopLeptonJets::BoostedLikelihoodTopLeptonJets()
+  : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , fFlagGetParSigmasFromTFs(false)
   , ETmiss_x(0.)

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -47,8 +47,7 @@ KLFitter::BoostedLikelihoodTopLeptonJets::BoostedLikelihoodTopLeptonJets() : KLF
 }
 
 // ---------------------------------------------------------
-KLFitter::BoostedLikelihoodTopLeptonJets::~BoostedLikelihoodTopLeptonJets() {
-}
+KLFitter::BoostedLikelihoodTopLeptonJets::~BoostedLikelihoodTopLeptonJets() = default;
 
 // ---------------------------------------------------------
 int KLFitter::BoostedLikelihoodTopLeptonJets::SetET_miss_XY_SumET(double etx, double ety, double sumet) {

--- a/src/DetectorAtlas_7TeV.cxx
+++ b/src/DetectorAtlas_7TeV.cxx
@@ -167,8 +167,7 @@ KLFitter::DetectorAtlas_7TeV::DetectorAtlas_7TeV(std::string folder) : DetectorB
 }
 
 // ---------------------------------------------------------
-KLFitter::DetectorAtlas_7TeV::~DetectorAtlas_7TeV() {
-}
+KLFitter::DetectorAtlas_7TeV::~DetectorAtlas_7TeV() = default;
 
 // ---------------------------------------------------------
 KLFitter::ResolutionBase * KLFitter::DetectorAtlas_7TeV::ResEnergyLightJet(double eta) {

--- a/src/DetectorAtlas_8TeV.cxx
+++ b/src/DetectorAtlas_8TeV.cxx
@@ -127,8 +127,7 @@ KLFitter::DetectorAtlas_8TeV::DetectorAtlas_8TeV(std::string folder) : DetectorB
 }
 
 // ---------------------------------------------------------
-KLFitter::DetectorAtlas_8TeV::~DetectorAtlas_8TeV() {
-}
+KLFitter::DetectorAtlas_8TeV::~DetectorAtlas_8TeV() = default;
 
 // ---------------------------------------------------------
 KLFitter::ResolutionBase * KLFitter::DetectorAtlas_8TeV::ResEnergyLightJet(double eta) {

--- a/src/DetectorBase.cxx
+++ b/src/DetectorBase.cxx
@@ -24,14 +24,14 @@
 #include "KLFitter/ResolutionBase.h"
 
 // ---------------------------------------------------------
-KLFitter::DetectorBase::DetectorBase(std::string folder) :
-  fResEnergyLightJet(0),
-  fResEnergyBJet(0),
-  fResEnergyGluonJet(0),
-  fResEnergyElectron(0),
-  fResEnergyMuon(0),
-  fResEnergyPhoton(0),
-  fResMissingET(0) {
+KLFitter::DetectorBase::DetectorBase(std::string folder)
+  : fResEnergyLightJet(0)
+  , fResEnergyBJet(0)
+  , fResEnergyGluonJet(0)
+  , fResEnergyElectron(0)
+  , fResEnergyMuon(0)
+  , fResEnergyPhoton(0)
+  , fResMissingET(0) {
 }
 
 // ---------------------------------------------------------

--- a/src/DetectorBase.cxx
+++ b/src/DetectorBase.cxx
@@ -35,8 +35,7 @@ KLFitter::DetectorBase::DetectorBase(std::string folder) :
 }
 
 // ---------------------------------------------------------
-KLFitter::DetectorBase::~DetectorBase() {
-}
+KLFitter::DetectorBase::~DetectorBase() = default;
 
 // ---------------------------------------------------------
 int KLFitter::DetectorBase::SetResEnergyBJet(KLFitter::ResolutionBase * res) {

--- a/src/DetectorSnowmass.cxx
+++ b/src/DetectorSnowmass.cxx
@@ -65,8 +65,7 @@ KLFitter::DetectorSnowmass::DetectorSnowmass(std::string folder) : DetectorBase(
 }
 
 // ---------------------------------------------------------
-KLFitter::DetectorSnowmass::~DetectorSnowmass() {
-}
+KLFitter::DetectorSnowmass::~DetectorSnowmass() = default;
 
 // ---------------------------------------------------------
 KLFitter::ResolutionBase * KLFitter::DetectorSnowmass::ResEnergyLightJet(double eta) {

--- a/src/Fitter.cxx
+++ b/src/Fitter.cxx
@@ -28,20 +28,20 @@
 #include "KLFitter/Permutations.h"
 
 // ---------------------------------------------------------
-KLFitter::Fitter::Fitter() :
-    fDetector(nullptr),
-    fParticles(nullptr),
-    ETmiss_x(0.),
-    ETmiss_y(0.),
-    SumET(0.),
-    fParticlesPermuted(nullptr),
-    fMyParticlesTruth(nullptr),
-    fLikelihood(nullptr),
-    fPermutations(std::unique_ptr<KLFitter::Permutations>(new KLFitter::Permutations{&fParticles, &fParticlesPermuted})),
-    fMinuitStatus(0),
-    fConvergenceStatus(0),
-    fTurnOffSA(false),
-    fMinimizationMethod(kMinuit) {
+KLFitter::Fitter::Fitter()
+  : fDetector(nullptr)
+  , fParticles(nullptr)
+  , ETmiss_x(0.)
+  , ETmiss_y(0.)
+  , SumET(0.)
+  , fParticlesPermuted(nullptr)
+  , fMyParticlesTruth(nullptr)
+  , fLikelihood(nullptr)
+  , fPermutations(std::unique_ptr<KLFitter::Permutations>(new KLFitter::Permutations{&fParticles, &fParticlesPermuted}))
+  , fMinuitStatus(0)
+  , fConvergenceStatus(0)
+  , fTurnOffSA(false)
+  , fMinimizationMethod(kMinuit) {
   // empty
 }
 

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -31,16 +31,17 @@
 #include "TRandom3.h"
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodBase::LikelihoodBase(Particles** particles) : BCModel(),
-                                                                  fParticlesPermuted(particles),
-                                                                  fPermutations(0),
-                                                                  fDetector(0),
-                                                                  fEventProbability(std::vector<double>(0)),
-                                                                  fFlagIntegrate(0),
-                                                                  fFlagIsNan(false),
-                                                                  fFlagUseJetMass(false),
-                                                                  fTFgood(true),
-                                                                  fBTagMethod(kNotag) {
+KLFitter::LikelihoodBase::LikelihoodBase(Particles** particles)
+  : BCModel()
+  , fParticlesPermuted(particles)
+  , fPermutations(0)
+  , fDetector(0)
+  , fEventProbability(std::vector<double>(0))
+  , fFlagIntegrate(0)
+  , fFlagIsNan(false)
+  , fFlagUseJetMass(false)
+  , fTFgood(true)
+  , fBTagMethod(kNotag) {
   BCLog::SetLogLevel(BCLog::nothing);
   MCMCSetRandomSeed(123456789);
 }

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -32,7 +32,8 @@
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodSgTopWtLJ::LikelihoodSgTopWtLJ(): KLFitter::LikelihoodBase::LikelihoodBase()
+KLFitter::LikelihoodSgTopWtLJ::LikelihoodSgTopWtLJ()
+  : KLFitter::LikelihoodBase::LikelihoodBase()
   , fHadronicTop(true)
   , ETmiss_x(0.)
   , ETmiss_y(0.)

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -46,8 +46,7 @@ KLFitter::LikelihoodSgTopWtLJ::LikelihoodSgTopWtLJ(): KLFitter::LikelihoodBase::
 }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodSgTopWtLJ::~LikelihoodSgTopWtLJ() {
-}
+KLFitter::LikelihoodSgTopWtLJ::~LikelihoodSgTopWtLJ() = default;
 
 // ---------------------------------------------------------
 TLorentzVector* KLFitter::LikelihoodSgTopWtLJ::GetLepton(KLFitter::Particles* particles) {

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -47,8 +47,7 @@ KLFitter::LikelihoodTTHLeptonJets::LikelihoodTTHLeptonJets() : KLFitter::Likelih
 }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTTHLeptonJets::~LikelihoodTTHLeptonJets() {
-}
+KLFitter::LikelihoodTTHLeptonJets::~LikelihoodTTHLeptonJets() = default;
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTTHLeptonJets::SetET_miss_XY_SumET(double etx, double ety, double sumet) {

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -32,7 +32,8 @@
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTTHLeptonJets::LikelihoodTTHLeptonJets() : KLFitter::LikelihoodBase::LikelihoodBase()
+KLFitter::LikelihoodTTHLeptonJets::LikelihoodTTHLeptonJets()
+  : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , fFlagHiggsMassFixed(false)
   , ETmiss_x(0.)

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -49,8 +49,7 @@ KLFitter::LikelihoodTTZTrilepton::LikelihoodTTZTrilepton() : KLFitter::Likelihoo
 }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTTZTrilepton::~LikelihoodTTZTrilepton() {
-}
+KLFitter::LikelihoodTTZTrilepton::~LikelihoodTTZTrilepton() = default;
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTTZTrilepton::SetET_miss_XY_SumET(double etx, double ety, double sumet) {

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -32,7 +32,8 @@
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTTZTrilepton::LikelihoodTTZTrilepton() : KLFitter::LikelihoodBase::LikelihoodBase()
+KLFitter::LikelihoodTTZTrilepton::LikelihoodTTZTrilepton()
+  : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , fFlagGetParSigmasFromTFs(false)
   , ETmiss_x(0.)

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -33,7 +33,8 @@
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopAllHadronic::LikelihoodTopAllHadronic() : KLFitter::LikelihoodBase::LikelihoodBase()
+KLFitter::LikelihoodTopAllHadronic::LikelihoodTopAllHadronic()
+  : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , fFlagGetParSigmasFromTFs(false) {
   // define model particles

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -44,8 +44,7 @@ KLFitter::LikelihoodTopAllHadronic::LikelihoodTopAllHadronic() : KLFitter::Likel
 }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopAllHadronic::~LikelihoodTopAllHadronic() {
-}
+KLFitter::LikelihoodTopAllHadronic::~LikelihoodTopAllHadronic() = default;
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopAllHadronic::DefineModelParticles() {

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -45,7 +45,8 @@ public:
 };
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopDilepton::LikelihoodTopDilepton() : KLFitter::LikelihoodBase::LikelihoodBase()
+KLFitter::LikelihoodTopDilepton::LikelihoodTopDilepton()
+  : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -69,8 +69,7 @@ KLFitter::LikelihoodTopDilepton::LikelihoodTopDilepton() : KLFitter::LikelihoodB
 }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopDilepton::~LikelihoodTopDilepton() {
-}
+KLFitter::LikelihoodTopDilepton::~LikelihoodTopDilepton() = default;
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopDilepton::SetET_miss_XY_SumET(double etx, double ety, double sumet) {

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -32,7 +32,8 @@
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets() : KLFitter::LikelihoodBase::LikelihoodBase()
+KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
+  : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , fFlagGetParSigmasFromTFs(false)
   , ETmiss_x(0.)

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -47,8 +47,7 @@ KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets() : KLFitter::Likelih
 }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets::~LikelihoodTopLeptonJets() {
-}
+KLFitter::LikelihoodTopLeptonJets::~LikelihoodTopLeptonJets() = default;
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets::SetET_miss_XY_SumET(double etx, double ety, double sumet) {

--- a/src/LikelihoodTopLeptonJetsUDSep.cxx
+++ b/src/LikelihoodTopLeptonJetsUDSep.cxx
@@ -34,8 +34,9 @@
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJetsUDSep::LikelihoodTopLeptonJetsUDSep() : KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets(),
-  fLJetSeparationMethod(KLFitter::LikelihoodTopLeptonJetsUDSep::kNone) {
+KLFitter::LikelihoodTopLeptonJetsUDSep::LikelihoodTopLeptonJetsUDSep()
+  : KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
+  , fLJetSeparationMethod(KLFitter::LikelihoodTopLeptonJetsUDSep::kNone) {
   // define model particles
   this->DefineModelParticles();
 

--- a/src/LikelihoodTopLeptonJetsUDSep.cxx
+++ b/src/LikelihoodTopLeptonJetsUDSep.cxx
@@ -44,8 +44,7 @@ KLFitter::LikelihoodTopLeptonJetsUDSep::LikelihoodTopLeptonJetsUDSep() : KLFitte
   }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJetsUDSep::~LikelihoodTopLeptonJetsUDSep() {
-}
+KLFitter::LikelihoodTopLeptonJetsUDSep::~LikelihoodTopLeptonJetsUDSep() = default;
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJetsUDSep::DefineModelParticles() {

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -46,8 +46,7 @@ KLFitter::LikelihoodTopLeptonJets_Angular::LikelihoodTopLeptonJets_Angular() : K
 }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets_Angular::~LikelihoodTopLeptonJets_Angular() {
-}
+KLFitter::LikelihoodTopLeptonJets_Angular::~LikelihoodTopLeptonJets_Angular() = default;
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets_Angular::SetET_miss_XY_SumET(double etx, double ety, double sumet) {

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -32,7 +32,8 @@
 #include "TLorentzVector.h"
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets_Angular::LikelihoodTopLeptonJets_Angular() : KLFitter::LikelihoodBase::LikelihoodBase()
+KLFitter::LikelihoodTopLeptonJets_Angular::LikelihoodTopLeptonJets_Angular()
+  : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , ETmiss_x(0.)
   , ETmiss_y(0.)

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -48,8 +48,7 @@ KLFitter::LikelihoodTopLeptonJets_JetAngles::LikelihoodTopLeptonJets_JetAngles()
 }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets_JetAngles::~LikelihoodTopLeptonJets_JetAngles() {
-}
+KLFitter::LikelihoodTopLeptonJets_JetAngles::~LikelihoodTopLeptonJets_JetAngles() = default;
 
 // ---------------------------------------------------------
 int KLFitter::LikelihoodTopLeptonJets_JetAngles::SetET_miss_XY_SumET(double etx, double ety, double sumet) {

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -33,7 +33,8 @@
 #include "TMath.h"
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets_JetAngles::LikelihoodTopLeptonJets_JetAngles() : KLFitter::LikelihoodBase::LikelihoodBase()
+KLFitter::LikelihoodTopLeptonJets_JetAngles::LikelihoodTopLeptonJets_JetAngles()
+  : KLFitter::LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , fFlagGetParSigmasFromTFs(false)
   , ETmiss_x(0.)

--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -24,10 +24,10 @@
 #include <set>
 
 // ---------------------------------------------------------
-KLFitter::Permutations::Permutations(KLFitter::Particles ** p, KLFitter::Particles ** pp) :
-    fParticles(p),
-    fParticlesPermuted(pp),
-    fPermutationIndex(-1) {
+KLFitter::Permutations::Permutations(KLFitter::Particles ** p, KLFitter::Particles ** pp)
+  : fParticles(p)
+  , fParticlesPermuted(pp)
+  , fPermutationIndex(-1) {
   // empty
 }
 

--- a/src/PhysicsConstants.cxx
+++ b/src/PhysicsConstants.cxx
@@ -39,8 +39,7 @@ KLFitter::PhysicsConstants::PhysicsConstants() {
 }
 
 // ---------------------------------------------------------
-KLFitter::PhysicsConstants::~PhysicsConstants() {
-}
+KLFitter::PhysicsConstants::~PhysicsConstants() = default;
 
 // ---------------------------------------------------------
 int KLFitter::PhysicsConstants::SetMassBottom(double mass) {

--- a/src/ResDoubleGaussBase.cxx
+++ b/src/ResDoubleGaussBase.cxx
@@ -38,9 +38,7 @@ KLFitter::ResDoubleGaussBase::ResDoubleGaussBase(std::vector<double> const& para
 }
 
 // ---------------------------------------------------------
-KLFitter::ResDoubleGaussBase::~ResDoubleGaussBase() {
-  // empty destructor
-}
+KLFitter::ResDoubleGaussBase::~ResDoubleGaussBase() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResDoubleGaussBase::GetSigma(double xmeas) {

--- a/src/ResDoubleGaussE_1.cxx
+++ b/src/ResDoubleGaussE_1.cxx
@@ -29,9 +29,7 @@ KLFitter::ResDoubleGaussE_1::ResDoubleGaussE_1(const char * filename) : KLFitter
 KLFitter::ResDoubleGaussE_1::ResDoubleGaussE_1(std::vector<double> const& parameters) : KLFitter::ResDoubleGaussBase(parameters) { }
 
 // ---------------------------------------------------------
-KLFitter::ResDoubleGaussE_1::~ResDoubleGaussE_1() {
-  // empty destructor
-}
+KLFitter::ResDoubleGaussE_1::~ResDoubleGaussE_1() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResDoubleGaussE_1::GetMean1(double x) {

--- a/src/ResDoubleGaussE_2.cxx
+++ b/src/ResDoubleGaussE_2.cxx
@@ -29,9 +29,7 @@ KLFitter::ResDoubleGaussE_2::ResDoubleGaussE_2(const char * filename) : KLFitter
 KLFitter::ResDoubleGaussE_2::ResDoubleGaussE_2(std::vector<double> const& parameters) : KLFitter::ResDoubleGaussBase(parameters) { }
 
 // ---------------------------------------------------------
-KLFitter::ResDoubleGaussE_2::~ResDoubleGaussE_2() {
-  // empty destructor
-}
+KLFitter::ResDoubleGaussE_2::~ResDoubleGaussE_2() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResDoubleGaussE_2::GetMean1(double x) {

--- a/src/ResDoubleGaussE_3.cxx
+++ b/src/ResDoubleGaussE_3.cxx
@@ -29,9 +29,7 @@ KLFitter::ResDoubleGaussE_3::ResDoubleGaussE_3(const char * filename) : KLFitter
 KLFitter::ResDoubleGaussE_3::ResDoubleGaussE_3(std::vector<double> const& parameters) : KLFitter::ResDoubleGaussBase(parameters) { }
 
 // ---------------------------------------------------------
-KLFitter::ResDoubleGaussE_3::~ResDoubleGaussE_3() {
-  // empty destructor
-}
+KLFitter::ResDoubleGaussE_3::~ResDoubleGaussE_3() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResDoubleGaussE_3::GetMean1(double x) {

--- a/src/ResDoubleGaussE_4.cxx
+++ b/src/ResDoubleGaussE_4.cxx
@@ -29,9 +29,7 @@ KLFitter::ResDoubleGaussE_4::ResDoubleGaussE_4(const char * filename) : KLFitter
 KLFitter::ResDoubleGaussE_4::ResDoubleGaussE_4(std::vector<double> const& parameters) : KLFitter::ResDoubleGaussBase(parameters) { }
 
 // ---------------------------------------------------------
-KLFitter::ResDoubleGaussE_4::~ResDoubleGaussE_4() {
-  // empty destructor
-}
+KLFitter::ResDoubleGaussE_4::~ResDoubleGaussE_4() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResDoubleGaussE_4::GetMean1(double x) {

--- a/src/ResDoubleGaussE_5.cxx
+++ b/src/ResDoubleGaussE_5.cxx
@@ -29,9 +29,7 @@ KLFitter::ResDoubleGaussE_5::ResDoubleGaussE_5(const char * filename) : KLFitter
 KLFitter::ResDoubleGaussE_5::ResDoubleGaussE_5(std::vector<double> const& parameters) : KLFitter::ResDoubleGaussBase(parameters) { }
 
 // ---------------------------------------------------------
-KLFitter::ResDoubleGaussE_5::~ResDoubleGaussE_5() {
-  // empty destructor
-}
+KLFitter::ResDoubleGaussE_5::~ResDoubleGaussE_5() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResDoubleGaussE_5::GetMean1(double x) {

--- a/src/ResDoubleGaussPt.cxx
+++ b/src/ResDoubleGaussPt.cxx
@@ -29,9 +29,7 @@ KLFitter::ResDoubleGaussPt::ResDoubleGaussPt(const char * filename) : KLFitter::
 KLFitter::ResDoubleGaussPt::ResDoubleGaussPt(std::vector<double> const& parameters) : KLFitter::ResDoubleGaussBase(parameters) { }
 
 // ---------------------------------------------------------
-KLFitter::ResDoubleGaussPt::~ResDoubleGaussPt() {
-  // empty destructor
-}
+KLFitter::ResDoubleGaussPt::~ResDoubleGaussPt() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResDoubleGaussPt::GetMean1(double x) {

--- a/src/ResGauss.cxx
+++ b/src/ResGauss.cxx
@@ -36,8 +36,7 @@ KLFitter::ResGauss::ResGauss(double sigma) : KLFitter::ResolutionBase(1) {
 }
 
 // ---------------------------------------------------------
-KLFitter::ResGauss::~ResGauss() {
-}
+KLFitter::ResGauss::~ResGauss() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResGauss::GetSigma(double dummy) {

--- a/src/ResGaussE.cxx
+++ b/src/ResGaussE.cxx
@@ -36,8 +36,7 @@ KLFitter::ResGaussE::ResGaussE(std::vector<double> const& parameters) :KLFitter:
   }
 }
 // ---------------------------------------------------------1
-KLFitter::ResGaussE::~ResGaussE() {
-}
+KLFitter::ResGaussE::~ResGaussE() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResGaussE::GetSigma(double x) {

--- a/src/ResGaussPt.cxx
+++ b/src/ResGaussPt.cxx
@@ -36,8 +36,7 @@ KLFitter::ResGaussPt::ResGaussPt(std::vector<double> const& parameters) :KLFitte
   }
 }
 // ---------------------------------------------------------1
-KLFitter::ResGaussPt::~ResGaussPt() {
-}
+KLFitter::ResGaussPt::~ResGaussPt() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResGaussPt::GetSigma(double x) {

--- a/src/ResGauss_MET.cxx
+++ b/src/ResGauss_MET.cxx
@@ -39,8 +39,7 @@ KLFitter::ResGauss_MET::ResGauss_MET(std::vector<double> const& parameters) :KLF
 }
 
 // ---------------------------------------------------------
-KLFitter::ResGauss_MET::~ResGauss_MET() {
-}
+KLFitter::ResGauss_MET::~ResGauss_MET() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResGauss_MET::GetSigma(double sumet) {

--- a/src/ResolutionBase.cxx
+++ b/src/ResolutionBase.cxx
@@ -46,9 +46,7 @@ KLFitter::ResolutionBase::ResolutionBase(std::vector <double> parameters) {
 }
 
 // ---------------------------------------------------------
-KLFitter::ResolutionBase::~ResolutionBase() {
-  fParameters.clear();
-}
+KLFitter::ResolutionBase::~ResolutionBase() = default;
 
 // ---------------------------------------------------------
 int KLFitter::ResolutionBase::Par(int index, double *par) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR applies two changes:
- Destructors are explicitly defaulted with `= default` if applicable.
- Constructor initialiser lists now have a common format.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#26 (reduce number of user-defined constructors/destructors)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled and tested with the included example as usual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
