### PR TITLE
Documentation deployment: allow empty commit to keep track of history better

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,8 @@ before_install:
   skip-cleanup: true
   github-token: $DOC_TOKEN
   keep-history: true
+  verbose: true
+  allow-empty-commit: true
 
 
 # Before the deployment step, build the doxygen documentation


### PR DESCRIPTION
Two options were added for the documentation deployment:
* verbose: true
* allow-empty-commit: true