### PR TITLE
Auto-deploying documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,3 +149,8 @@ jobs:
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make install"
         - *run_unit_tests
         - *run_unit_test_diff
+
+after_success:
+  - cd $TRAVIS_BUILD_DIR
+  - chmod +x cmake/DeployDoxygen.sh
+  - ./cmake/DeployDoxygen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,27 +130,36 @@ jobs:
         - *run_cmake_build
         - *run_unit_tests
         - *run_unit_test_diff
-    - env:
-        - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DINSTALL_TESTS=TRUE"
-        - KLF_SOURCE_DIR=$KLF_SOURCE_DIR/KLFitter
-      script:
-        - mv CMakeLists.txt cmake data include src tests util $KLF_SOURCE_DIR
-        - *run_download_bat
-        - *run_compile_bat
-        - *run_cmake_configure
-        - *run_cmake_build
-        - *run_unit_tests
-        - *run_unit_test_diff
-    - script:
-        - *run_download_bat
-        - *run_compile_bat
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make tests"
-        - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make install"
-        - *run_unit_tests
-        - *run_unit_test_diff
+    # - env:
+    #     - KLF_CMAKE_OPTS="-DBUILTIN_BAT=FALSE -DINSTALL_TESTS=TRUE"
+    #     - KLF_SOURCE_DIR=$KLF_SOURCE_DIR/KLFitter
+    #   script:
+    #     - mv CMakeLists.txt cmake data include src tests util $KLF_SOURCE_DIR
+    #     - *run_download_bat
+    #     - *run_compile_bat
+    #     - *run_cmake_configure
+    #     - *run_cmake_build
+    #     - *run_unit_tests
+    #     - *run_unit_test_diff
+    # - script:
+    #     - *run_download_bat
+    #     - *run_compile_bat
+    #     - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make"
+    #     - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make tests"
+    #     - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make install"
+    #     - *run_unit_tests
+    #     - *run_unit_test_diff
 
-after_success:
+before_deploy:
   - cd $TRAVIS_BUILD_DIR
-  - chmod +x cmake/DeployDoxygen.sh
-  - ./cmake/DeployDoxygen.sh
+  - doxygen doc/Doxyfile 2>&1
+
+deploy:
+  provider: pages
+  repo: https://github.com/KLFitter/KLFitter.github.io
+  local-dir: doc/html
+  skip-cleanup: true
+  github-token: $DOC_TOKEN
+  keep-history: true
+  # on:
+  #   branch: master

--- a/cmake/DeployDoxygen.sh
+++ b/cmake/DeployDoxygen.sh
@@ -25,7 +25,7 @@ if [ -d "html" ] && [ -f "html/index.html" ]; then
 
     echo 'Uploading documentation to the repository ...'
     git add --all
-    git commit -m "Deploy documentation; travis build: ${TRAVIS_BUILD_NUMBER}" -m "Commit: ${TRAVIS_COMMIT}"
+    git commit --allow-empty -m "Deploy documentation; travis build: ${TRAVIS_BUILD_NUMBER}" -m "Commit: ${TRAVIS_COMMIT}"
     git push --force "https://${DOC_TOKEN}@github.com/KLFitter/${DOC_REPO}" > /dev/null 2>&1
 else
     echo '' >&2

--- a/cmake/DeployDoxygen.sh
+++ b/cmake/DeployDoxygen.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Required variables:
+# - TRAVIS_BUILD_NUMBER : The number of the current build.
+# - TRAVIS_COMMIT       : The commit that the current build is testing.
+# - DOC_DOXYFILE        : The Doxygen configuration file.
+# - DOC_REPO            : The documentation repository.
+# - DOC_TOKEN           : Secure token to the github repository.
+#
+
+set -e
+mkdir doc_tmp && cd doc_tmp
+
+git clone https://git@github.com/KLFitter/$DOC_REPO
+cd $DOC_REPO
+
+git config user.name "Travis CI"
+git config user.email "travis@travis-ci.org"
+
+rm -rf *
+echo "" > .nojekyll
+doxygen $DOXYFILE 2>&1 | tee doxygen.log
+
+if [ -d "html" ] && [ -f "html/index.html" ]; then
+
+    echo 'Uploading documentation to the repository ...'
+    git add --all
+    git commit -m "Deploy documentation; travis build: ${TRAVIS_BUILD_NUMBER}" -m "Commit: ${TRAVIS_COMMIT}"
+    git push --force "https://${DOC_TOKEN}@github.com/KLFitter/${DOC_REPO}" > /dev/null 2>&1
+else
+    echo '' >&2
+    echo 'Warning: No documentation (html) files have been found!' >&2
+    echo 'Warning: Not going to push the documentation to GitHub!' >&2
+    exit 1
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds an auto-deployment step of the KLFitter documentation to the builds with Travis. On successful build, Travis executes the script and deploys the documentation to [KLFitter/KLFitter.github.io](https://github.com/KLFitter/KLFitter.github.io). 
