### PR TITLE
Reimplementing AddParticle() functions to respect const correctness

### DIFF
--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -396,6 +396,13 @@ class Particles final {
     * @param measuredindex The index of the associated measured particle.
     * @return An error code.
     */
+  int AddParticle(const TLorentzVector& particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1);
+
+  /**
+   * Overloaded implementation of the previous function. This
+   * function is deprecated and only kept for compatibility
+   * reasons, but is to be _removed_ in the next major release.
+   */
   int AddParticle(const TLorentzVector* const particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1);
 
   /**

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -419,6 +419,13 @@ class Particles final {
     * @param btagweight The b tagger weight).
     * @return An error code.
     */
+  int AddParticle(const TLorentzVector& particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
+
+  /**
+   * Overloaded implementation of the previous function. This
+   * function is deprecated and only kept for compatibility
+   * reasons, but is to be _removed_ in the next major release.
+   */
   int AddParticle(const TLorentzVector* const particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
 
   /**

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -399,9 +399,11 @@ class Particles final {
   int AddParticle(const TLorentzVector& particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1);
 
   /**
-   * Overloaded implementation of the previous function. This
-   * function is deprecated and only kept for compatibility
-   * reasons, but is to be _removed_ in the next major release.
+   * DEPRECATED FUNCTION. This is an overloaded implementation of
+   * the previous function using TLorentzVector pointers instead
+   * of const ref. The usage of this function is deprecated and
+   * it will be removed in the next major release. Please switch
+   * to the above implementation.
    */
   int AddParticle(const TLorentzVector* const particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1);
 
@@ -422,9 +424,11 @@ class Particles final {
   int AddParticle(const TLorentzVector& particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
 
   /**
-   * Overloaded implementation of the previous function. This
-   * function is deprecated and only kept for compatibility
-   * reasons, but is to be _removed_ in the next major release.
+   * DEPRECATED FUNCTION. This is an overloaded implementation of
+   * the previous function using TLorentzVector pointers instead
+   * of const ref. The usage of this function is deprecated and
+   * it will be removed in the next major release. Please switch
+   * to the above implementation.
    */
   int AddParticle(const TLorentzVector* const particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
 
@@ -444,9 +448,11 @@ class Particles final {
   int AddParticle(const TLorentzVector& particle, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
 
   /**
-   * Overloaded implementation of the previous function. This
-   * function is deprecated and only kept for compatibility
-   * reasons, but is to be _removed_ in the next major release.
+   * DEPRECATED FUNCTION. This is an overloaded implementation of
+   * the previous function using TLorentzVector pointers instead
+   * of const ref. The usage of this function is deprecated and
+   * it will be removed in the next major release. Please switch
+   * to the above implementation.
    */
   int AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
 
@@ -463,9 +469,11 @@ class Particles final {
   int AddParticle(const TLorentzVector& particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight = 999);
 
   /**
-   * Overloaded implementation of the previous function. This
-   * function is deprecated and only kept for compatibility
-   * reasons, but is to be _removed_ in the next major release.
+   * DEPRECATED FUNCTION. This is an overloaded implementation of
+   * the previous function using TLorentzVector pointers instead
+   * of const ref. The usage of this function is deprecated and
+   * it will be removed in the next major release. Please switch
+   * to the above implementation.
    */
   int AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight = 999);
 

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -441,6 +441,13 @@ class Particles final {
     * @param btagweight The b tagger weight).
     * @return An error code.
     */
+  int AddParticle(const TLorentzVector& particle, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
+
+  /**
+   * Overloaded implementation of the previous function. This
+   * function is deprecated and only kept for compatibility
+   * reasons, but is to be _removed_ in the next major release.
+   */
   int AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
 
   /**
@@ -453,6 +460,13 @@ class Particles final {
     * @param btagweight The b tagger weight).
     * @return An error code.
     */
+  int AddParticle(const TLorentzVector& particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight = 999);
+
+  /**
+   * Overloaded implementation of the previous function. This
+   * function is deprecated and only kept for compatibility
+   * reasons, but is to be _removed_ in the next major release.
+   */
   int AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight = 999);
 
   /**

--- a/include/KLFitter/Particles.h
+++ b/include/KLFitter/Particles.h
@@ -396,7 +396,7 @@ class Particles final {
     * @param measuredindex The index of the associated measured particle.
     * @return An error code.
     */
-  int AddParticle(TLorentzVector * particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1);
+  int AddParticle(const TLorentzVector* const particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1);
 
   /**
     * Add a particle to a list of particles.
@@ -412,7 +412,7 @@ class Particles final {
     * @param btagweight The b tagger weight).
     * @return An error code.
     */
-  int AddParticle(TLorentzVector * particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
+  int AddParticle(const TLorentzVector* const particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
 
   /**
     * Add a particle to a list of particles.
@@ -427,7 +427,7 @@ class Particles final {
     * @param btagweight The b tagger weight).
     * @return An error code.
     */
-  int AddParticle(TLorentzVector * particle, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
+  int AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name = "", int measuredindex = -1, bool isBtagged = false, double bTagEff = -1., double bTagRej = -1., TrueFlavorType trueflav = kNone, double btagweight = 999);
 
   /**
     * Add a particle to a list of particles (especially for model particles).
@@ -439,7 +439,7 @@ class Particles final {
     * @param btagweight The b tagger weight).
     * @return An error code.
     */
-  int AddParticle(TLorentzVector * particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight = 999);
+  int AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight = 999);
 
   /**
     * Removes a particle from a list of particles.

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -293,7 +293,7 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, doubl
 }
 
 // ---------------------------------------------------------
-int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
+int KLFitter::Particles::AddParticle(const TLorentzVector& particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
   // set default DetEta
   double DetEta =-999;
 
@@ -303,8 +303,13 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, KLFit
   return 1;
 }
 
+// --------------------------------------------------------- // THIS FUNCTION IS TO BE REMOVED IN THE NEXT MAJOR RELEASE
+int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
+  return AddParticle(*particle, ptype, name, measuredindex, isBtagged, bTagEff, bTagRej, trueflav, btagweight);
+}
+
 // ---------------------------------------------------------
-int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight) {
+int KLFitter::Particles::AddParticle(const TLorentzVector& particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight) {
   // set default DetEta
   double DetEta =-999;
 
@@ -312,6 +317,11 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, KLFit
 
   // no error
   return 1;
+}
+
+// --------------------------------------------------------- // THIS FUNCTION IS TO BE REMOVED IN THE NEXT MAJOR RELEASE
+int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight) {
+  return AddParticle(*particle, ptype, name, measuredindex, trueflav, btagweight);
 }
 
 // ---------------------------------------------------------

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -294,13 +294,7 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, doubl
 
 // ---------------------------------------------------------
 int KLFitter::Particles::AddParticle(const TLorentzVector& particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
-  // set default DetEta
-  double DetEta =-999;
-
-  this->AddParticle(particle, DetEta, ptype, name, measuredindex, isBtagged, bTagEff, bTagRej, trueflav, btagweight);
-
-  // no error
-  return 1;
+  return AddParticle(particle, -999, ptype, name, measuredindex, isBtagged, bTagEff, bTagRej, trueflav, btagweight);
 }
 
 // --------------------------------------------------------- // THIS FUNCTION IS TO BE REMOVED IN THE NEXT MAJOR RELEASE
@@ -310,13 +304,7 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, KLFit
 
 // ---------------------------------------------------------
 int KLFitter::Particles::AddParticle(const TLorentzVector& particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight) {
-  // set default DetEta
-  double DetEta =-999;
-
-  this->AddParticle(particle, DetEta, ptype, name, measuredindex, false, -1., -1., trueflav, btagweight);
-
-  // no error
-  return 1;
+  return AddParticle(particle, -999, ptype, name, measuredindex, false, -1., -1., trueflav, btagweight);
 }
 
 // --------------------------------------------------------- // THIS FUNCTION IS TO BE REMOVED IN THE NEXT MAJOR RELEASE

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -166,7 +166,7 @@ KLFitter::Particles& KLFitter::Particles::operator=(const KLFitter::Particles& o
 }
 
 // ---------------------------------------------------------
-int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex) {
+int KLFitter::Particles::AddParticle(const TLorentzVector& particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex) {
   // get particle container
   auto container = ParticleContainer(ptype);
 
@@ -189,7 +189,7 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, doubl
   if (!FindParticle(name, vect, &index, &temptype)) {
     // add particle
     // create pointer copy of particle content which is owend by Particles
-    std::unique_ptr<TLorentzVector> cparticle{new TLorentzVector{particle->Px(), particle->Py(), particle->Pz(), particle->E()}};
+    std::unique_ptr<TLorentzVector> cparticle{new TLorentzVector{particle.Px(), particle.Py(), particle.Pz(), particle.E()}};
     container->emplace_back(std::move(cparticle));
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kElectron) {
@@ -209,13 +209,18 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, doubl
     return 0;
   }
 
-  if (fabs(particle->P()/particle->E()-1) > 1.e-6 && particle->M() < 0) {  // No Warning if P differs less than 1e-6 from E
-    std::cout << "KLFitter::Particles::AddParticle(). WARNING : A particle with negative mass " << particle->M() << " of type " << ptype << " was added." << std::endl;
+  if (fabs(particle.P()/particle.E()-1) > 1.e-6 && particle.M() < 0) {  // No Warning if P differs less than 1e-6 from E
+    std::cout << "KLFitter::Particles::AddParticle(). WARNING : A particle with negative mass " << particle.M() << " of type " << ptype << " was added." << std::endl;
     return 1;
   }
 
   // no error
   return 1;
+}
+
+// --------------------------------------------------------- // THIS FUNCTION IS TO BE REMOVED IN THE NEXT MAJOR RELEASE
+int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex) {
+  return AddParticle(*particle, DetEta, LepCharge, ptype, name, measuredindex);
 }
 
 // ---------------------------------------------------------

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -166,7 +166,7 @@ KLFitter::Particles& KLFitter::Particles::operator=(const KLFitter::Particles& o
 }
 
 // ---------------------------------------------------------
-int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex) {
+int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, double DetEta, float LepCharge, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex) {
   // get particle container
   auto container = ParticleContainer(ptype);
 
@@ -219,7 +219,7 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, f
 }
 
 // ---------------------------------------------------------
-int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
+int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
   // get particle container
   auto container = ParticleContainer(ptype);
 
@@ -283,7 +283,7 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, double DetEta, K
 }
 
 // ---------------------------------------------------------
-int KLFitter::Particles::AddParticle(TLorentzVector * particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
+int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
   // set default DetEta
   double DetEta =-999;
 
@@ -294,7 +294,7 @@ int KLFitter::Particles::AddParticle(TLorentzVector * particle, KLFitter::Partic
 }
 
 // ---------------------------------------------------------
-int KLFitter::Particles::AddParticle(TLorentzVector * particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight) {
+int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, TrueFlavorType trueflav, double btagweight) {
   // set default DetEta
   double DetEta =-999;
 

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -224,7 +224,7 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, doubl
 }
 
 // ---------------------------------------------------------
-int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
+int KLFitter::Particles::AddParticle(const TLorentzVector& particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
   // get particle container
   auto container = ParticleContainer(ptype);
 
@@ -247,7 +247,7 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, doubl
   if (!FindParticle(name, vect, &index, &temptype)) {
     // add particle
     // create pointer copy of particle content which is owend by Particles
-    std::unique_ptr<TLorentzVector> cparticle{new TLorentzVector{particle->Px(), particle->Py(), particle->Pz(), particle->E()}};
+    std::unique_ptr<TLorentzVector> cparticle{new TLorentzVector{particle.Px(), particle.Py(), particle.Pz(), particle.E()}};
     container->emplace_back(std::move(cparticle));
     ParticleNameContainer(ptype)->push_back(name);
     if (ptype == KLFitter::Particles::kParton) {
@@ -278,13 +278,18 @@ int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, doubl
     return 0;
   }
 
-  if (fabs(particle->P()/particle->E()-1) > 1.e-6 && particle->M() < 0) {  // No Warning if P differs less than 1e-6 from E
-    std::cout << "KLFitter::Particles::AddParticle(). WARNING : A particle with negative mass " << particle->M() << " of type " << ptype << " was added." << std::endl;
+  if (fabs(particle.P()/particle.E()-1) > 1.e-6 && particle.M() < 0) {  // No Warning if P differs less than 1e-6 from E
+    std::cout << "KLFitter::Particles::AddParticle(). WARNING : A particle with negative mass " << particle.M() << " of type " << ptype << " was added." << std::endl;
     return 1;
   }
 
   // no error
   return 1;
+}
+
+// --------------------------------------------------------- // THIS FUNCTION IS TO BE REMOVED IN THE NEXT MAJOR RELEASE
+int KLFitter::Particles::AddParticle(const TLorentzVector* const particle, double DetEta, KLFitter::Particles::ParticleType ptype, std::string name, int measuredindex, bool isBtagged, double bTagEff, double bTagRej, TrueFlavorType trueflav, double btagweight) {
+  return AddParticle(*particle, DetEta, ptype, name, measuredindex, isBtagged, bTagEff, bTagRej, trueflav, btagweight);
 }
 
 // ---------------------------------------------------------

--- a/tests/test-ljets-lh.cxx
+++ b/tests/test-ljets-lh.cxx
@@ -54,23 +54,23 @@ std::unique_ptr<KLFitter::Particles> getExampleParticles(float tag_eff, float ta
   lep.SetPtEtaPhiE(30.501886, 0.4483959, 2.9649317, 33.620113);
 
   std::unique_ptr<KLFitter::Particles> particles{new KLFitter::Particles};
-  particles->AddParticle(&jet1, jet1.Eta(),
+  particles->AddParticle(jet1, jet1.Eta(),
       KLFitter::Particles::kParton, "", 0,
       jet1_has_btag, tag_eff, tag_ineff,
       KLFitter::Particles::kNone, jet1_btag_weight);
-  particles->AddParticle(&jet2, jet2.Eta(),
+  particles->AddParticle(jet2, jet2.Eta(),
       KLFitter::Particles::kParton, "", 1,
       jet2_has_btag, tag_eff, tag_ineff,
       KLFitter::Particles::kNone, jet2_btag_weight);
-  particles->AddParticle(&jet3, jet3.Eta(),
+  particles->AddParticle(jet3, jet3.Eta(),
       KLFitter::Particles::kParton, "", 2,
       jet3_has_btag, tag_eff, tag_ineff,
       KLFitter::Particles::kNone, jet3_btag_weight);
-  particles->AddParticle(&jet4, jet4.Eta(),
+  particles->AddParticle(jet4, jet4.Eta(),
       KLFitter::Particles::kParton, "", 3,
       jet4_has_btag, tag_eff, tag_ineff,
       KLFitter::Particles::kNone, jet4_btag_weight);
-  particles->AddParticle(&lep, lep.Eta(), KLFitter::Particles::kMuon, "", 0);
+  particles->AddParticle(lep, lep.Eta(), KLFitter::Particles::kMuon, "", 0);
   return particles;
 }
 

--- a/util/example-top-ljets.cxx
+++ b/util/example-top-ljets.cxx
@@ -249,10 +249,10 @@ int main(int argc, char *argv[]) {
     lepton.SetPtEtaPhiE(event.lepton_pt, event.lepton_eta, event.lepton_phi, event.lepton_e);
     if (event.lepton_is_e) {
       likelihood.SetLeptonType(KLFitter::LikelihoodTopLeptonJets::kElectron);
-      particles.AddParticle(&lepton, event.lepton_eta, KLFitter::Particles::kElectron);
+      particles.AddParticle(lepton, event.lepton_eta, KLFitter::Particles::kElectron);
     } else if (event.lepton_is_mu) {
       likelihood.SetLeptonType(KLFitter::LikelihoodTopLeptonJets::kMuon);
-      particles.AddParticle(&lepton, event.lepton_eta, KLFitter::Particles::kMuon);
+      particles.AddParticle(lepton, event.lepton_eta, KLFitter::Particles::kMuon);
     } else {
       std::cerr << "WARNING: Event has no electrons or muons. Skipping." << std::endl;
       continue;
@@ -275,7 +275,7 @@ int main(int argc, char *argv[]) {
       //  8) 1./tagging inefficiency required for kWorkingPoint
       //  9) true flavour type
       //  10) btag discriminant
-      particles.AddParticle(&jet, event.jet_eta->at(ijet), KLFitter::Particles::kParton,
+      particles.AddParticle(jet, event.jet_eta->at(ijet), KLFitter::Particles::kParton,
           "", ijet, static_cast<int>(event.jet_has_btag->at(ijet)), 0.6, 145.,
           KLFitter::Particles::kNone, event.jet_btag_weight->at(ijet));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR does two changes to the `Particles::AddParticle()` functions:
1. The existing implementations used `TLorentzVector*` for the four-vector input parameters, but these pointers were not modified in the functions. To respect const correctness and to allow feeding in constant pointers, the implementations were adjusted to use `const TLorentzVector* const` instead.
2. As the TLorentzVector objects are only used as input to the functions, it makes more sense to simply use `const TLorentzVector&` type objects. The four above AddParticle() functions were therefore reimplemented using references, and the four above versions using pointers now internally call those reference versions. The pointer versions are kept for compatibility reasons to not break any software interfacing KLFitter, but they will be removed in the next major release.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#49 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Input parameters should ideally be const references if the method only reads from them. For compatibility reasons, the pointer versions will be kept in parallel until the next major release.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
