### PR TITLE
Corrected Energy Resolution for Snowmass Transferfunctions

### DIFF
--- a/src/ResGaussE.cxx
+++ b/src/ResGaussE.cxx
@@ -40,7 +40,7 @@ KLFitter::ResGaussE::~ResGaussE() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResGaussE::GetSigma(double x) {
-  return fParameters[0]*x + fParameters[1]*sqrt(x) + fParameters[2];
+  return sqrt(fParameters[0]*fParameters[0]*x*x + fParameters[1]*fParameters[1]*x + fParameters[2]*fParameters[2]);
 }
 
 // ---------------------------------------------------------

--- a/tests/output-ref-ljets-lh.txt
+++ b/tests/output-ref-ljets-lh.txt
@@ -1,13 +1,13 @@
 Using TFs from SnowMass ...
-Permutation: 1  	LogLikelihood: -74.28  	EvtProbability: 0.00000
-Permutation: 2  	LogLikelihood: -68.54  	EvtProbability: 0.01720
-Permutation: 3  	LogLikelihood: -73.69  	EvtProbability: 0.00000
-Permutation: 4  	LogLikelihood: -67.64  	EvtProbability: 0.00015
-Permutation: 5  	LogLikelihood: -71.24  	EvtProbability: 0.00116
-Permutation: 6  	LogLikelihood: -84.55  	EvtProbability: 0.00000
-Permutation: 7  	LogLikelihood: -64.58  	EvtProbability: 0.90221
-Permutation: 8  	LogLikelihood: -80.32  	EvtProbability: 0.00000
-Permutation: 9  	LogLikelihood: -84.29  	EvtProbability: 0.00000
-Permutation: 10  	LogLikelihood: -61.35  	EvtProbability: 0.07917
-Permutation: 11  	LogLikelihood: -82.97  	EvtProbability: 0.00000
-Permutation: 12  	LogLikelihood: -73.64  	EvtProbability: 0.00010
+Permutation: 1  	LogLikelihood: -76.16  	EvtProbability: 0.00000
+Permutation: 2  	LogLikelihood: -67.13  	EvtProbability: 0.06306
+Permutation: 3  	LogLikelihood: -72.02  	EvtProbability: 0.00000
+Permutation: 4  	LogLikelihood: -66.07  	EvtProbability: 0.00063
+Permutation: 5  	LogLikelihood: -70.13  	EvtProbability: 0.00313
+Permutation: 6  	LogLikelihood: -83.00  	EvtProbability: 0.00000
+Permutation: 7  	LogLikelihood: -64.88  	EvtProbability: 0.59638
+Permutation: 8  	LogLikelihood: -78.97  	EvtProbability: 0.00000
+Permutation: 9  	LogLikelihood: -82.74  	EvtProbability: 0.00000
+Permutation: 10  	LogLikelihood: -59.78  	EvtProbability: 0.33648
+Permutation: 11  	LogLikelihood: -81.51  	EvtProbability: 0.00000
+Permutation: 12  	LogLikelihood: -72.43  	EvtProbability: 0.00031


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Fixes issue #48

## Description
<!--- Describe your changes in detail -->
The energy resolution formula that is currently implemented in KLFitter and is used in the SnowmassDetector module differs from the HCalResolutionFormula that is used in Delphes to smear the jet energy.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #48

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Formula in KLFitter (before this change):
sigma = a * E + b * sqrt(E) + c
The parameters a, b, c were taken from the formula in delphes which is of the following form:
sigma = sqrt(a^2 * E^2 + b^2 * E + c^2)
Location of the parameters (with quoted snowmass resolution formula)
https://github.com/KLFitter/KLFitter/blob/master/data/transferfunctions/snowmass
delphes detector card from HepSim for snowmass:
http://atlaswww.hep.anl.gov/hepsim/soft/detectors/delphes_dpf1/card.tcl
resolution formula on ll. 178-182 (for electrons) and ll. 289-292 (for jets)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

