### PR TITLE
Autodeploy documentation to github pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,9 +128,6 @@ before_install:
   skip-cleanup: true
   github-token: $DOC_TOKEN
   keep-history: true
-  on:
-    repo: KLFitter/KLFitter
-    branch: master
 
 
 # Before the deployment step, build the doxygen documentation
@@ -184,5 +181,6 @@ jobs:
         - *run_unit_test_diff
     - stage: deploy
       script: skip
+      if: branch = master AND repo = KLFitter/KLFitter AND NOT type = pull_request
       deploy:
         <<: *deploy_documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,27 @@ before_install:
   diff -u $KLF_BUILD_DIR/test-output.txt $KLF_SOURCE_DIR/tests/output-ref-ljets-lh.txt
 
 
+# Deploy the documentation under doc/html/ into the github pages
+# repository under https://KLFitter.github.io. To point out
+# changes in the documentation, every deployment adds a new
+# commit (instead of force-pushing).
+.deploy_documentation: &deploy_documentation
+  provider: pages
+  repo: KLFitter/KLFitter.github.io
+  target-branch: master
+  local-dir: doc/html
+  skip-cleanup: true
+  github-token: $DOC_TOKEN
+  keep-history: true
+
+
+# Before the deployment step, build the doxygen documentation
+# into the doc/html/ subdirectory.
+before_deploy:
+  - cd $TRAVIS_BUILD_DIR
+  - doxygen doc/Doxyfile 2>&1
+
+
 # Definiton of the actual CI jobs. We build KLFitter with three
 # different scenarios:
 # 1. Make a fully automatized build of KLFitter and BAT using
@@ -158,24 +179,7 @@ jobs:
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make install"
         - *run_unit_tests
         - *run_unit_test_diff
-
-
-# Before the deployment step, build the doxygen documentation
-# into the doc/html/ subdirectory.
-before_deploy:
-  - cd $TRAVIS_BUILD_DIR
-  - doxygen doc/Doxyfile 2>&1
-
-
-# Deploy the documentation under doc/html/ into the github pages
-# repository under https://KLFitter.github.io. To point out
-# changes in the documentation, every deployment adds a new
-# commit (instead of force-pushing).
-deploy:
-  provider: pages
-  repo: KLFitter/KLFitter.github.io
-  target-branch: master
-  local-dir: doc/html
-  skip-cleanup: true
-  github-token: $DOC_TOKEN
-  keep-history: true
+    - stage: deploy
+      script: skip
+      deploy:
+        <<: *deploy_documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,15 @@ sudo: required
 services: docker
 
 
+# Add the doxygen package from apt. Doxygen is needed to
+# automatically build and deploy the reference guide online to
+# https://KLFitter.github.io.
+addons:
+  apt:
+    packages:
+      - doxygen
+
+
 # Definition of global variables. These include:
 #   - BATINSTALLDIR: the directory to install BAT into.
 #   - DOCKER_IMAGE: the name of the ROOT docker image.
@@ -149,3 +158,24 @@ jobs:
         - $CMD_DOCKER "${CMD_EXPORT_BATINSTALL} && make install"
         - *run_unit_tests
         - *run_unit_test_diff
+
+
+# Before the deployment step, build the doxygen documentation
+# into the doc/html/ subdirectory.
+before_deploy:
+  - cd $TRAVIS_BUILD_DIR
+  - doxygen doc/Doxyfile 2>&1
+
+
+# Deploy the documentation under doc/html/ into the github pages
+# repository under https://KLFitter.github.io. To point out
+# changes in the documentation, every deployment adds a new
+# commit (instead of force-pushing).
+deploy:
+  provider: pages
+  repo: KLFitter/KLFitter.github.io
+  target-branch: master
+  local-dir: doc/html
+  skip-cleanup: true
+  github-token: $DOC_TOKEN
+  keep-history: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,9 @@ before_install:
   skip-cleanup: true
   github-token: $DOC_TOKEN
   keep-history: true
+  on:
+    repo: KLFitter/KLFitter
+    branch: master
 
 
 # Before the deployment step, build the doxygen documentation

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ easily modified to fit other processes. Detailed documentation:
 - [Out-of-the-box example](doc/Example.md)
 - [Frequently Asked Questions](doc/FAQ.md)
 
+An auto-generated class reference guide for the KLFitter library is also uploaded to https://KLFitter.github.io. The uploaded version always corresponds to the latest version of the master branch.
+
 
 ### Licensing terms
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds support to automatically deploy the doxygen documentation to the KLFitter github pages on https://KLFitter.github.io. Travis pushes to that repository for every push to the KLFitter:master branch, i.e. after every merged pull request.