### PR TITLE
Clean-up/consistency checks in the l+jets likelihood classes

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -205,7 +205,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -20,7 +20,6 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETS_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETS_H_
 
-#include <iostream>
 #include <vector>
 
 #include "KLFitter/LikelihoodBase.h"

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -47,9 +47,7 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
    */
   LikelihoodTopLeptonJets();
 
-  /**
-   * The (defaulted) destructor.
-   */
+  /// The (defaulted) destructor.
   ~LikelihoodTopLeptonJets();
 
   /// @}
@@ -89,15 +87,15 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   void SetFlagGetParSigmasFromTFs(bool flag) { fFlagGetParSigmasFromTFs = flag; }
 
   /**
-    * Set the type of lepton
-    * @param leptontype The type of lepton: kElectron or kMuon
-    */
+   * Set the type of lepton
+   * @param leptontype The type of lepton: kElectron or kMuon
+   */
   void SetLeptonType(LeptonType leptontype);
 
   /**
-    * Set the type of lepton
-    * @param leptontype The type of lepton: electron(1) or muon (2)
-    */
+   * Set the type of lepton
+   * @param leptontype The type of lepton: electron(1) or muon (2)
+   */
   void SetLeptonType(int leptontype);
 
   /// @}
@@ -127,31 +125,31 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   virtual std::vector<double> GetInitialParametersWoNeutrinoPz();
 
   /**
-    * The posterior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
+   * The posterior probability definition, overloaded from BCModel.
+   * @param parameters A vector of parameters (double values).
+   * @return The logarithm of the prior probability.
+   */
   double LogLikelihood(const std::vector <double> & parameters) override;
 
   /**
-    * The posterior probability definition, overloaded from BCModel. Instead of
-    * the final log likelihood value as in LogLikelihood(), this returns all
-    * subcomponents.
-    * @param parameters A vector of parameters (double values).
-    * @return A vector with the components of the logarithm of the prior
-    * probability. Its components are: \n
-    *   0) TF_bhad \n
-    *   1) TF_blep \n
-    *   2) TF_lq1 \n
-    *   3) TF_lq2 \n
-    *   4) TF_lep \n
-    *   5) TF_METx \n
-    *   6) TF_METy \n
-    *   7) BW_Whad \n
-    *   8) BW_Wlep \n
-    *   9) BW_Thad \n
-    *   10) BW_Tlep
-    */
+   * The posterior probability definition, overloaded from BCModel. Instead of
+   * the final log likelihood value as in LogLikelihood(), this returns all
+   * subcomponents.
+   * @param parameters A vector of parameters (double values).
+   * @return A vector with the components of the logarithm of the prior
+   * probability. Its components are: \n
+   *   0) TF_bhad \n
+   *   1) TF_blep \n
+   *   2) TF_lq1 \n
+   *   3) TF_lq2 \n
+   *   4) TF_lep \n
+   *   5) TF_METx \n
+   *   6) TF_METy \n
+   *   7) BW_Whad \n
+   *   8) BW_Wlep \n
+   *   9) BW_Thad \n
+   *   10) BW_Tlep
+   */
   std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
   /// @}
@@ -173,13 +171,13 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
 
  protected:
   /**
-    * Adjust ranges of the parameters. This either takes the parameter sigmas
-    * from the transfer functions, if #fFlagGetParSigmasFromTFs is set.
-    * Otherwise, a fixed sigma is used to calculate the parameter ranges. Then,
-    * SetParameterRange() is called to set the range. If #fFlagTopMassFixed is
-    * set, the top mass will be fixed to the pole mass.
-    * @return An error code.
-    */
+   * Adjust ranges of the parameters. This either takes the parameter sigmas
+   * from the transfer functions, if #fFlagGetParSigmasFromTFs is set.
+   * Otherwise, a fixed sigma is used to calculate the parameter ranges. Then,
+   * SetParameterRange() is called to set the range. If #fFlagTopMassFixed is
+   * set, the top mass will be fixed to the pole mass.
+   * @return An error code.
+   */
   int AdjustParameterRanges() override;
 
   /**
@@ -211,10 +209,10 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   std::vector<double> CalculateNeutrinoPzSolutions(TLorentzVector* additionalParticle = nullptr);
 
   /**
-    * Define the model particles. Create the object #fParticlesModel and add all
-    * particles of this likelihood. The 4-vector components are set to zero.
-    * @return An error code.
-    */
+   * Define the model particles. Create the object #fParticlesModel and add all
+   * particles of this likelihood. The 4-vector components are set to zero.
+   * @return An error code.
+   */
   int DefineModelParticles() override;
 
   /**
@@ -225,28 +223,28 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   std::vector<double> GetNeutrinoPzSolutions();
 
   /**
-    * Remove the invariant particle permutations. In particular, this removes
-    * permutations where the two light jets are swapped. In addition, in case
-    * two types of leptons were added, only permutations with leptons of type
-    * #fTypeLepton are kept.
-    * @return An error code.
-    */
+   * Remove the invariant particle permutations. In particular, this removes
+   * permutations where the two light jets are swapped. In addition, in case
+   * two types of leptons were added, only permutations with leptons of type
+   * #fTypeLepton are kept.
+   * @return An error code.
+   */
   int RemoveInvariantParticlePermutations() override;
 
   /**
-    * Save permuted particles. This takes the permuted particles, stored in
-    * #fParticlesPermuted, and saves their values in the internal variables,
-    * such as #bhad_meas_eta.
-    * @return An error code.
-    */
+   * Save permuted particles. This takes the permuted particles, stored in
+   * #fParticlesPermuted, and saves their values in the internal variables,
+   * such as #bhad_meas_eta.
+   * @return An error code.
+   */
   int SavePermutedParticles() override;
 
   /**
-    * Save the resolution functions from the detector to the internal pointers.
-    * This sets the internal pointers, such as #fResEnergyBhad to the resolution
-    * objects stored in the detector.
-    * @return An error code.
-    */
+   * Save the resolution functions from the detector to the internal pointers.
+   * This sets the internal pointers, such as #fResEnergyBhad to the resolution
+   * objects stored in the detector.
+   * @return An error code.
+   */
   int SaveResolutionFunctions() override;
 
   /// \name Member attributes

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -23,76 +23,69 @@
 #include <iostream>
 #include <vector>
 
-class TLorentzVector;
-
-namespace KLFitter {
-  class ResolutionBase;
-}
-
 #include "KLFitter/LikelihoodBase.h"
+
+class TLorentzVector;
 
 // ---------------------------------------------------------
 
-/**
- * \namespace KLFitter
- * \brief The KLFitter namespace
- */
 namespace KLFitter {
+class ResolutionBase;
+
 /**
-  * \class KLFitter::LikelihoodTopLeptonJets
-  * \brief A class implementing a likelihood for the ttbar lepton+jets channel.
-  *
-  * This class represents a likelihood for the ttbar into lepton+jets.
-  */
+ * A class implementing a likelihood for the ttbar lepton+jets channel. This
+ * class represents a likelihood for the ttbar into lepton+jets.
+ */
 class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
  public:
-  /** \name Constructors and destructors */
-  /* @{ */
+  /// \name Constructors and destructors
+  /// @{
 
   /**
-    * The default constructor.
-    */
+   * The default constructor. This initializes all member attributes and calls
+   * the functions DefineModelParticles() and DefineParameters().
+   */
   LikelihoodTopLeptonJets();
 
   /**
-    * The (defaulted) destructor.
-    */
+   * The (defaulted) destructor.
+   */
   ~LikelihoodTopLeptonJets();
 
-  /* @} */
-  /** \name Member functions (Get)  */
-  /* @{ */
+  /// @}
 
-  /* @} */
-  /** \name Member functions (Set)  */
-  /* @{ */
+  /// Enumerator for the lepton type.
+  enum LeptonType { kElectron,  ///< Leptons of type electron
+                    kMuon       ///< Leptons of type muon
+  };
 
-  /**
-    * Enumerator for the lepton type.
-    */
-  enum LeptonType { kElectron, kMuon };
+  /// Enumerator for the fitted parameters of this likelihood.
+  enum Parameters { parBhadE,   ///< Energy of the hadronic b quark
+                    parBlepE,   ///< Energy of the leptonic b quark
+                    parLQ1E,    ///< Energy of the light quark 1
+                    parLQ2E,    ///< Energy of the light quark 2
+                    parLepE,    ///< Energy of the lepton
+                    parNuPx,    ///< p_x of the neutrino
+                    parNuPy,    ///< p_y of the neutrino
+                    parNuPz,    ///< p_z of the neutrino
+                    parTopM     ///< Mass of the top quark
+  };
 
-  /**
-    * Enumerator for the parameters.
-    */
-  enum Parameters { parBhadE, parBlepE, parLQ1E, parLQ2E, parLepE, parNuPx, parNuPy, parNuPz, parTopM };
-
-  /**
-    * Set the values for the missing ET x and y components and the SumET.
-    * @param etx missing ET x component.
-    * @param ety missing ET y component.
-    * @param sumet total scalar ET.
-    * @return An error flag.
-    */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
+  /// \name Member functions (Set)
+  /// @{
 
   /**
-    * Set a flag. If flag is true the invariant top quark mass is
-    * fixed to the pole mass.
-    * @param flag The flag.
-    */
+   * Set a flag. If flag is true the invariant top quark mass is
+   * fixed to the pole mass.
+   * @param flag The flag.
+   */
   void SetFlagTopMassFixed(bool flag) { fFlagTopMassFixed = flag; }
 
+  /**
+   * Set a flag. If flag is true, take the parameter sigma values from the
+   * transfer functions.
+   * @param flag The flag.
+   */
   void SetFlagGetParSigmasFromTFs(bool flag) { fFlagGetParSigmasFromTFs = flag; }
 
   /**
@@ -107,18 +100,31 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
     */
   void SetLeptonType(int leptontype);
 
-  /* @} */
-  /** \name Member functions (misc)  */
-  /* @{ */
-
-  /* @} */
-  /** \name Member functions (BAT)  */
-  /* @{ */
+  /// @}
+  /// \name Member functions (BAT)
+  /// @{
 
   /**
-    * Define the parameters of the fit.
-    */
+   * Define the parameters of the fit. This calls BCModel::AddParameter() for
+   * all parameters in the enum #Parameters.
+   */
   void DefineParameters() override;
+
+  /**
+   * Get initial values for the parameters. This calls
+   * GetInitialParametersWoNeutrinoPz() and retrieves the neutrino solutions
+   * via GetNeutrinoPzSolutions(). The initial values are then set accordingly.
+   * @return vector of initial values.
+   */
+  std::vector<double> GetInitialParameters() override;
+
+  /**
+   * Get initial values for the parameters with a dummy of "0.0" for the neutrino pz.
+   * The decision on the initial value for the neutrino pz then needs to be done in
+   * GetInitialParameters().
+   * @return vector of initial values.
+   */
+  virtual std::vector<double> GetInitialParametersWoNeutrinoPz();
 
   /**
     * The posterior probability definition, overloaded from BCModel.
@@ -128,148 +134,164 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   double LogLikelihood(const std::vector <double> & parameters) override;
 
   /**
-    * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
+    * The posterior probability definition, overloaded from BCModel. Instead of
+    * the final log likelihood value as in LogLikelihood(), this returns all
+    * subcomponents.
     * @param parameters A vector of parameters (double values).
-    * @return A vector with the components of the logarithm of the prior probability. Its components are:
-    * 0:  TF_bhad
-    * 1:  TF_blep
-    * 2:  TF_lq1
-    * 3:  TF_lq2
-    * 4:  TF_lep
-    * 5:  TF_METx
-    * 6:  TF_METy
-    * 7:  BW_Whad
-    * 8:  BW_Wlep
-    * 9:  BW_Thad
-    * 10: BW_Tlep
+    * @return A vector with the components of the logarithm of the prior
+    * probability. Its components are: \n
+    *   0) TF_bhad \n
+    *   1) TF_blep \n
+    *   2) TF_lq1 \n
+    *   3) TF_lq2 \n
+    *   4) TF_lep \n
+    *   5) TF_METx \n
+    *   6) TF_METy \n
+    *   7) BW_Whad \n
+    *   8) BW_Wlep \n
+    *   9) BW_Thad \n
+    *   10) BW_Tlep
     */
   std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
-  /**
-    * Get initial values for the parameters.
-    * @return vector of initial values.
-    */
-  std::vector<double> GetInitialParameters() override;
+  /// @}
+  /// \name Member functions (misc)
+  /// @{
 
   /**
-    * Get initial values for the parameters with a dummy of "0.0" for the neutrino pz.
-    * The decision on the initial value for the neutrino pz then needs to be done in
-    * GetInitialParameters().
-    * @return vector of initial values.
-    */
-  virtual std::vector<double> GetInitialParametersWoNeutrinoPz();
+   * Set the values for the missing ET x and y components and the SumET. This
+   * sets the internal variables #ETmiss_x, #ETmiss_y and #SumET to the
+   * given values.
+   * @param etx missing ET x component.
+   * @param ety missing ET y component.
+   * @param sumet total scalar ET.
+   * @return An error flag.
+   */
+  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
-  /* @} */
+  /// @}
 
  protected:
-  /** \name Member functions (misc)  */
-  /* @{ */
-
   /**
-    * Update 4-vectors of model particles.
-    * @return An error flag.
-    */
-  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
-
-  /**
-    * Adjust parameter ranges
+    * Adjust ranges of the parameters. This either takes the parameter sigmas
+    * from the transfer functions, if #fFlagGetParSigmasFromTFs is set.
+    * Otherwise, a fixed sigma is used to calculate the parameter ranges. Then,
+    * SetParameterRange() is called to set the range. If #fFlagTopMassFixed is
+    * set, the top mass will be fixed to the pole mass.
+    * @return An error code.
     */
   int AdjustParameterRanges() override;
 
   /**
-    * Define the model particles
+   * Build the model particles from the best fit parameters. This sets the
+   * particles of #fParticlesModel to the fitted parameter values. The W boson
+   * and top quark parameters are combined from the other particles.
+   * @return An error code.
+   */
+  int BuildModelParticles() override;
+
+  /**
+   * Update 4-vector values of the model particles. This updates the internal
+   * variables, such as #bhad_fit_px or #thad_fit_m to the latest values from
+   * the fit. These variables are for example used in the log likelihood
+   * calculation.
+   * @return An error flag.
+   */
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
+
+  /**
+   * Calculates the neutrino pz solutions from the measured values and the W
+   * mass. An additional particle to be added to the charged lepton may be
+   * specified, for example a photon in ttbargamma, which is radiated from the
+   * leptonic W or the charged lepton;
+   * @param additionalParticle Pointer to a 4-vector of a particle which is
+   * added to the charged lepton in the calculation.
+   * @return A vector with 0, 1 or 2 neutrino pz solutions.
+   */
+  std::vector<double> CalculateNeutrinoPzSolutions(TLorentzVector* additionalParticle = nullptr);
+
+  /**
+    * Define the model particles. Create the object #fParticlesModel and add all
+    * particles of this likelihood. The 4-vector components are set to zero.
     * @return An error code.
     */
   int DefineModelParticles() override;
 
   /**
-    * Remove invariant particle permutations.
+   * Return the neutrino pz solutions from the measured values and the W mass.
+   * This calls CalculateNeutrinoPzSolutions() and returns the results.
+   * @return A vector with 0, 1 or 2 neutrino pz solutions.
+   */
+  std::vector<double> GetNeutrinoPzSolutions();
+
+  /**
+    * Remove the invariant particle permutations. In particular, this removes
+    * permutations where the two light jets are swapped. In addition, in case
+    * two types of leptons were added, only permutations with leptons of type
+    * #fTypeLepton are kept.
     * @return An error code.
     */
   int RemoveInvariantParticlePermutations() override;
 
   /**
-    * Build the model particles from the best fit parameters.
+    * Save permuted particles. This takes the permuted particles, stored in
+    * #fParticlesPermuted, and saves their values in the internal variables,
+    * such as #bhad_meas_eta.
     * @return An error code.
-    */
-  int BuildModelParticles() override;
-
-  /* @} */
-
- protected:
-  /**
-    * A flag for using a fixed top mass (true) or not (false).
-    */
-  bool fFlagTopMassFixed;
-
-  /**
-    *  Flag for using ResolutionBase::GetSigma() to retrieve the parameter ranges
-    */
-  bool fFlagGetParSigmasFromTFs;
-
-  /**
-    * Return the neutrino pz solutions from the measured values
-    * and the W mass.
-    * @return A vector with 0, 1 or 2 neutrino pz solutions.
-    */
-  std::vector<double> GetNeutrinoPzSolutions();
-
-  /**
-    * Calculates the neutrino pz solutions from the measured values
-    * and the W mass. An additional particle to be added to the
-    * charged lepton may be specified, for example a photon
-    * in ttbargamma, which is radiated from the leptonic W
-    * or the charged lepton;
-    * @param additionalParticle Pointer to a 4-vector of a particle which is
-    * added to the charged lepton in the calculation
-    * @return A vector with 0, 1 or 2 neutrino pz solutions.
-    */
-  std::vector<double> CalculateNeutrinoPzSolutions(TLorentzVector * additionalParticle = 0x0);
-
-  /**
-    * Save permuted particles.
     */
   int SavePermutedParticles() override;
 
   /**
-    * Save resolution functions.
+    * Save the resolution functions from the detector to the internal pointers.
+    * This sets the internal pointers, such as #fResEnergyBhad to the resolution
+    * objects stored in the detector.
+    * @return An error code.
     */
   int SaveResolutionFunctions() override;
 
-  /**
-    * The values of the x component of the missing ET.
-    */
+  /// \name Member attributes
+  /// @{
+
+  /// A flag for using a fixed top mass (true) or not (false).
+  bool fFlagTopMassFixed;
+
+  /// Flag for using ResolutionBase::GetSigma() to retrieve the parameter ranges
+  bool fFlagGetParSigmasFromTFs;
+
+  /// The values of the x component of the missing ET.
   double ETmiss_x;
 
-  /**
-    * The values of the y component of the missing ET.
-    */
+  /// The values of the y component of the missing ET.
   double ETmiss_y;
 
-  /**
-    * The values of the total scalar ET.
-    */
+  /// The values of the total scalar ET.
   double SumET;
 
-  /**
-    * An index deciding if the event is electron (1) or muon (2) plus
-    * jets.
-    */
+  /// An index deciding if the event is electron (1) or muon (2) plus jets.
   LeptonType fTypeLepton;
 
-  /**
-    * Save resolution functions since the eta of the partons is not fitted.
-    */
-  ResolutionBase * fResEnergyBhad;
-  ResolutionBase * fResEnergyBlep;
-  ResolutionBase * fResEnergyLQ1;
-  ResolutionBase * fResEnergyLQ2;
-  ResolutionBase * fResLepton;
-  ResolutionBase * fResMET;
+  /// Pointer to resolution function for hadronic b quark.
+  ResolutionBase* fResEnergyBhad;
 
-  /**
-    * Save measured particle values for frequent calls
-    */
+  /// Pointer to resolution function for leptonic b quark.
+  ResolutionBase* fResEnergyBlep;
+
+  /// Pointer to resolution function for first light quark jet.
+  ResolutionBase* fResEnergyLQ1;
+
+  /// Pointer to resolution function for second light quark jet.
+  ResolutionBase* fResEnergyLQ2;
+
+  /// Pointer to resolution function for the lepton.
+  ResolutionBase* fResLepton;
+
+  /// Pointer to resolution function for MET.
+  ResolutionBase* fResMET;
+
+  /// @}
+  /// \name Member attributes (measured parameters)
+  /// @{
+
   double bhad_meas_e;
   double bhad_meas_p;
   double bhad_meas_m;
@@ -318,9 +340,10 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   double lep_meas_py;
   double lep_meas_pz;
 
-  /**
-    * Save fit particle values for frequent calls
-    */
+  /// @}
+  /// \name Member attributes (fitted parameters)
+  /// @{
+
   double bhad_fit_e;
   double bhad_fit_px;
   double bhad_fit_py;
@@ -365,6 +388,8 @@ class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
   double wlep_fit_m;
   double thad_fit_m;
   double tlep_fit_m;
+
+  /// @}
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -36,7 +36,7 @@ class ResolutionBase;
  * A class implementing a likelihood for the ttbar lepton+jets channel. This
  * class represents a likelihood for the ttbar into lepton+jets.
  */
-class LikelihoodTopLeptonJets : public KLFitter::LikelihoodBase {
+class LikelihoodTopLeptonJets : public LikelihoodBase {
  public:
   /// \name Constructors and destructors
   /// @{

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -77,14 +77,14 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
    * fixed to the pole mass.
    * @param flag The flag.
    */
-  void SetFlagTopMassFixed(bool flag) { fFlagTopMassFixed = flag; }
+  void SetFlagTopMassFixed(bool flag) { m_flag_top_mass_fixed = flag; }
 
   /**
    * Set a flag. If flag is true, take the parameter sigma values from the
    * transfer functions.
    * @param flag The flag.
    */
-  void SetFlagGetParSigmasFromTFs(bool flag) { fFlagGetParSigmasFromTFs = flag; }
+  void SetFlagGetParSigmasFromTFs(bool flag) { m_flag_get_par_sigmas_from_TFs = flag; }
 
   /**
    * Set the type of lepton
@@ -157,8 +157,8 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
   /// @{
 
   /**
-   * Set the values for the missing ET x and y components and the SumET. This
-   * sets the internal variables #ETmiss_x, #ETmiss_y and #SumET to the
+   * Set the values for the missing ET x and y components and the m_et_miss_sum. This
+   * sets the internal variables #m_et_miss_x, #m_et_miss_y and #m_et_miss_sum to the
    * given values.
    * @param etx missing ET x component.
    * @param ety missing ET y component.
@@ -172,9 +172,9 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
  protected:
   /**
    * Adjust ranges of the parameters. This either takes the parameter sigmas
-   * from the transfer functions, if #fFlagGetParSigmasFromTFs is set.
+   * from the transfer functions, if #m_flag_get_par_sigmas_from_TFs is set.
    * Otherwise, a fixed sigma is used to calculate the parameter ranges. Then,
-   * SetParameterRange() is called to set the range. If #fFlagTopMassFixed is
+   * SetParameterRange() is called to set the range. If #m_flag_top_mass_fixed is
    * set, the top mass will be fixed to the pole mass.
    * @return An error code.
    */
@@ -190,7 +190,7 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
 
   /**
    * Update 4-vector values of the model particles. This updates the internal
-   * variables, such as #bhad_fit_px or #thad_fit_m to the latest values from
+   * variables, such as #m_bhad_fit_px or #m_thad_fit_m to the latest values from
    * the fit. These variables are for example used in the log likelihood
    * calculation.
    * @return An error flag.
@@ -226,7 +226,7 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
    * Remove the invariant particle permutations. In particular, this removes
    * permutations where the two light jets are swapped. In addition, in case
    * two types of leptons were added, only permutations with leptons of type
-   * #fTypeLepton are kept.
+   * #m_lepton_type are kept.
    * @return An error code.
    */
   int RemoveInvariantParticlePermutations() override;
@@ -234,14 +234,14 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
   /**
    * Save permuted particles. This takes the permuted particles, stored in
    * #fParticlesPermuted, and saves their values in the internal variables,
-   * such as #bhad_meas_eta.
+   * such as #m_bhad_meas_eta.
    * @return An error code.
    */
   int SavePermutedParticles() override;
 
   /**
    * Save the resolution functions from the detector to the internal pointers.
-   * This sets the internal pointers, such as #fResEnergyBhad to the resolution
+   * This sets the internal pointers, such as #m_res_energy_bhad to the resolution
    * objects stored in the detector.
    * @return An error code.
    */
@@ -251,141 +251,141 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
   /// @{
 
   /// A flag for using a fixed top mass (true) or not (false).
-  bool fFlagTopMassFixed;
+  bool m_flag_top_mass_fixed;
 
   /// Flag for using ResolutionBase::GetSigma() to retrieve the parameter ranges
-  bool fFlagGetParSigmasFromTFs;
+  bool m_flag_get_par_sigmas_from_TFs;
 
   /// The values of the x component of the missing ET.
-  double ETmiss_x;
+  double m_et_miss_x;
 
   /// The values of the y component of the missing ET.
-  double ETmiss_y;
+  double m_et_miss_y;
 
   /// The values of the total scalar ET.
-  double SumET;
+  double m_et_miss_sum;
 
   /// An index deciding if the event is electron (1) or muon (2) plus jets.
-  LeptonType fTypeLepton;
+  LeptonType m_lepton_type;
 
   /// Pointer to resolution function for hadronic b quark.
-  ResolutionBase* fResEnergyBhad;
+  ResolutionBase* m_res_energy_bhad;
 
   /// Pointer to resolution function for leptonic b quark.
-  ResolutionBase* fResEnergyBlep;
+  ResolutionBase* m_res_energy_blep;
 
   /// Pointer to resolution function for first light quark jet.
-  ResolutionBase* fResEnergyLQ1;
+  ResolutionBase* m_res_energy_lq1;
 
   /// Pointer to resolution function for second light quark jet.
-  ResolutionBase* fResEnergyLQ2;
+  ResolutionBase* m_res_energy_lq2;
 
   /// Pointer to resolution function for the lepton.
-  ResolutionBase* fResLepton;
+  ResolutionBase* m_res_lepton;
 
   /// Pointer to resolution function for MET.
-  ResolutionBase* fResMET;
+  ResolutionBase* m_res_met;
 
   /// @}
   /// \name Member attributes (measured parameters)
   /// @{
 
-  double bhad_meas_e;
-  double bhad_meas_p;
-  double bhad_meas_m;
-  double bhad_meas_deteta;
-  double bhad_meas_eta;
-  double bhad_meas_phi;
-  double bhad_meas_px;
-  double bhad_meas_py;
-  double bhad_meas_pz;
+  double m_bhad_meas_e;
+  double m_bhad_meas_p;
+  double m_bhad_meas_m;
+  double m_bhad_meas_deteta;
+  double m_bhad_meas_eta;
+  double m_bhad_meas_phi;
+  double m_bhad_meas_px;
+  double m_bhad_meas_py;
+  double m_bhad_meas_pz;
 
-  double blep_meas_e;
-  double blep_meas_p;
-  double blep_meas_m;
-  double blep_meas_deteta;
-  double blep_meas_eta;
-  double blep_meas_phi;
-  double blep_meas_px;
-  double blep_meas_py;
-  double blep_meas_pz;
+  double m_blep_meas_e;
+  double m_blep_meas_p;
+  double m_blep_meas_m;
+  double m_blep_meas_deteta;
+  double m_blep_meas_eta;
+  double m_blep_meas_phi;
+  double m_blep_meas_px;
+  double m_blep_meas_py;
+  double m_blep_meas_pz;
 
-  double lq1_meas_e;
-  double lq1_meas_p;
-  double lq1_meas_m;
-  double lq1_meas_deteta;
-  double lq1_meas_eta;
-  double lq1_meas_phi;
-  double lq1_meas_px;
-  double lq1_meas_py;
-  double lq1_meas_pz;
+  double m_lq1_meas_e;
+  double m_lq1_meas_p;
+  double m_lq1_meas_m;
+  double m_lq1_meas_deteta;
+  double m_lq1_meas_eta;
+  double m_lq1_meas_phi;
+  double m_lq1_meas_px;
+  double m_lq1_meas_py;
+  double m_lq1_meas_pz;
 
-  double lq2_meas_e;
-  double lq2_meas_p;
-  double lq2_meas_m;
-  double lq2_meas_deteta;
-  double lq2_meas_eta;
-  double lq2_meas_phi;
-  double lq2_meas_px;
-  double lq2_meas_py;
-  double lq2_meas_pz;
+  double m_lq2_meas_e;
+  double m_lq2_meas_p;
+  double m_lq2_meas_m;
+  double m_lq2_meas_deteta;
+  double m_lq2_meas_eta;
+  double m_lq2_meas_phi;
+  double m_lq2_meas_px;
+  double m_lq2_meas_py;
+  double m_lq2_meas_pz;
 
-  double lep_meas_e;
-  double lep_meas_deteta;
-  double lep_meas_sintheta;
-  double lep_meas_pt;
-  double lep_meas_px;
-  double lep_meas_py;
-  double lep_meas_pz;
+  double m_lep_meas_e;
+  double m_lep_meas_deteta;
+  double m_lep_meas_sintheta;
+  double m_lep_meas_pt;
+  double m_lep_meas_px;
+  double m_lep_meas_py;
+  double m_lep_meas_pz;
 
   /// @}
   /// \name Member attributes (fitted parameters)
   /// @{
 
-  double bhad_fit_e;
-  double bhad_fit_px;
-  double bhad_fit_py;
-  double bhad_fit_pz;
+  double m_bhad_fit_e;
+  double m_bhad_fit_px;
+  double m_bhad_fit_py;
+  double m_bhad_fit_pz;
 
-  double blep_fit_e;
-  double blep_fit_px;
-  double blep_fit_py;
-  double blep_fit_pz;
+  double m_blep_fit_e;
+  double m_blep_fit_px;
+  double m_blep_fit_py;
+  double m_blep_fit_pz;
 
-  double lq1_fit_e;
-  double lq1_fit_px;
-  double lq1_fit_py;
-  double lq1_fit_pz;
+  double m_lq1_fit_e;
+  double m_lq1_fit_px;
+  double m_lq1_fit_py;
+  double m_lq1_fit_pz;
 
-  double lq2_fit_e;
-  double lq2_fit_px;
-  double lq2_fit_py;
-  double lq2_fit_pz;
+  double m_lq2_fit_e;
+  double m_lq2_fit_px;
+  double m_lq2_fit_py;
+  double m_lq2_fit_pz;
 
-  double lep_fit_e;
-  double lep_fit_px;
-  double lep_fit_py;
-  double lep_fit_pz;
+  double m_lep_fit_e;
+  double m_lep_fit_px;
+  double m_lep_fit_py;
+  double m_lep_fit_pz;
 
-  double nu_fit_e;
-  double nu_fit_px;
-  double nu_fit_py;
-  double nu_fit_pz;
+  double m_nu_fit_e;
+  double m_nu_fit_px;
+  double m_nu_fit_py;
+  double m_nu_fit_pz;
 
-  double wlep_fit_e;
-  double wlep_fit_px;
-  double wlep_fit_py;
-  double wlep_fit_pz;
+  double m_wlep_fit_e;
+  double m_wlep_fit_px;
+  double m_wlep_fit_py;
+  double m_wlep_fit_pz;
 
-  double whad_fit_e;
-  double whad_fit_px;
-  double whad_fit_py;
-  double whad_fit_pz;
+  double m_whad_fit_e;
+  double m_whad_fit_px;
+  double m_whad_fit_py;
+  double m_whad_fit_pz;
 
-  double whad_fit_m;
-  double wlep_fit_m;
-  double thad_fit_m;
-  double tlep_fit_m;
+  double m_whad_fit_m;
+  double m_wlep_fit_m;
+  double m_thad_fit_m;
+  double m_tlep_fit_m;
 
   /// @}
 };

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -37,8 +37,8 @@ class ResolutionBase;
  */
 class LikelihoodTopLeptonJets : public LikelihoodBase {
  public:
-  /// \name Constructors and destructors
-  /// @{
+  /** \name Constructors and destructors */
+  /* @{ */
 
   /**
    * The default constructor. This initializes all member attributes and calls
@@ -49,7 +49,7 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
   /// The (defaulted) destructor.
   ~LikelihoodTopLeptonJets();
 
-  /// @}
+  /* @} */
 
   /// Enumerator for the lepton type.
   enum LeptonType { kElectron,  ///< Leptons of type electron
@@ -68,8 +68,8 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
                     parTopM     ///< Mass of the top quark
   };
 
-  /// \name Member functions (Set)
-  /// @{
+  /** \name Member functions (Set)  */
+  /* @{ */
 
   /**
    * Set a flag. If flag is true the invariant top quark mass is
@@ -97,9 +97,9 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
    */
   void SetLeptonType(int leptontype);
 
-  /// @}
-  /// \name Member functions (BAT)
-  /// @{
+  /* @} */
+  /** \name Member functions (BAT)  */
+  /* @{ */
 
   /**
    * Define the parameters of the fit. This calls BCModel::AddParameter() for
@@ -151,9 +151,9 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
    */
   std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
-  /// @}
-  /// \name Member functions (misc)
-  /// @{
+  /* @} */
+  /** \name Member functions (misc)  */
+  /* @{ */
 
   /**
    * Set the values for the missing ET x and y components and the m_et_miss_sum. This
@@ -166,7 +166,7 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
    */
   int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
-  /// @}
+  /* @} */
 
  protected:
   /**
@@ -246,8 +246,8 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
    */
   int SaveResolutionFunctions() override;
 
-  /// \name Member attributes
-  /// @{
+  /** \name Member attributes */
+  /* @{ */
 
   /// A flag for using a fixed top mass (true) or not (false).
   bool m_flag_top_mass_fixed;
@@ -285,9 +285,9 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
   /// Pointer to resolution function for MET.
   ResolutionBase* m_res_met;
 
-  /// @}
-  /// \name Member attributes (measured parameters)
-  /// @{
+  /* @} */
+  /** \name Member attributes (measured parameters) */
+  /* @{ */
 
   double m_bhad_meas_e;
   double m_bhad_meas_p;
@@ -337,9 +337,9 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
   double m_lep_meas_py;
   double m_lep_meas_pz;
 
-  /// @}
-  /// \name Member attributes (fitted parameters)
-  /// @{
+  /* @} */
+  /** \name Member attributes (fitted parameters) */
+  /* @{ */
 
   double m_bhad_fit_e;
   double m_bhad_fit_px;
@@ -386,7 +386,7 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
   double m_thad_fit_m;
   double m_tlep_fit_m;
 
-  /// @}
+  /* @} */
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -22,30 +22,24 @@
 
 #include <iostream>
 
+#include "KLFitter/LikelihoodTopLeptonJets.h"
+
 class TH1F;
 class TH2F;
 class TLorentzVector;
 
-namespace KLFitter {
-  class ResolutionBase;
-}
-
-#include "KLFitter/LikelihoodTopLeptonJets.h"
-
 // ---------------------------------------------------------
 
-/**
- * \namespace KLFitter
- * \brief The KLFitter namespace
- */
 namespace KLFitter {
+class ResolutionBase;
+
 /**
   * \class KLFitter::LikelihoodTopLeptonJetsUDSep
   * \brief A class implementing a likelihood for the ttbar lepton+jets channel.
   *
   * This class represents a likelihood for the ttbar into lepton+jets.
   */
-class LikelihoodTopLeptonJetsUDSep : public KLFitter::LikelihoodTopLeptonJets {
+class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
  public:
   /**
     * Enumerate for lJet reweighting methods
@@ -198,7 +192,7 @@ class LikelihoodTopLeptonJetsUDSep : public KLFitter::LikelihoodTopLeptonJets {
     * Set a flag. If flag is true the permutations are reweighted with the pT and tag weight probabilities.
     * @param flag The flag.
     */
-  void SetLJetSeparationMethod(KLFitter::LikelihoodTopLeptonJetsUDSep::LJetSeparationMethod flag) { fLJetSeparationMethod = flag; }
+  void SetLJetSeparationMethod(LikelihoodTopLeptonJetsUDSep::LJetSeparationMethod flag) { fLJetSeparationMethod = flag; }
 
   /**
     * Check if the permutation is LH invariant.
@@ -252,7 +246,7 @@ class LikelihoodTopLeptonJetsUDSep : public KLFitter::LikelihoodTopLeptonJets {
   /**
     * A flag for using an additional reweighting of the permutations with the pT and tag weight probability (default: false);
     */
-  KLFitter::LikelihoodTopLeptonJetsUDSep::LJetSeparationMethod fLJetSeparationMethod;
+  LikelihoodTopLeptonJetsUDSep::LJetSeparationMethod fLJetSeparationMethod;
 
   /**
     * A pointer to the histogram of the up type jet pT distribution.

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -95,70 +95,70 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
   /// @{
 
   /// Set a flag. If flag is true the permutations are reweighted with the pT and tag weight probabilities.
-  void SetLJetSeparationMethod(LJetSeparationMethod flag) { fLJetSeparationMethod = flag; }
+  void SetLJetSeparationMethod(LJetSeparationMethod flag) { m_ljet_separation_method = flag; }
 
   /**
    * Set histogram for tag weight distribution of b jets.
    * @param hist Pointer to histogram.
    * @return An error flag.
    */
-  int SetBJet2DWeightHisto(TH2F* hist) { fBJet2DWeightHisto = hist; return 1; }
+  int SetBJet2DWeightHisto(TH2F* hist) { m_bjet_2d_weight_histo = hist; return 1; }
 
   /**
    * Set histogram for pT distribution of b jets (reco level).
    * @param hist Pointer to histogram.
    * @return An error flag.
    */
-  int SetBJetPtHisto(TH1F* hist) { fBJetPtHisto = hist; return 1; }
+  int SetBJetPtHisto(TH1F* hist) { m_bjet_pt_histo = hist; return 1; }
 
   /**
    * Set histogram for tag weight distribution of b jets.
    * @param hist Pointer to histogram.
    * @return An error flag.
    */
-  int SetBJetTagWeightHisto(TH1F* hist) { fBJetTagWeightHisto = hist; return 1; }
+  int SetBJetTagWeightHisto(TH1F* hist) { m_bjet_tag_weight_histo = hist; return 1; }
 
   /**
    * Set histogram for tag weight distribution of down type jets.
    * @param hist Pointer to histogram.
    * @return An error flag.
    */
-  int SetDownJet2DWeightHisto(TH2F* hist) { fDownJet2DWeightHisto = hist; return 1; }
+  int SetDownJet2DWeightHisto(TH2F* hist) { m_down_jet_2d_weight_histo = hist; return 1; }
 
   /**
    * Set histogram for pT distribution of down jets (reco level).
    * @param hist Pointer to histogram.
    * @return An error flag.
    */
-  int SetDownJetPtHisto(TH1F* hist) { fDownJetPtHisto = hist; return 1; }
+  int SetDownJetPtHisto(TH1F* hist) { m_down_jet_pt_histo = hist; return 1; }
 
   /**
    * Set histogram for tag weight distribution of down type jets.
    * @param hist Pointer to histogram.
    * @return An error flag.
    */
-  int SetDownJetTagWeightHisto(TH1F* hist) { fDownJetTagWeightHisto = hist; return 1; }
+  int SetDownJetTagWeightHisto(TH1F* hist) { m_down_jet_tag_weight_histo = hist; return 1; }
 
   /**
    * Set histogram for tag weight distribution of up type jets.
    * @param hist Pointer to histogram.
    * @return An error flag.
    */
-  int SetUpJet2DWeightHisto(TH2F* hist) { fUpJet2DWeightHisto = hist; return 1; }
+  int SetUpJet2DWeightHisto(TH2F* hist) { m_up_jet_2d_weight_histo = hist; return 1; }
 
   /**
    * Set histogram for pT distribution of up jets (reco level).
    * @param hist Pointer to histogram.
    * @return An error flag.
    */
-  int SetUpJetPtHisto(TH1F* hist) { fUpJetPtHisto = hist; return 1; }
+  int SetUpJetPtHisto(TH1F* hist) { m_up_jet_pt_histo = hist; return 1; }
 
   /**
    * Set histogram for tag weight distribution of up type jets.
    * @param hist Pointer to histogram.
    * @return An error flag.
    */
-  int SetUpJetTagWeightHisto(TH1F* hist) { fUpJetTagWeightHisto = hist; return 1; }
+  int SetUpJetTagWeightHisto(TH1F* hist) { m_up_jet_tag_weight_histo = hist; return 1; }
 
   /// @}
   /// \name Member functions (BAT)
@@ -226,34 +226,34 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
 
   /// A flag for using an additional reweighting of the permutations with the pT
   /// and tag weight probability (default: false);
-  LJetSeparationMethod fLJetSeparationMethod;
+  LJetSeparationMethod m_ljet_separation_method;
 
   /// A pointer to the 2d histogram "tag weight vs. pT for bQuarks"
-  TH2F* fBJet2DWeightHisto;
+  TH2F* m_bjet_2d_weight_histo;
 
   /// A pointer to the histogram of the down b jet pT distribution.
-  TH1F* fBJetPtHisto;
+  TH1F* m_bjet_pt_histo;
 
   /// A pointer to the histogram of the up b tag weight distribution.
-  TH1F* fBJetTagWeightHisto;
+  TH1F* m_bjet_tag_weight_histo;
 
   /// A pointer to the 2d histogram "tag weight vs. pT for downQuarks"
-  TH2F* fDownJet2DWeightHisto;
+  TH2F* m_down_jet_2d_weight_histo;
 
   /// A pointer to the histogram of the down type jet pT distribution.
-  TH1F* fDownJetPtHisto;
+  TH1F* m_down_jet_pt_histo;
 
   /// A pointer to the histogram of the down quark tag weight distribution.
-  TH1F* fDownJetTagWeightHisto;
+  TH1F* m_down_jet_tag_weight_histo;
 
   /// A pointer to the 2d histogram "tag weight vs. pT for upQuarks"
-  TH2F* fUpJet2DWeightHisto;
+  TH2F* m_up_jet_2d_weight_histo;
 
   /// A pointer to the histogram of the up type jet pT distribution.
-  TH1F* fUpJetPtHisto;
+  TH1F* m_up_jet_pt_histo;
 
   /// A pointer to the histogram of the up quark tag weight distribution.
-  TH1F* fUpJetTagWeightHisto;
+  TH1F* m_up_jet_tag_weight_histo;
 
   /// @}
 };

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -20,19 +20,14 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETSUDSEP_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETSUDSEP_H_
 
-#include <iostream>
-
 #include "KLFitter/LikelihoodTopLeptonJets.h"
 
 class TH1F;
 class TH2F;
-class TLorentzVector;
 
 // ---------------------------------------------------------
 
 namespace KLFitter {
-class ResolutionBase;
-
 /**
   * \class KLFitter::LikelihoodTopLeptonJetsUDSep
   * \brief A class implementing a likelihood for the ttbar lepton+jets channel.

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -42,8 +42,8 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
     kPermReweight2D  ///< description here
   };
 
-  /// \name Constructors and destructors
-  /// @{
+  /** \name Constructors and destructors */
+  /* @{ */
 
   /// The default constructor. In addition to LikelihoodTopLeptonJets(), this
   /// initializes #m_ljet_separation_method to kNone.
@@ -52,9 +52,9 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
   /// The (defaulted) destructor.
   ~LikelihoodTopLeptonJetsUDSep();
 
-  /// @}
-  /// \name Member functions (Get)
-  /// @{
+  /* @} */
+  /** \name Member functions (Get)  */
+  /* @{ */
 
   /// Probability of a jet to have the tag weight and pT of a b jet.
   double BJetProb(double tagweight, double pt);
@@ -83,9 +83,9 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
   /// Probability of a jet to have the tag weight of an up-type jet.
   double UpJetTagWeight(double tagweight);
 
-  /// @}
-  /// \name Member functions (Set)
-  /// @{
+  /* @} */
+  /** \name Member functions (Set)  */
+  /* @{ */
 
   /// Set a flag. If flag is true the permutations are reweighted with the pT
   /// and tag weight probabilities.
@@ -154,9 +154,9 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
    */
   int SetUpJetTagWeightHisto(TH1F* hist) { m_up_jet_tag_weight_histo = hist; return 1; }
 
-  /// @}
-  /// \name Member functions (BAT)
-  /// @{
+  /* @} */
+  /** \name Member functions (BAT)  */
+  /* @{ */
 
   /**
    * Define the parameters of the fit. In addition to
@@ -183,9 +183,9 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
    */
   double LogEventProbabilityBTag() override;
 
-  /// @}
-  /// \name Member functions (misc)
-  /// @{
+  /* @} */
+  /** \name Member functions (misc)  */
+  /* @{ */
 
   /**
    * Check if the permutation is LH invariant. A documentation, as to \a why
@@ -206,7 +206,7 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
    */
   double LogEventProbabilityLJetReweight();
 
-  /// @}
+  /* @} */
 
  protected:
   /**
@@ -231,8 +231,8 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
    */
   int RemoveInvariantParticlePermutations() override;
 
-  /// @{
-  /// \name Member attributes
+  /* @{ */
+  /** \name Member attributes */
 
   /// A flag for using an additional reweighting of the permutations with the pT
   /// and tag weight probability (default: false);
@@ -265,7 +265,7 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
   /// A pointer to the histogram of the up quark tag weight distribution.
   TH1F* m_up_jet_tag_weight_histo;
 
-  /// @}
+  /* @} */
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -165,20 +165,26 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
   /// @{
 
   /**
-   * Define the parameters of the fit.
+   * Define the parameters of the fit. In addition to
+   * LikelihoodTopLeptonJets::DefineParameters(), this renames the two energy
+   * parameters of the light quarks to "up-type" and "down-type".
    */
   void DefineParameters() override;
 
   /**
-   * Return the log of the event probability fof the current
-   * combination
+   * Return the log of the event probability for the current combination.
+   * Basically identical to LikelihoodBase::LogEventProbability(), but adds an
+   * additional term for the light jets to the probability calculation.
    * @return The event probability
    */
   double LogEventProbability() override;
 
   /**
-   * Return the contribution from b tagging to the log of the
-   * event probability for the current combination
+   * Return the contribution from b tagging to the log of the event probability
+   * for the current combination. Basically identical to
+   * LikelihoodBase::LogEventProbabilityBTag(), but corrections were made to use
+   * kLightUp and kLightDown from #KLFitter::Particles::TrueFlavorType instead
+   * of just kLight.
    * @return The event probability contribution
    */
   double LogEventProbabilityBTag() override;
@@ -188,14 +194,20 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
   /// @{
 
   /**
-   * Check if the permutation is LH invariant.
+   * Check if the permutation is LH invariant. A documentation, as to \a why
+   * this needs to be reimplemented, needs to be added.
+   * @param iperm Current permutation
+   * @param nperms Total number of permutations
+   * @param switchpar1 ???
+   * @param switchpar2 ???
    * @return Permutation of the invariant partner, -1 if there is no one.
    */
   int LHInvariantPermutationPartner(int iperm, int nperms, int *switchpar1, int *switchpar2) override;
 
   /**
-   * Return the contribution from pT and b tag weight probability (by LJetSeparationMethod)
-   * to the log of the event probability for the current combination
+   * Return the contribution from pT and b tag weight probability (by
+   * #LJetSeparationMethod) to the log of the event probability for the current
+   * combination.
    * @return The event probability contribution
    */
   double LogEventProbabilityLJetReweight();
@@ -210,13 +222,17 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
   int DefineModelParticles() override;
 
   /**
-   * Remove forbidden particle permutations.
+   * Remove forbidden particle permutations. Reimplemented, because there are \a
+   * no forbidden particle permutations, if up-type and down-type quarks are
+   * distinguished, i.e. this function doesn't do anything.
    * @return An error code.
    */
   int RemoveForbiddenParticlePermutations() override { return 1; }
 
   /**
-   * Remove invariant particle permutations.
+   * Remove invariant particle permutations. Reimplemented, because particle
+   * permutations with the two light jets swapped are \a not invariant in this
+   * likelihood.
    * @return An error code.
    */
   int RemoveInvariantParticlePermutations() override;

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -41,259 +41,221 @@ class ResolutionBase;
   */
 class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
  public:
-  /**
-    * Enumerate for lJet reweighting methods
-    */
-  enum LJetSeparationMethod{
-    kNone,
-    kPermReweight,
-    kPermReweight2D
+  /// Enumerate for light-jet reweighting methods
+  enum LJetSeparationMethod {
+    kNone,           ///< description here
+    kPermReweight,   ///< description here
+    kPermReweight2D  ///< description here
   };
 
-  /** \name Constructors and destructors */
-  /* @{ */
+  /// \name Constructors and destructors
+  /// @{
 
   /**
-    * The default constructor.
-    */
+   * The default constructor.
+   */
   LikelihoodTopLeptonJetsUDSep();
 
-  /**
-    * The (defaulted) destructor.
-    */
+  /// The (defaulted) destructor.
   ~LikelihoodTopLeptonJetsUDSep();
 
-  /* @} */
+  /// @}
+  /// \name Member functions (Get)
+  /// @{
 
-  /**
-    * Define the parameters of the fit.
-    */
-  void DefineParameters() override;
+  /// Returns the probability of a jet to have the tag weight and pT of an b type jet.
+  double BJetProb(double tagweight, double pt);
 
-  /**
-    * Return the log of the event probability fof the current
-    * combination
-    * @return The event probability
-    */
-  double LogEventProbability() override;
-
-  /**
-    * Return the contribution from b tagging to the log of the
-    * event probability for the current combination
-    * @return The event probability contribution
-    */
-  double LogEventProbabilityBTag() override;
-
-  /**
-    * Return the contribution from pT and b tag weight probability (by LJetSeparationMethod)
-    * to the log of the event probability for the current combination
-    * @return The event probability contribution
-    */
-  double LogEventProbabilityLJetReweight();
-
-  /**
-    * Returns the probability of a jet to have the pT of an up type jet.
-    * @return The probability.
-    */
-  double UpJetPt(double pt);
-
-  /**
-    * Returns the probability of a jet to have the pT of an down type jet.
-    * @return The probability.
-    */
-  double DownJetPt(double pt);
-
-  /**
-    * Returns the probability of a jet to have the pT of an b type jet.
-    * @return The probability.
-    */
+  /// Returns the probability of a jet to have the pT of an b type jet.
   double BJetPt(double pt);
 
-  /**
-    * Returns the probability of a jet to have the tag weight of an up type jet.
-    * @return The probability.
-    */
-  double UpJetTagWeight(double tagweight);
-
-  /**
-    * Returns the probability of a jet to have the tag weight of an down type jet.
-    * @return The probability.
-    */
-  double DownJetTagWeight(double tagweight);
-
-  /**
-    * Returns the probability of a jet to have the tag weight of an b type jet.
-    * @return The probability.
-    */
+  /// Returns the probability of a jet to have the tag weight of an b type jet.
   double BJetTagWeight(double tagweight);
-  //
-  /**
-    * Returns the probability of a jet to have the tag weight and pT of an up type jet.
-    * @return The probability.
-    */
-  double UpJetProb(double tagweight, double pt);
 
-  /**
-    * Returns the probability of a jet to have the tag weight and pT of an down type jet.
-    * @return The probability.
-    */
+  /// Returns the probability of a jet to have the tag weight and pT of an down type jet.
   double DownJetProb(double tagweight, double pt);
 
-  /**
-    * Returns the probability of a jet to have the tag weight and pT of an b type jet.
-    * @return The probability.
-    */
-  double BJetProb(double tagweight, double pt);
-  //
+  /// Returns the probability of a jet to have the pT of an down type jet.
+  double DownJetPt(double pt);
+
+  /// Returns the probability of a jet to have the tag weight of an down type jet.
+  double DownJetTagWeight(double tagweight);
+
+  /// Returns the probability of a jet to have the tag weight and pT of an up type jet.
+  double UpJetProb(double tagweight, double pt);
+
+  /// Returns the probability of a jet to have the pT of an up type jet.
+  double UpJetPt(double pt);
+
+  /// Returns the probability of a jet to have the tag weight of an up type jet.
+  double UpJetTagWeight(double tagweight);
+
+  /// @}
+  /// \name Member functions (Set)
+  /// @{
+
+  /// Set a flag. If flag is true the permutations are reweighted with the pT and tag weight probabilities.
+  void SetLJetSeparationMethod(LJetSeparationMethod flag) { fLJetSeparationMethod = flag; }
 
   /**
-    * Set histogram for pT distribution of up jets (reco level).
-    * @param hist Pointer to histogram.
-    * @return An error flag.
-    */
-  int SetUpJetPtHisto(TH1F* hist) { fUpJetPtHisto = hist; return 1; }
+   * Set histogram for tag weight distribution of b jets.
+   * @param hist Pointer to histogram.
+   * @return An error flag.
+   */
+  int SetBJet2DWeightHisto(TH2F* hist) { fBJet2DWeightHisto = hist; return 1; }
 
   /**
-    * Set histogram for pT distribution of down jets (reco level).
-    * @param hist Pointer to histogram.
-    * @return An error flag.
-    */
-  int SetDownJetPtHisto(TH1F* hist) { fDownJetPtHisto = hist; return 1; }
-
-  /**
-    * Set histogram for pT distribution of b jets (reco level).
-    * @param hist Pointer to histogram.
-    * @return An error flag.
-    */
+   * Set histogram for pT distribution of b jets (reco level).
+   * @param hist Pointer to histogram.
+   * @return An error flag.
+   */
   int SetBJetPtHisto(TH1F* hist) { fBJetPtHisto = hist; return 1; }
 
   /**
-    * Set histogram for tag weight distribution of up type jets.
-    * @param hist Pointer to histogram.
-    * @return An error flag.
-    */
-  int SetUpJetTagWeightHisto(TH1F* hist) { fUpJetTagWeightHisto = hist; return 1; }
-
-  /**
-    * Set histogram for tag weight distribution of down type jets.
-    * @param hist Pointer to histogram.
-    * @return An error flag.
-    */
-  int SetDownJetTagWeightHisto(TH1F* hist) { fDownJetTagWeightHisto = hist; return 1; }
-
-  /**
-    * Set histogram for tag weight distribution of b jets.
-    * @param hist Pointer to histogram.
-    * @return An error flag.
-    */
+   * Set histogram for tag weight distribution of b jets.
+   * @param hist Pointer to histogram.
+   * @return An error flag.
+   */
   int SetBJetTagWeightHisto(TH1F* hist) { fBJetTagWeightHisto = hist; return 1; }
 
   /**
-    * Set a flag. If flag is true the permutations are reweighted with the pT and tag weight probabilities.
-    * @param flag The flag.
-    */
-  void SetLJetSeparationMethod(LikelihoodTopLeptonJetsUDSep::LJetSeparationMethod flag) { fLJetSeparationMethod = flag; }
-
-  /**
-    * Check if the permutation is LH invariant.
-    * @return Permutation of the invariant partner, -1 if there is no one.
-    */
-  int LHInvariantPermutationPartner(int iperm, int nperms, int *switchpar1, int *switchpar2) override;
-
-  /**
-    * Set histogram for tag weight distribution of up type jets.
-    * @param hist Pointer to histogram.
-    * @return An error flag.
-    */
-  int SetUpJet2DWeightHisto(TH2F* hist) { fUpJet2DWeightHisto = hist; return 1; }
-
-  /**
-    * Set histogram for tag weight distribution of down type jets.
-    * @param hist Pointer to histogram.
-    * @return An error flag.
-    */
+   * Set histogram for tag weight distribution of down type jets.
+   * @param hist Pointer to histogram.
+   * @return An error flag.
+   */
   int SetDownJet2DWeightHisto(TH2F* hist) { fDownJet2DWeightHisto = hist; return 1; }
 
   /**
-    * Set histogram for tag weight distribution of b jets.
-    * @param hist Pointer to histogram.
-    * @return An error flag.
-    */
-  int SetBJet2DWeightHisto(TH2F* hist) { fBJet2DWeightHisto = hist; return 1; }
-
- protected:
-  /** \name Member functions (misc)  */
-  /* @{ */
+   * Set histogram for pT distribution of down jets (reco level).
+   * @param hist Pointer to histogram.
+   * @return An error flag.
+   */
+  int SetDownJetPtHisto(TH1F* hist) { fDownJetPtHisto = hist; return 1; }
 
   /**
-    * Define the model particles
-    * @return An error code.
-    */
+   * Set histogram for tag weight distribution of down type jets.
+   * @param hist Pointer to histogram.
+   * @return An error flag.
+   */
+  int SetDownJetTagWeightHisto(TH1F* hist) { fDownJetTagWeightHisto = hist; return 1; }
+
+  /**
+   * Set histogram for tag weight distribution of up type jets.
+   * @param hist Pointer to histogram.
+   * @return An error flag.
+   */
+  int SetUpJet2DWeightHisto(TH2F* hist) { fUpJet2DWeightHisto = hist; return 1; }
+
+  /**
+   * Set histogram for pT distribution of up jets (reco level).
+   * @param hist Pointer to histogram.
+   * @return An error flag.
+   */
+  int SetUpJetPtHisto(TH1F* hist) { fUpJetPtHisto = hist; return 1; }
+
+  /**
+   * Set histogram for tag weight distribution of up type jets.
+   * @param hist Pointer to histogram.
+   * @return An error flag.
+   */
+  int SetUpJetTagWeightHisto(TH1F* hist) { fUpJetTagWeightHisto = hist; return 1; }
+
+  /// @}
+  /// \name Member functions (BAT)
+  /// @{
+
+  /**
+   * Define the parameters of the fit.
+   */
+  void DefineParameters() override;
+
+  /**
+   * Return the log of the event probability fof the current
+   * combination
+   * @return The event probability
+   */
+  double LogEventProbability() override;
+
+  /**
+   * Return the contribution from b tagging to the log of the
+   * event probability for the current combination
+   * @return The event probability contribution
+   */
+  double LogEventProbabilityBTag() override;
+
+  /// @}
+  /// \name Member functions (misc)
+  /// @{
+
+  /**
+   * Check if the permutation is LH invariant.
+   * @return Permutation of the invariant partner, -1 if there is no one.
+   */
+  int LHInvariantPermutationPartner(int iperm, int nperms, int *switchpar1, int *switchpar2) override;
+
+  /**
+   * Return the contribution from pT and b tag weight probability (by LJetSeparationMethod)
+   * to the log of the event probability for the current combination
+   * @return The event probability contribution
+   */
+  double LogEventProbabilityLJetReweight();
+
+  /// @}
+
+ protected:
+  /**
+   * Define the model particles
+   * @return An error code.
+   */
   int DefineModelParticles() override;
 
   /**
-    * Remove invariant particle permutations.
-    * @return An error code.
-    */
-  int RemoveInvariantParticlePermutations() override;
-
-  /**
-    * Remove forbidden particle permutations.
-    * @return An error code.
-    */
+   * Remove forbidden particle permutations.
+   * @return An error code.
+   */
   int RemoveForbiddenParticlePermutations() override { return 1; }
 
   /**
-    * A flag for using an additional reweighting of the permutations with the pT and tag weight probability (default: false);
-    */
-  LikelihoodTopLeptonJetsUDSep::LJetSeparationMethod fLJetSeparationMethod;
+   * Remove invariant particle permutations.
+   * @return An error code.
+   */
+  int RemoveInvariantParticlePermutations() override;
 
-  /**
-    * A pointer to the histogram of the up type jet pT distribution.
-    */
-  TH1F* fUpJetPtHisto;
+  /// @{
+  /// \name Member attributes
 
-  /**
-    * A pointer to the histogram of the down type jet pT distribution.
-    */
-  TH1F* fDownJetPtHisto;
+  /// A flag for using an additional reweighting of the permutations with the pT
+  /// and tag weight probability (default: false);
+  LJetSeparationMethod fLJetSeparationMethod;
 
-  /**
-    * A pointer to the histogram of the down b jet pT distribution.
-    */
-  TH1F* fBJetPtHisto;
-
-  /**
-    * A pointer to the histogram of the up quark tag weight distribution.
-    */
-  TH1F* fUpJetTagWeightHisto;
-
-  /**
-    * A pointer to the histogram of the down quark tag weight distribution.
-    */
-  TH1F* fDownJetTagWeightHisto;
-
-  /**
-    * A pointer to the histogram of the up b tag weight distribution.
-    */
-  TH1F* fBJetTagWeightHisto;
-
-  /**
-    * A pointer to the 2d histogram "tag weight vs. pT for upQuarks"
-    */
-  TH2F* fUpJet2DWeightHisto;
-
-  /**
-    * A pointer to the 2d histogram "tag weight vs. pT for downQuarks"
-    */
-  TH2F* fDownJet2DWeightHisto;
-
-  /**
-    * A pointer to the 2d histogram "tag weight vs. pT for bQuarks"
-    */
+  /// A pointer to the 2d histogram "tag weight vs. pT for bQuarks"
   TH2F* fBJet2DWeightHisto;
 
-  /* @} */
+  /// A pointer to the histogram of the down b jet pT distribution.
+  TH1F* fBJetPtHisto;
+
+  /// A pointer to the histogram of the up b tag weight distribution.
+  TH1F* fBJetTagWeightHisto;
+
+  /// A pointer to the 2d histogram "tag weight vs. pT for downQuarks"
+  TH2F* fDownJet2DWeightHisto;
+
+  /// A pointer to the histogram of the down type jet pT distribution.
+  TH1F* fDownJetPtHisto;
+
+  /// A pointer to the histogram of the down quark tag weight distribution.
+  TH1F* fDownJetTagWeightHisto;
+
+  /// A pointer to the 2d histogram "tag weight vs. pT for upQuarks"
+  TH2F* fUpJet2DWeightHisto;
+
+  /// A pointer to the histogram of the up type jet pT distribution.
+  TH1F* fUpJetPtHisto;
+
+  /// A pointer to the histogram of the up quark tag weight distribution.
+  TH1F* fUpJetTagWeightHisto;
+
+  /// @}
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
+++ b/include/KLFitter/LikelihoodTopLeptonJetsUDSep.h
@@ -29,11 +29,10 @@ class TH2F;
 
 namespace KLFitter {
 /**
-  * \class KLFitter::LikelihoodTopLeptonJetsUDSep
-  * \brief A class implementing a likelihood for the ttbar lepton+jets channel.
-  *
-  * This class represents a likelihood for the ttbar into lepton+jets.
-  */
+ * This class is a variation of LikelihoodTopLeptonJets. It adds methods to
+ * distinguish up-type and down-type quarks, i.e. their permutations are not
+ * invariant in this likelihood.
+ */
 class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
  public:
   /// Enumerate for light-jet reweighting methods
@@ -46,9 +45,8 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
   /// \name Constructors and destructors
   /// @{
 
-  /**
-   * The default constructor.
-   */
+  /// The default constructor. In addition to LikelihoodTopLeptonJets(), this
+  /// initializes #m_ljet_separation_method to kNone.
   LikelihoodTopLeptonJetsUDSep();
 
   /// The (defaulted) destructor.
@@ -58,38 +56,39 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
   /// \name Member functions (Get)
   /// @{
 
-  /// Returns the probability of a jet to have the tag weight and pT of an b type jet.
+  /// Probability of a jet to have the tag weight and pT of a b jet.
   double BJetProb(double tagweight, double pt);
 
-  /// Returns the probability of a jet to have the pT of an b type jet.
+  /// Probability of a jet to have the pT of a b jet.
   double BJetPt(double pt);
 
-  /// Returns the probability of a jet to have the tag weight of an b type jet.
+  /// Probability of a jet to have the tag weight of a b jet.
   double BJetTagWeight(double tagweight);
 
-  /// Returns the probability of a jet to have the tag weight and pT of an down type jet.
+  /// Probability of a jet to have the tag weight and pT of a down-type jet.
   double DownJetProb(double tagweight, double pt);
 
-  /// Returns the probability of a jet to have the pT of an down type jet.
+  /// Probability of a jet to have the pT of a down-type jet.
   double DownJetPt(double pt);
 
-  /// Returns the probability of a jet to have the tag weight of an down type jet.
+  /// Probability of a jet to have the tag weight of a down-type jet.
   double DownJetTagWeight(double tagweight);
 
-  /// Returns the probability of a jet to have the tag weight and pT of an up type jet.
+  /// Probability of a jet to have the tag weight and pT of an up-type jet.
   double UpJetProb(double tagweight, double pt);
 
-  /// Returns the probability of a jet to have the pT of an up type jet.
+  /// Probability of a jet to have the pT of an up-type jet.
   double UpJetPt(double pt);
 
-  /// Returns the probability of a jet to have the tag weight of an up type jet.
+  /// Probability of a jet to have the tag weight of an up-type jet.
   double UpJetTagWeight(double tagweight);
 
   /// @}
   /// \name Member functions (Set)
   /// @{
 
-  /// Set a flag. If flag is true the permutations are reweighted with the pT and tag weight probabilities.
+  /// Set a flag. If flag is true the permutations are reweighted with the pT
+  /// and tag weight probabilities.
   void SetLJetSeparationMethod(LJetSeparationMethod flag) { m_ljet_separation_method = flag; }
 
   /**
@@ -211,7 +210,7 @@ class LikelihoodTopLeptonJetsUDSep : public LikelihoodTopLeptonJets {
 
  protected:
   /**
-   * Define the model particles
+   * Define the model particles.
    * @return An error code.
    */
   int DefineModelParticles() override;

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -65,7 +65,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodTopLeptonJets
  protected:
   /**
    * Adjust ranges of the parameters. As opposed to
-   * LikelihoodTopLeptonJets::AdjustParameterRanges(), this does \emph not
+   * LikelihoodTopLeptonJets::AdjustParameterRanges(), this does \a not
    * utilize the flag #m_flag_get_par_sigmas_from_TFs, but only uses a fixed
    * sigma to calculate the parameter range and set it with SetParameterRange().
    * If #m_flag_top_mass_fixed is set, the top mass will be fixed to the pole

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -41,14 +41,10 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodTopLeptonJets
   /// \name Constructors and destructors
   /// @{
 
-  /**
-    * The (defaulted) constructor.
-    */
+  /// The (defaulted) constructor.
   LikelihoodTopLeptonJets_Angular();
 
-  /**
-    * The (defaulted) destructor.
-    */
+  /// The (defaulted) destructor.
   ~LikelihoodTopLeptonJets_Angular();
 
   /// @}

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -66,9 +66,10 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodTopLeptonJets
   /**
    * Adjust ranges of the parameters. As opposed to
    * LikelihoodTopLeptonJets::AdjustParameterRanges(), this does \emph not
-   * utilize the flag #fFlagGetParSigmasFromTFs, but only uses a fixed sigma to
-   * calculate the parameter range and set it with SetParameterRange(). If
-   * #fFlagTopMassFixed is set, the top mass will be fixed to the pole mass.
+   * utilize the flag #m_flag_get_par_sigmas_from_TFs, but only uses a fixed
+   * sigma to calculate the parameter range and set it with SetParameterRange().
+   * If #m_flag_top_mass_fixed is set, the top mass will be fixed to the pole
+   * mass.
    * @return An error code.
    */
   int AdjustParameterRanges() override;

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -33,8 +33,8 @@ namespace KLFitter {
   */
 class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodTopLeptonJets {
  public:
-  /// \name Constructors and destructors
-  /// @{
+  /** \name Constructors and destructors */
+  /* @{ */
 
   /// The (defaulted) constructor.
   LikelihoodTopLeptonJets_Angular();
@@ -42,9 +42,9 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodTopLeptonJets
   /// The (defaulted) destructor.
   ~LikelihoodTopLeptonJets_Angular();
 
-  /// @}
-  /// \name Member functions (misc)
-  /// @{
+  /* @} */
+  /** \name Member functions (misc)  */
+  /* @{ */
 
   /**
    * The posterior probability definition, overloaded from BCModel. In addition
@@ -55,7 +55,7 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodTopLeptonJets
    */
   double LogLikelihood(const std::vector <double> & parameters) override;
 
-  /// @}
+  /* @} */
 
  protected:
   /**

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -29,26 +29,20 @@ class TLorentzVector;
 
 // ---------------------------------------------------------
 
-/**
- * \namespace KLFitter
- * \brief The KLFitter namespace
- */
 namespace KLFitter {
 class ResolutionBase;
 
 /**
-  * \class KLFitter::LikelihoodTopLeptonJets_Angular
-  * \brief Add brief description here
-  *
-  * Add detailed description here.
+  * This is an extension of LikelihoodTopLeptonJets, which adds angular
+  * information to the likelihood.
   */
 class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodTopLeptonJets {
  public:
-  /** \name Constructors and destructors */
-  /* @{ */
+  /// \name Constructors and destructors
+  /// @{
 
   /**
-    * The default constructor.
+    * The (defaulted) constructor.
     */
   LikelihoodTopLeptonJets_Angular();
 
@@ -57,29 +51,31 @@ class LikelihoodTopLeptonJets_Angular : public KLFitter::LikelihoodTopLeptonJets
     */
   ~LikelihoodTopLeptonJets_Angular();
 
-  /* @} */
-  /** \name Member functions (misc)  */
-  /* @{ */
+  /// @}
+  /// \name Member functions (misc)
+  /// @{
 
   /**
-    * The posterior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
+   * The posterior probability definition, overloaded from BCModel. In addition
+   * to what is implemented in LikelihoodTopLeptonJets::LogLikelihood(), this
+   * also includes angular information in the calculation of the log likelihood.
+   * @param parameters A vector of parameters (double values).
+   * @return The logarithm of the prior probability.
+   */
   double LogLikelihood(const std::vector <double> & parameters) override;
 
-  /* @} */
+  /// @}
 
  protected:
-  /** \name Member functions (misc)  */
-  /* @{ */
-
   /**
-    * Adjust parameter ranges
-    */
+   * Adjust ranges of the parameters. As opposed to
+   * LikelihoodTopLeptonJets::AdjustParameterRanges(), this does \emph not
+   * utilize the flag #fFlagGetParSigmasFromTFs, but only uses a fixed sigma to
+   * calculate the parameter range and set it with SetParameterRange(). If
+   * #fFlagTopMassFixed is set, the top mass will be fixed to the pole mass.
+   * @return An error code.
+   */
   int AdjustParameterRanges() override;
-
-  /* @} */
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_Angular.h
@@ -20,18 +20,13 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETS_ANGULAR_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETS_ANGULAR_H_
 
-#include <iostream>
 #include <vector>
 
 #include "KLFitter/LikelihoodTopLeptonJets.h"
 
-class TLorentzVector;
-
 // ---------------------------------------------------------
 
 namespace KLFitter {
-class ResolutionBase;
-
 /**
   * This is an extension of LikelihoodTopLeptonJets, which adds angular
   * information to the likelihood.

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -20,12 +20,9 @@
 #ifndef KLFITTER_LIKELIHOODTOPLEPTONJETS_JETANGLES_H_
 #define KLFITTER_LIKELIHOODTOPLEPTONJETS_JETANGLES_H_
 
-#include <iostream>
 #include <vector>
 
 #include "KLFitter/LikelihoodTopLeptonJets.h"
-
-class TLorentzVector;
 
 // ---------------------------------------------------------
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -37,103 +37,124 @@ namespace KLFitter {
 class ResolutionBase;
 
 /**
-  * \class KLFitter::LikelihoodTopLeptonJets_JetAngles
-  * \brief Add brief description here
-  *
-  * Add a detailed description here.
+  * This is an extension of LikelihoodTopLeptonJets, which adds eta and phi
+  * values of the jets to the fit. The additional parameters need the
+  * corresponding parameterizations in the transfer functions.
   */
 class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodTopLeptonJets {
  public:
-  /** \name Constructors and destructors */
-  /* @{ */
+  /// \name Constructors and destructors
+  /// @{
 
-  /**
-    * The default constructor.
-    */
+  /// The (defaulted) constructor.
   LikelihoodTopLeptonJets_JetAngles();
 
-  /**
-    * The (defaulted) destructor.
-    */
+  /// The (defaulted) destructor.
   ~LikelihoodTopLeptonJets_JetAngles();
 
-  /* @} */
-  /** \name Member functions (Set)  */
-  /* @{ */
+  /// @}
+
+  /// Enumerator for the fitted parameters of this likelihood.
+  enum Parameters { parBhadE,     ///< Energy of the hadronic b quark
+                    parBlepE,     ///< Energy of the leptonic b quark
+                    parLQ1E,      ///< Energy of the light quark 1
+                    parLQ2E,      ///< Energy of the light quark 2
+                    parLepE,      ///< Energy of the lepton
+                    parNuPx,      ///< p_x of the neutrino
+                    parNuPy,      ///< p_y of the neutrino
+                    parNuPz,      ///< p_z of the neutrino
+                    parBhadEta,   ///< Eta of the hadronic b quark
+                    parBlepEta,   ///< Eta of the leptonic b quark
+                    parLQ1Eta,    ///< Eta of the light quark 1
+                    parLQ2Eta,    ///< Eta of the light quark 2
+                    parBhadPhi,   ///< Phi of the hadronic b quark
+                    parBlepPhi,   ///< Phi of the leptonic b quark
+                    parLQ1Phi,    ///< Phi of the light quark 1
+                    parLQ2Phi,    ///< Phi of the light quark 2
+                    parTopM       ///< Mass of the top quark
+  };
+
+  /// \name Member functions (misc)
+  /// @{
 
   /**
-    * Enumerator for the parameters.
-    */
-  enum Parameters { parBhadE, parBlepE, parLQ1E, parLQ2E, parLepE, parNuPx, parNuPy, parNuPz, parBhadEta, parBlepEta, parLQ1Eta, parLQ2Eta, parBhadPhi, parBlepPhi, parLQ1Phi, parLQ2Phi, parTopM };
-
-  /* @} */
-  /** \name Member functions (misc)  */
-  /* @{ */
-
-  /**
-    * Define the parameters of the fit.
-    */
+   * Define the parameters of the fit. This calls BCModel::AddParameter() for
+   * all parameters in the enum #Parameters. Reimplemented with respect to
+   * LikelihoodTopLeptonJets::DefineParameters() due to the additional
+   * parameters in #Parameters.
+   */
   void DefineParameters() override;
 
   /**
-    * The posterior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
+   * Identical to LikelihoodTopLeptonJets::GetInitialParametersWoNeutrinoPz(),
+   * but adds the initial values for the additional angular parameters.
+   * @return vector of initial values.
+   */
+  std::vector<double> GetInitialParametersWoNeutrinoPz() override;
+
+  /**
+   * The posterior probability definition, overloaded from BCModel. With respect
+   * to LikelihoodTopLeptonJets::LogLikelihood(), this also adds resolutions
+   * terms for the jet eta and phi values.
+   * @param parameters A vector of parameters (double values).
+   * @return The logarithm of the prior probability.
+   */
   double LogLikelihood(const std::vector <double> & parameters) override;
 
   /**
-    * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents
-    * @param parameters A vector of parameters (double values).
-    * @return A vector with the components of the logarithm of the prior probability. Its components are:
-    * 0:  TF_bhad
-    * 1:  TF_blep
-    * 2:  TF_lq1
-    * 3:  TF_lq2
-    * 4:  TF_lep
-    * 5:  TF_METx
-    * 6:  TF_METy
-    * 7:  TFeta_bhad
-    * 8:  TFeta_blep
-    * 9:  TFeta_lq1
-    *10:  TFeta_lq2
-    *11:  TFphi_bhad
-    *12:  TFphi_blep
-    *13:  TFphi_lq1
-    *14:  TFphi_lq2
-    *15:  BW_Whad
-    *16:  BW_Wlep
-    *17:  BW_Thad
-    *18:  BW_Tlep
-    */
+   * The posterior probability definition, overloaded from BCModel. Instead of
+   * the final log likelihood value as in LogLikelihood(), this returns all
+   * subcomponents.
+   * @param parameters A vector of parameters (double values).
+   * @return A vector with the components of the logarithm of the prior
+   * probability. Its components are: \n
+   *   0) TF_bhad \n
+   *   1) TF_blep \n
+   *   2) TF_lq1 \n
+   *   3) TF_lq2 \n
+   *   4) TF_lep \n
+   *   5) TF_METx \n
+   *   6) TF_METy \n
+   *   7)  TFeta_bhad \n
+   *   8)  TFeta_blep \n
+   *   9)  TFeta_lq1 \n
+   *  10)  TFeta_lq2 \n
+   *  11)  TFphi_bhad \n
+   *  12)  TFphi_blep \n
+   *  13)  TFphi_lq1 \n
+   *  14)  TFphi_lq2 \n
+   *  15)  BW_Whad \n
+   *  16)  BW_Wlep \n
+   *  17)  BW_Thad \n
+   *  18)  BW_Tlep \n
+   */
   std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
-  /**
-    * Get initial values for the parameters with a dummy of "0.0" for the neutrino pz.
-    * The decision on the initial value for the neutrino pz then needs to be done in
-    * GetInitialParameters().
-    * @return vector of initial values.
-    */
-  std::vector<double> GetInitialParametersWoNeutrinoPz() override;
-
-  /* @} */
+  /// @}
 
  protected:
-  /** \name Member functions (misc)  */
-  /* @{ */
-
   /**
-    * Update 4-vectors of model particles.
-    * @return An error flag.
-    */
-  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
-
-  /**
-    * Adjust parameter ranges
-    */
+   * Adjust ranges of the parameters. This either takes the parameter sigmas
+   * from the transfer functions, if #fFlagGetParSigmasFromTFs is set.
+   * Otherwise, a fixed sigma is used to calculate the parameter ranges. Then,
+   * SetParameterRange() is called to set the range. If #fFlagTopMassFixed is
+   * set, the top mass will be fixed to the pole mass. Reimplemented with
+   * respect to LikelihoodTopLeptonJets::AdjustParameterRanges() due to
+   * additional parameters in #Parameters.
+   * @return An error code.
+   */
   int AdjustParameterRanges() override;
 
-  /* @} */
+  /**
+   * Update 4-vector values of the model particles. This updates the internal
+   * variables, such as #bhad_fit_px or #thad_fit_m to the latest values from
+   * the fit. These variables are for example used in the log likelihood
+   * calculation. As opposed to
+   * LikelihoodTopLeptonJets::CalculateLorentzVectors(), the 4-vector values for
+   * the jets include the fitted angular information as well.
+   * @return An error flag.
+   */
+  int CalculateLorentzVectors(std::vector <double> const& parameters) override;
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -54,8 +54,8 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodTopLeptonJe
                     parTopM       ///< Mass of the top quark
   };
 
-  /// \name Constructors and destructors
-  /// @{
+  /** \name Constructors and destructors */
+  /* @{ */
 
   /// The (defaulted) constructor.
   LikelihoodTopLeptonJets_JetAngles();
@@ -63,9 +63,9 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodTopLeptonJe
   /// The (defaulted) destructor.
   ~LikelihoodTopLeptonJets_JetAngles();
 
-  /// @}
-  /// \name Member functions (misc)
-  /// @{
+  /* @} */
+  /** \name Member functions (misc)  */
+  /* @{ */
 
   /**
    * Define the parameters of the fit. This calls BCModel::AddParameter() for
@@ -120,7 +120,7 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodTopLeptonJe
    */
   std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
-  /// @}
+  /* @} */
 
  protected:
   /**

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -135,10 +135,10 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodTopLeptonJe
  protected:
   /**
    * Adjust ranges of the parameters. This either takes the parameter sigmas
-   * from the transfer functions, if #fFlagGetParSigmasFromTFs is set.
+   * from the transfer functions, if #m_flag_get_par_sigmas_from_TFs is set.
    * Otherwise, a fixed sigma is used to calculate the parameter ranges. Then,
-   * SetParameterRange() is called to set the range. If #fFlagTopMassFixed is
-   * set, the top mass will be fixed to the pole mass. Reimplemented with
+   * SetParameterRange() is called to set the range. If #m_flag_top_mass_fixed
+   * is set, the top mass will be fixed to the pole mass. Reimplemented with
    * respect to LikelihoodTopLeptonJets::AdjustParameterRanges() due to
    * additional parameters in #Parameters.
    * @return An error code.

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -26,13 +26,7 @@
 
 // ---------------------------------------------------------
 
-/**
- * \namespace KLFitter
- * \brief The KLFitter namespace
- */
 namespace KLFitter {
-class ResolutionBase;
-
 /**
   * This is an extension of LikelihoodTopLeptonJets, which adds eta and phi
   * values of the jets to the fit. The additional parameters need the
@@ -40,17 +34,6 @@ class ResolutionBase;
   */
 class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodTopLeptonJets {
  public:
-  /// \name Constructors and destructors
-  /// @{
-
-  /// The (defaulted) constructor.
-  LikelihoodTopLeptonJets_JetAngles();
-
-  /// The (defaulted) destructor.
-  ~LikelihoodTopLeptonJets_JetAngles();
-
-  /// @}
-
   /// Enumerator for the fitted parameters of this likelihood.
   enum Parameters { parBhadE,     ///< Energy of the hadronic b quark
                     parBlepE,     ///< Energy of the leptonic b quark
@@ -71,6 +54,16 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodTopLeptonJe
                     parTopM       ///< Mass of the top quark
   };
 
+  /// \name Constructors and destructors
+  /// @{
+
+  /// The (defaulted) constructor.
+  LikelihoodTopLeptonJets_JetAngles();
+
+  /// The (defaulted) destructor.
+  ~LikelihoodTopLeptonJets_JetAngles();
+
+  /// @}
   /// \name Member functions (misc)
   /// @{
 

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -34,12 +34,12 @@
 namespace KLFitter {
 LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
   : LikelihoodBase::LikelihoodBase()
-  , fFlagTopMassFixed(false)
-  , fFlagGetParSigmasFromTFs(false)
-  , ETmiss_x(0.)
-  , ETmiss_y(0.)
-  , SumET(0.)
-  , fTypeLepton(kElectron) {
+  , m_flag_top_mass_fixed(false)
+  , m_flag_get_par_sigmas_from_TFs(false)
+  , m_et_miss_x(0.)
+  , m_et_miss_y(0.)
+  , m_et_miss_sum(0.)
+  , m_lepton_type(kElectron) {
   // define model particles
   this->DefineModelParticles();
 
@@ -52,10 +52,10 @@ LikelihoodTopLeptonJets::~LikelihoodTopLeptonJets() = default;
 
 // ---------------------------------------------------------
 int LikelihoodTopLeptonJets::SetET_miss_XY_SumET(double etx, double ety, double sumet) {
-  // set missing ET x and y component and the SumET
-  ETmiss_x = etx;
-  ETmiss_y = ety;
-  SumET = sumet;
+  // set missing ET x and y component and the m_et_miss_sum
+  m_et_miss_x = etx;
+  m_et_miss_y = ety;
+  m_et_miss_sum = sumet;
 
   // no error
   return 1;
@@ -65,9 +65,9 @@ int LikelihoodTopLeptonJets::SetET_miss_XY_SumET(double etx, double ety, double 
 void LikelihoodTopLeptonJets::SetLeptonType(LeptonType leptontype) {
   if (leptontype != kElectron && leptontype != kMuon) {
     std::cout << "KLFitter::SetLeptonType(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;
-    fTypeLepton = kElectron;
+    m_lepton_type = kElectron;
   } else {
-    fTypeLepton = leptontype;
+    m_lepton_type = leptontype;
   }
 
   // define model particles
@@ -119,9 +119,9 @@ int LikelihoodTopLeptonJets::DefineModelParticles() {
                                3,                   // index of corresponding particle
                                Particles::kLight);  // light jet (truth)
 
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     fParticlesModel->AddParticle(&dummy, Particles::kElectron, "electron");
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     fParticlesModel->AddParticle(&dummy, Particles::kMuon, "muon");
   }
 
@@ -164,73 +164,73 @@ int LikelihoodTopLeptonJets::CalculateLorentzVectors(std::vector <double> const&
   double tlep_fit_pz;
 
   // hadronic b quark
-  bhad_fit_e = parameters[parBhadE];
-  scale = sqrt(bhad_fit_e * bhad_fit_e - bhad_meas_m * bhad_meas_m) / bhad_meas_p;
-  bhad_fit_px = scale * bhad_meas_px;
-  bhad_fit_py = scale * bhad_meas_py;
-  bhad_fit_pz = scale * bhad_meas_pz;
+  m_bhad_fit_e = parameters[parBhadE];
+  scale = sqrt(m_bhad_fit_e * m_bhad_fit_e - m_bhad_meas_m * m_bhad_meas_m) / m_bhad_meas_p;
+  m_bhad_fit_px = scale * m_bhad_meas_px;
+  m_bhad_fit_py = scale * m_bhad_meas_py;
+  m_bhad_fit_pz = scale * m_bhad_meas_pz;
 
   // leptonic b quark
-  blep_fit_e = parameters[parBlepE];
-  scale = sqrt(blep_fit_e * blep_fit_e - blep_meas_m * blep_meas_m) / blep_meas_p;
-  blep_fit_px = scale * blep_meas_px;
-  blep_fit_py = scale * blep_meas_py;
-  blep_fit_pz = scale * blep_meas_pz;
+  m_blep_fit_e = parameters[parBlepE];
+  scale = sqrt(m_blep_fit_e * m_blep_fit_e - m_blep_meas_m * m_blep_meas_m) / m_blep_meas_p;
+  m_blep_fit_px = scale * m_blep_meas_px;
+  m_blep_fit_py = scale * m_blep_meas_py;
+  m_blep_fit_pz = scale * m_blep_meas_pz;
 
   // light quark 1
-  lq1_fit_e = parameters[parLQ1E];
-  scale = sqrt(lq1_fit_e * lq1_fit_e - lq1_meas_m * lq1_meas_m) / lq1_meas_p;
-  lq1_fit_px = scale * lq1_meas_px;
-  lq1_fit_py = scale * lq1_meas_py;
-  lq1_fit_pz = scale * lq1_meas_pz;
+  m_lq1_fit_e = parameters[parLQ1E];
+  scale = sqrt(m_lq1_fit_e * m_lq1_fit_e - m_lq1_meas_m * m_lq1_meas_m) / m_lq1_meas_p;
+  m_lq1_fit_px = scale * m_lq1_meas_px;
+  m_lq1_fit_py = scale * m_lq1_meas_py;
+  m_lq1_fit_pz = scale * m_lq1_meas_pz;
 
   // light quark 2
-  lq2_fit_e = parameters[parLQ2E];
-  scale = sqrt(lq2_fit_e * lq2_fit_e - lq2_meas_m * lq2_meas_m) / lq2_meas_p;
-  lq2_fit_px  = scale * lq2_meas_px;
-  lq2_fit_py  = scale * lq2_meas_py;
-  lq2_fit_pz  = scale * lq2_meas_pz;
+  m_lq2_fit_e = parameters[parLQ2E];
+  scale = sqrt(m_lq2_fit_e * m_lq2_fit_e - m_lq2_meas_m * m_lq2_meas_m) / m_lq2_meas_p;
+  m_lq2_fit_px  = scale * m_lq2_meas_px;
+  m_lq2_fit_py  = scale * m_lq2_meas_py;
+  m_lq2_fit_pz  = scale * m_lq2_meas_pz;
 
   // lepton
-  lep_fit_e = parameters[parLepE];
-  scale = lep_fit_e / lep_meas_e;
-  lep_fit_px = scale * lep_meas_px;
-  lep_fit_py = scale * lep_meas_py;
-  lep_fit_pz = scale * lep_meas_pz;
+  m_lep_fit_e = parameters[parLepE];
+  scale = m_lep_fit_e / m_lep_meas_e;
+  m_lep_fit_px = scale * m_lep_meas_px;
+  m_lep_fit_py = scale * m_lep_meas_py;
+  m_lep_fit_pz = scale * m_lep_meas_pz;
 
   // neutrino
-  nu_fit_px = parameters[parNuPx];
-  nu_fit_py = parameters[parNuPy];
-  nu_fit_pz = parameters[parNuPz];
-  nu_fit_e  = sqrt(nu_fit_px * nu_fit_px + nu_fit_py * nu_fit_py + nu_fit_pz * nu_fit_pz);
+  m_nu_fit_px = parameters[parNuPx];
+  m_nu_fit_py = parameters[parNuPy];
+  m_nu_fit_pz = parameters[parNuPz];
+  m_nu_fit_e  = sqrt(m_nu_fit_px * m_nu_fit_px + m_nu_fit_py * m_nu_fit_py + m_nu_fit_pz * m_nu_fit_pz);
 
   // hadronic W
-  whad_fit_e  = lq1_fit_e + lq2_fit_e;
-  whad_fit_px = lq1_fit_px + lq2_fit_px;
-  whad_fit_py = lq1_fit_py + lq2_fit_py;
-  whad_fit_pz = lq1_fit_pz + lq2_fit_pz;
-  whad_fit_m = sqrt(whad_fit_e * whad_fit_e - (whad_fit_px * whad_fit_px + whad_fit_py * whad_fit_py + whad_fit_pz * whad_fit_pz));
+  m_whad_fit_e  = m_lq1_fit_e + m_lq2_fit_e;
+  m_whad_fit_px = m_lq1_fit_px + m_lq2_fit_px;
+  m_whad_fit_py = m_lq1_fit_py + m_lq2_fit_py;
+  m_whad_fit_pz = m_lq1_fit_pz + m_lq2_fit_pz;
+  m_whad_fit_m = sqrt(m_whad_fit_e * m_whad_fit_e - (m_whad_fit_px * m_whad_fit_px + m_whad_fit_py * m_whad_fit_py + m_whad_fit_pz * m_whad_fit_pz));
 
   // leptonic W
-  wlep_fit_e  = lep_fit_e + nu_fit_e;
-  wlep_fit_px = lep_fit_px + nu_fit_px;
-  wlep_fit_py = lep_fit_py + nu_fit_py;
-  wlep_fit_pz = lep_fit_pz + nu_fit_pz;
-  wlep_fit_m = sqrt(wlep_fit_e * wlep_fit_e - (wlep_fit_px * wlep_fit_px + wlep_fit_py * wlep_fit_py + wlep_fit_pz * wlep_fit_pz));
+  m_wlep_fit_e  = m_lep_fit_e + m_nu_fit_e;
+  m_wlep_fit_px = m_lep_fit_px + m_nu_fit_px;
+  m_wlep_fit_py = m_lep_fit_py + m_nu_fit_py;
+  m_wlep_fit_pz = m_lep_fit_pz + m_nu_fit_pz;
+  m_wlep_fit_m = sqrt(m_wlep_fit_e * m_wlep_fit_e - (m_wlep_fit_px * m_wlep_fit_px + m_wlep_fit_py * m_wlep_fit_py + m_wlep_fit_pz * m_wlep_fit_pz));
 
   // hadronic top
-  thad_fit_e = whad_fit_e + bhad_fit_e;
-  thad_fit_px = whad_fit_px + bhad_fit_px;
-  thad_fit_py = whad_fit_py + bhad_fit_py;
-  thad_fit_pz = whad_fit_pz + bhad_fit_pz;
-  thad_fit_m = sqrt(thad_fit_e * thad_fit_e - (thad_fit_px * thad_fit_px + thad_fit_py * thad_fit_py + thad_fit_pz * thad_fit_pz));
+  thad_fit_e = m_whad_fit_e + m_bhad_fit_e;
+  thad_fit_px = m_whad_fit_px + m_bhad_fit_px;
+  thad_fit_py = m_whad_fit_py + m_bhad_fit_py;
+  thad_fit_pz = m_whad_fit_pz + m_bhad_fit_pz;
+  m_thad_fit_m = sqrt(thad_fit_e * thad_fit_e - (thad_fit_px * thad_fit_px + thad_fit_py * thad_fit_py + thad_fit_pz * thad_fit_pz));
 
   // leptonic top
-  tlep_fit_e = wlep_fit_e + blep_fit_e;
-  tlep_fit_px = wlep_fit_px + blep_fit_px;
-  tlep_fit_py = wlep_fit_py + blep_fit_py;
-  tlep_fit_pz = wlep_fit_pz + blep_fit_pz;
-  tlep_fit_m = sqrt(tlep_fit_e * tlep_fit_e - (tlep_fit_px * tlep_fit_px + tlep_fit_py * tlep_fit_py + tlep_fit_pz * tlep_fit_pz));
+  tlep_fit_e = m_wlep_fit_e + m_blep_fit_e;
+  tlep_fit_px = m_wlep_fit_px + m_blep_fit_px;
+  tlep_fit_py = m_wlep_fit_py + m_blep_fit_py;
+  tlep_fit_pz = m_wlep_fit_pz + m_blep_fit_pz;
+  m_tlep_fit_m = sqrt(tlep_fit_e * tlep_fit_e - (tlep_fit_px * tlep_fit_px + tlep_fit_py * tlep_fit_py + tlep_fit_pz * tlep_fit_pz));
 
   // no error
   return 1;
@@ -257,14 +257,14 @@ int LikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
   err *= (*fPermutations)->InvariantParticlePermutations(ptype, indexVector_Jets);
 
   // remove the permutation from the other lepton
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     ptype = Particles::kMuon;
     std::vector<int> indexVector_Muons;
     for (int iMuon = 0; iMuon < particles->NMuons(); iMuon++) {
       indexVector_Muons.push_back(iMuon);
     }
     err *= (*fPermutations)->InvariantParticlePermutations(ptype, indexVector_Muons);
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     ptype = Particles::kElectron;
     std::vector<int> indexVector_Electrons;
     for (int iElectron = 0; iElectron < particles->NElectrons(); iElectron++) {
@@ -280,14 +280,14 @@ int LikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
 // ---------------------------------------------------------
 int LikelihoodTopLeptonJets::AdjustParameterRanges() {
   // adjust limits
-  double nsigmas_jet    = fFlagGetParSigmasFromTFs ? 10 : 7;
-  double nsigmas_lepton = fFlagGetParSigmasFromTFs ? 10 : 2;
-  double nsigmas_met    = fFlagGetParSigmasFromTFs ? 10 : 1;
+  double nsigmas_jet    = m_flag_get_par_sigmas_from_TFs ? 10 : 7;
+  double nsigmas_lepton = m_flag_get_par_sigmas_from_TFs ? 10 : 2;
+  double nsigmas_met    = m_flag_get_par_sigmas_from_TFs ? 10 : 1;
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
   double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
-  double sigma = fFlagGetParSigmasFromTFs ? fResEnergyBhad->GetSigma(E) : sqrt(E);
+  double sigma = m_flag_get_par_sigmas_from_TFs ? m_res_energy_bhad->GetSigma(E) : sqrt(E);
   double Emin = std::max(m, E - nsigmas_jet * sigma);
   double Emax = E + nsigmas_jet * sigma;
   SetParameterRange(parBhadE, Emin, Emax);
@@ -295,7 +295,7 @@ int LikelihoodTopLeptonJets::AdjustParameterRanges() {
   E = (*fParticlesPermuted)->Parton(1)->E();
   m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
-  sigma = fFlagGetParSigmasFromTFs ? fResEnergyBlep->GetSigma(E) : sqrt(E);
+  sigma = m_flag_get_par_sigmas_from_TFs ? m_res_energy_blep->GetSigma(E) : sqrt(E);
   Emin = std::max(m, E - nsigmas_jet * sigma);
   Emax = E + nsigmas_jet * sigma;
   SetParameterRange(parBlepE, Emin, Emax);
@@ -303,7 +303,7 @@ int LikelihoodTopLeptonJets::AdjustParameterRanges() {
   E = (*fParticlesPermuted)->Parton(2)->E();
   m = 0.001;
   if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(2)->M());
-  sigma = fFlagGetParSigmasFromTFs ? fResEnergyLQ1->GetSigma(E) : sqrt(E);
+  sigma = m_flag_get_par_sigmas_from_TFs ? m_res_energy_lq1->GetSigma(E) : sqrt(E);
   Emin = std::max(m, E - nsigmas_jet * sigma);
   Emax = E + nsigmas_jet * sigma;
   SetParameterRange(parLQ1E, Emin, Emax);
@@ -311,32 +311,32 @@ int LikelihoodTopLeptonJets::AdjustParameterRanges() {
   E = (*fParticlesPermuted)->Parton(3)->E();
   m = 0.001;
   if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(3)->M());
-  sigma = fFlagGetParSigmasFromTFs ? fResEnergyLQ2->GetSigma(E) : sqrt(E);
+  sigma = m_flag_get_par_sigmas_from_TFs ? m_res_energy_lq2->GetSigma(E) : sqrt(E);
   Emin = std::max(m, E - nsigmas_jet * sigma);
   Emax = E + nsigmas_jet * sigma;
   SetParameterRange(parLQ2E, Emin, Emax);
 
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     E = (*fParticlesPermuted)->Electron(0)->E();
-    sigma = fFlagGetParSigmasFromTFs ? fResLepton->GetSigma(E) : sqrt(E);
+    sigma = m_flag_get_par_sigmas_from_TFs ? m_res_lepton->GetSigma(E) : sqrt(E);
     Emin = std::max(0.001, E - nsigmas_lepton * sigma);
     Emax = E + nsigmas_lepton * sigma;
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     E = (*fParticlesPermuted)->Muon(0)->E();
     double sintheta = sin((*fParticlesPermuted)->Muon(0)->Theta());
-    sigma = fFlagGetParSigmasFromTFs ? fResLepton->GetSigma(E * sintheta) / sintheta : E * E * sintheta;
+    sigma = m_flag_get_par_sigmas_from_TFs ? m_res_lepton->GetSigma(E * sintheta) / sintheta : E * E * sintheta;
     double sigrange = nsigmas_lepton * sigma;
     Emin = std::max(0.001, E - sigrange);
     Emax = E + sigrange;
   }
   SetParameterRange(parLepE, Emin, Emax);
 
-  sigma = fFlagGetParSigmasFromTFs ? fResMET->GetSigma(SumET) : 100;
+  sigma = m_flag_get_par_sigmas_from_TFs ? m_res_met->GetSigma(m_et_miss_sum) : 100;
   double sigrange = nsigmas_met * sigma;
-  SetParameterRange(parNuPx, ETmiss_x - sigrange, ETmiss_x + sigrange);
-  SetParameterRange(parNuPy, ETmiss_y - sigrange, ETmiss_y + sigrange);
+  SetParameterRange(parNuPx, m_et_miss_x - sigrange, m_et_miss_x + sigrange);
+  SetParameterRange(parNuPy, m_et_miss_y - sigrange, m_et_miss_y + sigrange);
 
-  if (fFlagTopMassFixed)
+  if (m_flag_top_mass_fixed)
     SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
   // no error
@@ -355,31 +355,31 @@ double LikelihoodTopLeptonJets::LogLikelihood(const std::vector<double> & parame
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
-  if (fTypeLepton == kElectron) {
-    logprob += log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp));
-  } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLepton->p(lep_fit_e * lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
+  if (m_lepton_type == kElectron) {
+    logprob += log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp));
+  } else if (m_lepton_type == kMuon) {
+    logprob += log(m_res_lepton->p(m_lep_fit_e * m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp));
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));
+  logprob += log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));
+  logprob += log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum));
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -388,16 +388,16 @@ double LikelihoodTopLeptonJets::LogLikelihood(const std::vector<double> & parame
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
-  logprob += BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW);
+  logprob += BCMath::LogBreitWignerRel(m_whad_fit_m, massW, gammaW);
 
   // Breit-Wigner of leptonically decaying W-boson
-  logprob += BCMath::LogBreitWignerRel(wlep_fit_m, massW, gammaW);
+  logprob += BCMath::LogBreitWignerRel(m_wlep_fit_m, massW, gammaW);
 
   // Breit-Wigner of hadronically decaying top quark
-  logprob += BCMath::LogBreitWignerRel(thad_fit_m, parameters[parTopM], gammaTop);
+  logprob += BCMath::LogBreitWignerRel(m_thad_fit_m, parameters[parTopM], gammaTop);
 
   // Breit-Wigner of leptonically decaying top quark
-  logprob += BCMath::LogBreitWignerRel(tlep_fit_m, parameters[parTopM], gammaTop);
+  logprob += BCMath::LogBreitWignerRel(m_tlep_fit_m, parameters[parTopM], gammaTop);
 
   // return log of likelihood
   return logprob;
@@ -429,21 +429,21 @@ std::vector<double> LikelihoodTopLeptonJets::GetInitialParametersWoNeutrinoPz() 
   std::vector<double> values(GetNParameters());
 
   // energies of the quarks
-  values[parBhadE] = bhad_meas_e;
-  values[parBlepE] = blep_meas_e;
-  values[parLQ1E]  = lq1_meas_e;
-  values[parLQ2E]  = lq2_meas_e;
+  values[parBhadE] = m_bhad_meas_e;
+  values[parBlepE] = m_blep_meas_e;
+  values[parLQ1E]  = m_lq1_meas_e;
+  values[parLQ2E]  = m_lq2_meas_e;
 
   // energy of the lepton
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     values[parLepE] = (*fParticlesPermuted)->Electron(0)->E();
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     values[parLepE] = (*fParticlesPermuted)->Muon(0)->E();
   }
 
   // missing px and py
-  values[parNuPx] = ETmiss_x;
-  values[parNuPy] = ETmiss_y;
+  values[parNuPx] = m_et_miss_x;
+  values[parNuPy] = m_et_miss_y;
 
   // pz of the neutrino
   values[parNuPz] = 0.;
@@ -479,12 +479,12 @@ std::vector<double> LikelihoodTopLeptonJets::CalculateNeutrinoPzSolutions(TLoren
   double pz_c = 0.0;
   double Ec = 0.0;
 
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     px_c = (*fParticlesPermuted)->Electron(0)->Px();
     py_c = (*fParticlesPermuted)->Electron(0)->Py();
     pz_c = (*fParticlesPermuted)->Electron(0)->Pz();
     Ec = (*fParticlesPermuted)->Electron(0)->E();
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     px_c = (*fParticlesPermuted)->Muon(0)->Px();
     py_c = (*fParticlesPermuted)->Muon(0)->Py();
     pz_c = (*fParticlesPermuted)->Muon(0)->Pz();
@@ -499,8 +499,8 @@ std::vector<double> LikelihoodTopLeptonJets::CalculateNeutrinoPzSolutions(TLoren
     Ec += additionalParticle->E();
   }
 
-  double px_nu = ETmiss_x;
-  double py_nu = ETmiss_y;
+  double px_nu = m_et_miss_x;
+  double py_nu = m_et_miss_y;
   double alpha = constants.MassW() * constants.MassW() - mE * mE + 2 * (px_c * px_nu + py_c * py_nu);
 
   double a = pz_c * pz_c - Ec * Ec;
@@ -525,52 +525,52 @@ std::vector<double> LikelihoodTopLeptonJets::CalculateNeutrinoPzSolutions(TLoren
 
 // ---------------------------------------------------------
 int LikelihoodTopLeptonJets::SavePermutedParticles() {
-  bhad_meas_e      = (*fParticlesPermuted)->Parton(0)->E();
-  bhad_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kParton);
-  bhad_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
-  bhad_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
-  bhad_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
-  bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &bhad_meas_px, &bhad_meas_py, &bhad_meas_pz, bhad_meas_e);
-  bhad_meas_p      = sqrt(bhad_meas_e*bhad_meas_e - bhad_meas_m*bhad_meas_m);
+  m_bhad_meas_e      = (*fParticlesPermuted)->Parton(0)->E();
+  m_bhad_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kParton);
+  m_bhad_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
+  m_bhad_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
+  m_bhad_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
+  m_bhad_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(0)->M(), fPhysicsConstants.MassBottom(), &m_bhad_meas_px, &m_bhad_meas_py, &m_bhad_meas_pz, m_bhad_meas_e);
+  m_bhad_meas_p      = sqrt(m_bhad_meas_e*m_bhad_meas_e - m_bhad_meas_m*m_bhad_meas_m);
 
-  blep_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
-  blep_meas_deteta = (*fParticlesPermuted)->DetEta(1, Particles::kParton);
-  blep_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
-  blep_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
-  blep_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
-  blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &blep_meas_px, &blep_meas_py, &blep_meas_pz, blep_meas_e);
-  blep_meas_p      = sqrt(blep_meas_e*blep_meas_e - blep_meas_m*blep_meas_m);
+  m_blep_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
+  m_blep_meas_deteta = (*fParticlesPermuted)->DetEta(1, Particles::kParton);
+  m_blep_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
+  m_blep_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
+  m_blep_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
+  m_blep_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(1)->M(), fPhysicsConstants.MassBottom(), &m_blep_meas_px, &m_blep_meas_py, &m_blep_meas_pz, m_blep_meas_e);
+  m_blep_meas_p      = sqrt(m_blep_meas_e*m_blep_meas_e - m_blep_meas_m*m_blep_meas_m);
 
-  lq1_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
-  lq1_meas_deteta = (*fParticlesPermuted)->DetEta(2, Particles::kParton);
-  lq1_meas_px     = (*fParticlesPermuted)->Parton(2)->Px();
-  lq1_meas_py     = (*fParticlesPermuted)->Parton(2)->Py();
-  lq1_meas_pz     = (*fParticlesPermuted)->Parton(2)->Pz();
-  lq1_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(2)->M(), 0., &lq1_meas_px, &lq1_meas_py, &lq1_meas_pz, lq1_meas_e);
-  lq1_meas_p      = sqrt(lq1_meas_e*lq1_meas_e - lq1_meas_m*lq1_meas_m);
+  m_lq1_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
+  m_lq1_meas_deteta = (*fParticlesPermuted)->DetEta(2, Particles::kParton);
+  m_lq1_meas_px     = (*fParticlesPermuted)->Parton(2)->Px();
+  m_lq1_meas_py     = (*fParticlesPermuted)->Parton(2)->Py();
+  m_lq1_meas_pz     = (*fParticlesPermuted)->Parton(2)->Pz();
+  m_lq1_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(2)->M(), 0., &m_lq1_meas_px, &m_lq1_meas_py, &m_lq1_meas_pz, m_lq1_meas_e);
+  m_lq1_meas_p      = sqrt(m_lq1_meas_e*m_lq1_meas_e - m_lq1_meas_m*m_lq1_meas_m);
 
-  lq2_meas_e      = (*fParticlesPermuted)->Parton(3)->E();
-  lq2_meas_deteta = (*fParticlesPermuted)->DetEta(3, Particles::kParton);
-  lq2_meas_px     = (*fParticlesPermuted)->Parton(3)->Px();
-  lq2_meas_py     = (*fParticlesPermuted)->Parton(3)->Py();
-  lq2_meas_pz     = (*fParticlesPermuted)->Parton(3)->Pz();
-  lq2_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(3)->M(), 0., &lq2_meas_px, &lq2_meas_py, &lq2_meas_pz, lq2_meas_e);
-  lq2_meas_p      = sqrt(lq2_meas_e*lq2_meas_e - lq2_meas_m*lq2_meas_m);
+  m_lq2_meas_e      = (*fParticlesPermuted)->Parton(3)->E();
+  m_lq2_meas_deteta = (*fParticlesPermuted)->DetEta(3, Particles::kParton);
+  m_lq2_meas_px     = (*fParticlesPermuted)->Parton(3)->Px();
+  m_lq2_meas_py     = (*fParticlesPermuted)->Parton(3)->Py();
+  m_lq2_meas_pz     = (*fParticlesPermuted)->Parton(3)->Pz();
+  m_lq2_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(3)->M(), 0., &m_lq2_meas_px, &m_lq2_meas_py, &m_lq2_meas_pz, m_lq2_meas_e);
+  m_lq2_meas_p      = sqrt(m_lq2_meas_e*m_lq2_meas_e - m_lq2_meas_m*m_lq2_meas_m);
 
   TLorentzVector* lepton(0);
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     lepton = (*fParticlesPermuted)->Electron(0);
-    lep_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kElectron);
+    m_lep_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kElectron);
   } else {
     lepton = (*fParticlesPermuted)->Muon(0);
-    lep_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kMuon);
+    m_lep_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kMuon);
   }
-  lep_meas_e        = lepton->E();
-  lep_meas_sintheta = sin(lepton->Theta());
-  lep_meas_pt       = lepton->Pt();
-  lep_meas_px       = lepton->Px();
-  lep_meas_py       = lepton->Py();
-  lep_meas_pz       = lepton->Pz();
+  m_lep_meas_e        = lepton->E();
+  m_lep_meas_sintheta = sin(lepton->Theta());
+  m_lep_meas_pt       = lepton->Pt();
+  m_lep_meas_px       = lepton->Px();
+  m_lep_meas_py       = lepton->Py();
+  m_lep_meas_pz       = lepton->Pz();
 
   // no error
   return 1;
@@ -578,16 +578,16 @@ int LikelihoodTopLeptonJets::SavePermutedParticles() {
 
 // ---------------------------------------------------------
 int LikelihoodTopLeptonJets::SaveResolutionFunctions() {
-  fResEnergyBhad = (*fDetector)->ResEnergyBJet(bhad_meas_deteta);
-  fResEnergyBlep = (*fDetector)->ResEnergyBJet(blep_meas_deteta);
-  fResEnergyLQ1  = (*fDetector)->ResEnergyLightJet(lq1_meas_deteta);
-  fResEnergyLQ2  = (*fDetector)->ResEnergyLightJet(lq2_meas_deteta);
-  if (fTypeLepton == kElectron) {
-    fResLepton = (*fDetector)->ResEnergyElectron(lep_meas_deteta);
-  } else if (fTypeLepton == kMuon) {
-    fResLepton = (*fDetector)->ResEnergyMuon(lep_meas_deteta);
+  m_res_energy_bhad = (*fDetector)->ResEnergyBJet(m_bhad_meas_deteta);
+  m_res_energy_blep = (*fDetector)->ResEnergyBJet(m_blep_meas_deteta);
+  m_res_energy_lq1  = (*fDetector)->ResEnergyLightJet(m_lq1_meas_deteta);
+  m_res_energy_lq2  = (*fDetector)->ResEnergyLightJet(m_lq2_meas_deteta);
+  if (m_lepton_type == kElectron) {
+    m_res_lepton = (*fDetector)->ResEnergyElectron(m_lep_meas_deteta);
+  } else if (m_lepton_type == kMuon) {
+    m_res_lepton = (*fDetector)->ResEnergyMuon(m_lep_meas_deteta);
   }
-  fResMET = (*fDetector)->ResMissingET();
+  m_res_met = (*fDetector)->ResMissingET();
 
   // no error
   return 1;
@@ -602,9 +602,9 @@ int LikelihoodTopLeptonJets::BuildModelParticles() {
   TLorentzVector* lq1  = fParticlesModel->Parton(2);
   TLorentzVector* lq2  = fParticlesModel->Parton(3);
   TLorentzVector* lep(0);
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     lep  = fParticlesModel->Electron(0);
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     lep  = fParticlesModel->Muon(0);
   }
   TLorentzVector* nu   = fParticlesModel->Neutrino(0);
@@ -613,12 +613,12 @@ int LikelihoodTopLeptonJets::BuildModelParticles() {
   TLorentzVector* thad  = fParticlesModel->Parton(4);
   TLorentzVector* tlep  = fParticlesModel->Parton(5);
 
-  bhad->SetPxPyPzE(bhad_fit_px, bhad_fit_py, bhad_fit_pz, bhad_fit_e);
-  blep->SetPxPyPzE(blep_fit_px, blep_fit_py, blep_fit_pz, blep_fit_e);
-  lq1 ->SetPxPyPzE(lq1_fit_px,  lq1_fit_py,  lq1_fit_pz,  lq1_fit_e);
-  lq2 ->SetPxPyPzE(lq2_fit_px,  lq2_fit_py,  lq2_fit_pz,  lq2_fit_e);
-  lep ->SetPxPyPzE(lep_fit_px,  lep_fit_py,  lep_fit_pz,  lep_fit_e);
-  nu  ->SetPxPyPzE(nu_fit_px,   nu_fit_py,   nu_fit_pz,   nu_fit_e);
+  bhad->SetPxPyPzE(m_bhad_fit_px, m_bhad_fit_py, m_bhad_fit_pz, m_bhad_fit_e);
+  blep->SetPxPyPzE(m_blep_fit_px, m_blep_fit_py, m_blep_fit_pz, m_blep_fit_e);
+  lq1 ->SetPxPyPzE(m_lq1_fit_px,  m_lq1_fit_py,  m_lq1_fit_pz,  m_lq1_fit_e);
+  lq2 ->SetPxPyPzE(m_lq2_fit_px,  m_lq2_fit_py,  m_lq2_fit_pz,  m_lq2_fit_e);
+  lep ->SetPxPyPzE(m_lep_fit_px,  m_lep_fit_py,  m_lep_fit_pz,  m_lep_fit_e);
+  nu  ->SetPxPyPzE(m_nu_fit_px,   m_nu_fit_py,   m_nu_fit_pz,   m_nu_fit_e);
 
   (*whad) = (*lq1)  + (*lq2);
   (*wlep) = (*lep)  + (*nu);
@@ -640,31 +640,31 @@ std::vector<double> LikelihoodTopLeptonJets::LogLikelihoodComponents(std::vector
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  vecci.push_back(log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp)));  // comp0
+  vecci.push_back(log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp)));  // comp0
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp)));  // comp1
+  vecci.push_back(log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp)));  // comp1
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp)));  // comp2
+  vecci.push_back(log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp)));  // comp2
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp)));  // comp3
+  vecci.push_back(log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp)));  // comp3
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
-  if (fTypeLepton == kElectron) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp)));  // comp4
-  } else if (fTypeLepton == kMuon) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp)));  // comp4
+  if (m_lepton_type == kElectron) {
+    vecci.push_back(log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp)));  // comp4
+  } else if (m_lepton_type == kMuon) {
+    vecci.push_back(log(m_res_lepton->p(m_lep_fit_e* m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp)));  // comp4
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  vecci.push_back(log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET)));  // comp5
+  vecci.push_back(log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum)));  // comp5
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET)));  // comp6
+  vecci.push_back(log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum)));  // comp6
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -673,16 +673,16 @@ std::vector<double> LikelihoodTopLeptonJets::LogLikelihoodComponents(std::vector
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
-  vecci.push_back(BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW));  // comp7
+  vecci.push_back(BCMath::LogBreitWignerRel(m_whad_fit_m, massW, gammaW));  // comp7
 
   // Breit-Wigner of leptonically decaying W-boson
-  vecci.push_back(BCMath::LogBreitWignerRel(wlep_fit_m, massW, gammaW));  // comp8
+  vecci.push_back(BCMath::LogBreitWignerRel(m_wlep_fit_m, massW, gammaW));  // comp8
 
   // Breit-Wigner of hadronically decaying top quark
-  vecci.push_back(BCMath::LogBreitWignerRel(thad_fit_m, parameters[parTopM], gammaTop));  // comp9
+  vecci.push_back(BCMath::LogBreitWignerRel(m_thad_fit_m, parameters[parTopM], gammaTop));  // comp9
 
   // Breit-Wigner of leptonically decaying top quark
-  vecci.push_back(BCMath::LogBreitWignerRel(tlep_fit_m, parameters[parTopM], gammaTop));  // comp10
+  vecci.push_back(BCMath::LogBreitWignerRel(m_tlep_fit_m, parameters[parTopM], gammaTop));  // comp10
 
   // return log of likelihood
   return vecci;

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -32,6 +32,7 @@
 #include "TLorentzVector.h"
 
 namespace KLFitter {
+// ---------------------------------------------------------
 LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
   : LikelihoodBase::LikelihoodBase()
   , m_flag_top_mass_fixed(false)

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -64,7 +64,7 @@ int LikelihoodTopLeptonJets::SetET_miss_XY_SumET(double etx, double ety, double 
 // ---------------------------------------------------------
 void LikelihoodTopLeptonJets::SetLeptonType(LeptonType leptontype) {
   if (leptontype != kElectron && leptontype != kMuon) {
-    std::cout << "KLFitter::SetLeptonTyp(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;
+    std::cout << "KLFitter::SetLeptonType(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;
     fTypeLepton = kElectron;
   } else {
     fTypeLepton = leptontype;
@@ -77,7 +77,7 @@ void LikelihoodTopLeptonJets::SetLeptonType(LeptonType leptontype) {
 // ---------------------------------------------------------
 void LikelihoodTopLeptonJets::SetLeptonType(int leptontype) {
   if (leptontype != 1 && leptontype != 2) {
-    std::cout << "KLFitter::SetLeptonTyp(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;
+    std::cout << "KLFitter::SetLeptonType(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;
     leptontype = 1;
   }
 
@@ -94,8 +94,7 @@ int LikelihoodTopLeptonJets::DefineModelParticles() {
   fParticlesModel.reset(new Particles{});
 
   // add model particles
-  // create dummy TLorentzVector
-  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  TLorentzVector dummy{0, 0, 0, 0};
   fParticlesModel->AddParticle(&dummy,
                                Particles::kParton,  // type
                                "hadronic b quark",  // name
@@ -129,11 +128,9 @@ int LikelihoodTopLeptonJets::DefineModelParticles() {
   fParticlesModel->AddParticle(&dummy, Particles::kNeutrino, "neutrino");
 
   fParticlesModel->AddParticle(&dummy, Particles::kBoson, "hadronic W");
-
   fParticlesModel->AddParticle(&dummy, Particles::kBoson, "leptonic W");
 
   fParticlesModel->AddParticle(&dummy, Particles::kParton, "hadronic top");
-
   fParticlesModel->AddParticle(&dummy, Particles::kParton, "leptonic top");
 
   // no error
@@ -143,15 +140,15 @@ int LikelihoodTopLeptonJets::DefineModelParticles() {
 // ---------------------------------------------------------
 void LikelihoodTopLeptonJets::DefineParameters() {
   // add parameters of model
-  AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
-  AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
-  AddParameter("energy light quark 1",    0.0, 1000.0);                              // parLQ1E
-  AddParameter("energy light quark 2",    0.0, 1000.0);                              // parLQ2E
-  AddParameter("energy lepton",           0.0, 1000.0);                              // parLepE
-  AddParameter("p_x neutrino",        -1000.0, 1000.0);                              // parNuPx
-  AddParameter("p_y neutrino",        -1000.0, 1000.0);                              // parNuPy
-  AddParameter("p_z neutrino",        -1000.0, 1000.0);                              // parNuPz
-  AddParameter("top mass",              100.0, 1000.0);                              // parTopM
+  AddParameter("energy hadronic b", fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
+  AddParameter("energy leptonic b", fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
+  AddParameter("energy light quark 1", 0.0, 1000.0);                          // parLQ1E
+  AddParameter("energy light quark 2", 0.0, 1000.0);                          // parLQ2E
+  AddParameter("energy lepton", 0.0, 1000.0);                                 // parLepE
+  AddParameter("p_x neutrino", -1000.0, 1000.0);                              // parNuPx
+  AddParameter("p_y neutrino", -1000.0, 1000.0);                              // parNuPy
+  AddParameter("p_z neutrino", -1000.0, 1000.0);                              // parNuPz
+  AddParameter("top mass", 100.0, 1000.0);                                   // parTopM
 }
 
 // ---------------------------------------------------------
@@ -168,28 +165,28 @@ int LikelihoodTopLeptonJets::CalculateLorentzVectors(std::vector <double> const&
 
   // hadronic b quark
   bhad_fit_e = parameters[parBhadE];
-  scale = sqrt(bhad_fit_e*bhad_fit_e - bhad_meas_m*bhad_meas_m) / bhad_meas_p;
+  scale = sqrt(bhad_fit_e * bhad_fit_e - bhad_meas_m * bhad_meas_m) / bhad_meas_p;
   bhad_fit_px = scale * bhad_meas_px;
   bhad_fit_py = scale * bhad_meas_py;
   bhad_fit_pz = scale * bhad_meas_pz;
 
   // leptonic b quark
   blep_fit_e = parameters[parBlepE];
-  scale = sqrt(blep_fit_e*blep_fit_e - blep_meas_m*blep_meas_m) / blep_meas_p;
+  scale = sqrt(blep_fit_e * blep_fit_e - blep_meas_m * blep_meas_m) / blep_meas_p;
   blep_fit_px = scale * blep_meas_px;
   blep_fit_py = scale * blep_meas_py;
   blep_fit_pz = scale * blep_meas_pz;
 
   // light quark 1
   lq1_fit_e = parameters[parLQ1E];
-  scale = sqrt(lq1_fit_e*lq1_fit_e - lq1_meas_m*lq1_meas_m) / lq1_meas_p;
+  scale = sqrt(lq1_fit_e * lq1_fit_e - lq1_meas_m * lq1_meas_m) / lq1_meas_p;
   lq1_fit_px = scale * lq1_meas_px;
   lq1_fit_py = scale * lq1_meas_py;
   lq1_fit_pz = scale * lq1_meas_pz;
 
   // light quark 2
   lq2_fit_e = parameters[parLQ2E];
-  scale = sqrt(lq2_fit_e*lq2_fit_e - lq2_meas_m*lq2_meas_m) / lq2_meas_p;
+  scale = sqrt(lq2_fit_e * lq2_fit_e - lq2_meas_m * lq2_meas_m) / lq2_meas_p;
   lq2_fit_px  = scale * lq2_meas_px;
   lq2_fit_py  = scale * lq2_meas_py;
   lq2_fit_pz  = scale * lq2_meas_pz;
@@ -205,35 +202,35 @@ int LikelihoodTopLeptonJets::CalculateLorentzVectors(std::vector <double> const&
   nu_fit_px = parameters[parNuPx];
   nu_fit_py = parameters[parNuPy];
   nu_fit_pz = parameters[parNuPz];
-  nu_fit_e  = sqrt(nu_fit_px*nu_fit_px + nu_fit_py*nu_fit_py + nu_fit_pz*nu_fit_pz);
+  nu_fit_e  = sqrt(nu_fit_px * nu_fit_px + nu_fit_py * nu_fit_py + nu_fit_pz * nu_fit_pz);
 
   // hadronic W
-  whad_fit_e  = lq1_fit_e +lq2_fit_e;
-  whad_fit_px = lq1_fit_px+lq2_fit_px;
-  whad_fit_py = lq1_fit_py+lq2_fit_py;
-  whad_fit_pz = lq1_fit_pz+lq2_fit_pz;
-  whad_fit_m = sqrt(whad_fit_e*whad_fit_e - (whad_fit_px*whad_fit_px + whad_fit_py*whad_fit_py + whad_fit_pz*whad_fit_pz));
+  whad_fit_e  = lq1_fit_e + lq2_fit_e;
+  whad_fit_px = lq1_fit_px + lq2_fit_px;
+  whad_fit_py = lq1_fit_py + lq2_fit_py;
+  whad_fit_pz = lq1_fit_pz + lq2_fit_pz;
+  whad_fit_m = sqrt(whad_fit_e * whad_fit_e - (whad_fit_px * whad_fit_px + whad_fit_py * whad_fit_py + whad_fit_pz * whad_fit_pz));
 
   // leptonic W
-  wlep_fit_e  = lep_fit_e +nu_fit_e;
-  wlep_fit_px = lep_fit_px+nu_fit_px;
-  wlep_fit_py = lep_fit_py+nu_fit_py;
-  wlep_fit_pz = lep_fit_pz+nu_fit_pz;
-  wlep_fit_m = sqrt(wlep_fit_e*wlep_fit_e - (wlep_fit_px*wlep_fit_px + wlep_fit_py*wlep_fit_py + wlep_fit_pz*wlep_fit_pz));
+  wlep_fit_e  = lep_fit_e + nu_fit_e;
+  wlep_fit_px = lep_fit_px + nu_fit_px;
+  wlep_fit_py = lep_fit_py + nu_fit_py;
+  wlep_fit_pz = lep_fit_pz + nu_fit_pz;
+  wlep_fit_m = sqrt(wlep_fit_e * wlep_fit_e - (wlep_fit_px * wlep_fit_px + wlep_fit_py * wlep_fit_py + wlep_fit_pz * wlep_fit_pz));
 
   // hadronic top
-  thad_fit_e = whad_fit_e+bhad_fit_e;
-  thad_fit_px = whad_fit_px+bhad_fit_px;
-  thad_fit_py = whad_fit_py+bhad_fit_py;
-  thad_fit_pz = whad_fit_pz+bhad_fit_pz;
-  thad_fit_m = sqrt(thad_fit_e*thad_fit_e - (thad_fit_px*thad_fit_px + thad_fit_py*thad_fit_py + thad_fit_pz*thad_fit_pz));
+  thad_fit_e = whad_fit_e + bhad_fit_e;
+  thad_fit_px = whad_fit_px + bhad_fit_px;
+  thad_fit_py = whad_fit_py + bhad_fit_py;
+  thad_fit_pz = whad_fit_pz + bhad_fit_pz;
+  thad_fit_m = sqrt(thad_fit_e * thad_fit_e - (thad_fit_px * thad_fit_px + thad_fit_py * thad_fit_py + thad_fit_pz * thad_fit_pz));
 
   // leptonic top
-  tlep_fit_e = wlep_fit_e+blep_fit_e;
-  tlep_fit_px = wlep_fit_px+blep_fit_px;
-  tlep_fit_py = wlep_fit_py+blep_fit_py;
-  tlep_fit_pz = wlep_fit_pz+blep_fit_pz;
-  tlep_fit_m = sqrt(tlep_fit_e*tlep_fit_e - (tlep_fit_px*tlep_fit_px + tlep_fit_py*tlep_fit_py + tlep_fit_pz*tlep_fit_pz));
+  tlep_fit_e = wlep_fit_e + blep_fit_e;
+  tlep_fit_px = wlep_fit_px + blep_fit_px;
+  tlep_fit_py = wlep_fit_py + blep_fit_py;
+  tlep_fit_pz = wlep_fit_pz + blep_fit_pz;
+  tlep_fit_m = sqrt(tlep_fit_e * tlep_fit_e - (tlep_fit_px * tlep_fit_px + tlep_fit_py * tlep_fit_py + tlep_fit_pz * tlep_fit_pz));
 
   // no error
   return 1;
@@ -251,7 +248,7 @@ int LikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
   indexVector_Jets.push_back(3);
   err *= (*fPermutations)->InvariantParticlePermutations(ptype, indexVector_Jets);
 
-  // remove invariant jet permutations of notevent jets
+  // remove invariant jet permutations of all jets not considered
   Particles* particles = (*fPermutations)->Particles();
   indexVector_Jets.clear();
   for (int iPartons = 4; iPartons < particles->NPartons(); iPartons++) {
@@ -289,61 +286,55 @@ int LikelihoodTopLeptonJets::AdjustParameterRanges() {
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
   double m = fPhysicsConstants.MassBottom();
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double sigma = fFlagGetParSigmasFromTFs ? fResEnergyBhad->GetSigma(E) : sqrt(E);
-  double Emin = std::max(m, E - nsigmas_jet* sigma);
-  double Emax  = E + nsigmas_jet* sigma;
+  double Emin = std::max(m, E - nsigmas_jet * sigma);
+  double Emax = E + nsigmas_jet * sigma;
   SetParameterRange(parBhadE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
   m = fPhysicsConstants.MassBottom();
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyBlep->GetSigma(E) : sqrt(E);
-  Emin = std::max(m, E - nsigmas_jet* sigma);
-  Emax  = E + nsigmas_jet* sigma;
+  Emin = std::max(m, E - nsigmas_jet * sigma);
+  Emax = E + nsigmas_jet * sigma;
   SetParameterRange(parBlepE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(2)->E();
   m = 0.001;
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(2)->M());
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(2)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyLQ1->GetSigma(E) : sqrt(E);
-  Emin = std::max(m, E - nsigmas_jet* sigma);
-  Emax  = E + nsigmas_jet* sigma;
+  Emin = std::max(m, E - nsigmas_jet * sigma);
+  Emax = E + nsigmas_jet * sigma;
   SetParameterRange(parLQ1E, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(3)->E();
   m = 0.001;
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(3)->M());
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(3)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyLQ2->GetSigma(E) : sqrt(E);
-  Emin = std::max(m, E - nsigmas_jet* sigma);
-  Emax  = E + nsigmas_jet* sigma;
+  Emin = std::max(m, E - nsigmas_jet * sigma);
+  Emax = E + nsigmas_jet * sigma;
   SetParameterRange(parLQ2E, Emin, Emax);
 
   if (fTypeLepton == kElectron) {
     E = (*fParticlesPermuted)->Electron(0)->E();
     sigma = fFlagGetParSigmasFromTFs ? fResLepton->GetSigma(E) : sqrt(E);
-    Emin = std::max(0.001, E - nsigmas_lepton* sigma);
-    Emax  = E + nsigmas_lepton* sigma;
+    Emin = std::max(0.001, E - nsigmas_lepton * sigma);
+    Emax = E + nsigmas_lepton * sigma;
   } else if (fTypeLepton == kMuon) {
     E = (*fParticlesPermuted)->Muon(0)->E();
     double sintheta = sin((*fParticlesPermuted)->Muon(0)->Theta());
-    sigma = fFlagGetParSigmasFromTFs ? fResLepton->GetSigma(E*sintheta)/sintheta : E*E*sintheta;
-    double sigrange = nsigmas_lepton* sigma;
-    Emin = std::max(0.001, E -sigrange);
-    Emax = E +sigrange;
+    sigma = fFlagGetParSigmasFromTFs ? fResLepton->GetSigma(E * sintheta) / sintheta : E * E * sintheta;
+    double sigrange = nsigmas_lepton * sigma;
+    Emin = std::max(0.001, E - sigrange);
+    Emax = E + sigrange;
   }
   SetParameterRange(parLepE, Emin, Emax);
 
-  // note: this is hard-coded in the momement
-
   sigma = fFlagGetParSigmasFromTFs ? fResMET->GetSigma(SumET) : 100;
-  double sigrange = nsigmas_met*sigma;
-  SetParameterRange(parNuPx, ETmiss_x-sigrange, ETmiss_x+sigrange);
-  SetParameterRange(parNuPy, ETmiss_y-sigrange, ETmiss_y+sigrange);
+  double sigrange = nsigmas_met * sigma;
+  SetParameterRange(parNuPx, ETmiss_x - sigrange, ETmiss_x + sigrange);
+  SetParameterRange(parNuPy, ETmiss_y - sigrange, ETmiss_y + sigrange);
 
   if (fFlagTopMassFixed)
     SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
@@ -380,7 +371,7 @@ double LikelihoodTopLeptonJets::LogLikelihood(const std::vector<double> & parame
   if (fTypeLepton == kElectron) {
     logprob += log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp));
   } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
+    logprob += log(fResLepton->p(lep_fit_e * lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
   }
   if (!TFgoodTmp) fTFgood = false;
 
@@ -394,9 +385,6 @@ double LikelihoodTopLeptonJets::LogLikelihood(const std::vector<double> & parame
   // physics constants
   double massW = fPhysicsConstants.MassW();
   double gammaW = fPhysicsConstants.GammaW();
-  // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
-  // (this will also set the correct width for the top)
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
@@ -430,8 +418,7 @@ std::vector<double> LikelihoodTopLeptonJets::GetInitialParameters() {
     values[parNuPz] = neutrino_pz_solutions[1];
     sol2 = LogLikelihood(values);
 
-    if (sol1 > sol2)
-      values[parNuPz] = neutrino_pz_solutions[0];
+    if (sol1 > sol2) values[parNuPz] = neutrino_pz_solutions[0];
   }
 
   return values;
@@ -514,24 +501,23 @@ std::vector<double> LikelihoodTopLeptonJets::CalculateNeutrinoPzSolutions(TLoren
 
   double px_nu = ETmiss_x;
   double py_nu = ETmiss_y;
-  double alpha = constants.MassW()*constants.MassW() - mE*mE + 2*(px_c*px_nu + py_c*py_nu);
+  double alpha = constants.MassW() * constants.MassW() - mE * mE + 2 * (px_c * px_nu + py_c * py_nu);
 
-  double a = pz_c*pz_c - Ec*Ec;
-  double b = alpha* pz_c;
-  double c = - Ec*Ec* (px_nu*px_nu + py_nu*py_nu) + alpha*alpha/4.;
+  double a = pz_c * pz_c - Ec * Ec;
+  double b = alpha * pz_c;
+  double c = - Ec * Ec * (px_nu * px_nu + py_nu * py_nu) + alpha * alpha / 4.;
 
-  double discriminant = b*b - 4*a*c;
-  if (discriminant < 0.)
-    return pz;
+  double discriminant = b * b - 4 * a * c;
+  if (discriminant < 0.) return pz;
 
-  double pz_offset = - b / (2*a);
+  double pz_offset = - b / (2 * a);
 
   double squareRoot = sqrt(discriminant);
   if (squareRoot < 1.e-6) {
     pz.push_back(pz_offset);
   } else {
-    pz.push_back(pz_offset + squareRoot / (2*a));
-    pz.push_back(pz_offset - squareRoot / (2*a));
+    pz.push_back(pz_offset + squareRoot / (2 * a));
+    pz.push_back(pz_offset - squareRoot / (2 * a));
   }
 
   return pz;
@@ -571,7 +557,7 @@ int LikelihoodTopLeptonJets::SavePermutedParticles() {
   lq2_meas_m      = SetPartonMass((*fParticlesPermuted)->Parton(3)->M(), 0., &lq2_meas_px, &lq2_meas_py, &lq2_meas_pz, lq2_meas_e);
   lq2_meas_p      = sqrt(lq2_meas_e*lq2_meas_e - lq2_meas_m*lq2_meas_m);
 
-  TLorentzVector * lepton(0);
+  TLorentzVector* lepton(0);
   if (fTypeLepton == kElectron) {
     lepton = (*fParticlesPermuted)->Electron(0);
     lep_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kElectron);
@@ -611,21 +597,21 @@ int LikelihoodTopLeptonJets::SaveResolutionFunctions() {
 int LikelihoodTopLeptonJets::BuildModelParticles() {
   if (GetBestFitParameters().size() > 0) CalculateLorentzVectors(GetBestFitParameters());
 
-  TLorentzVector * bhad = fParticlesModel->Parton(0);
-  TLorentzVector * blep = fParticlesModel->Parton(1);
-  TLorentzVector * lq1  = fParticlesModel->Parton(2);
-  TLorentzVector * lq2  = fParticlesModel->Parton(3);
-  TLorentzVector * lep(0);
+  TLorentzVector* bhad = fParticlesModel->Parton(0);
+  TLorentzVector* blep = fParticlesModel->Parton(1);
+  TLorentzVector* lq1  = fParticlesModel->Parton(2);
+  TLorentzVector* lq2  = fParticlesModel->Parton(3);
+  TLorentzVector* lep(0);
   if (fTypeLepton == kElectron) {
     lep  = fParticlesModel->Electron(0);
   } else if (fTypeLepton == kMuon) {
     lep  = fParticlesModel->Muon(0);
   }
-  TLorentzVector * nu   = fParticlesModel->Neutrino(0);
-  TLorentzVector * whad  = fParticlesModel->Boson(0);
-  TLorentzVector * wlep  = fParticlesModel->Boson(1);
-  TLorentzVector * thad  = fParticlesModel->Parton(4);
-  TLorentzVector * tlep  = fParticlesModel->Parton(5);
+  TLorentzVector* nu   = fParticlesModel->Neutrino(0);
+  TLorentzVector* whad  = fParticlesModel->Boson(0);
+  TLorentzVector* wlep  = fParticlesModel->Boson(1);
+  TLorentzVector* thad  = fParticlesModel->Parton(4);
+  TLorentzVector* tlep  = fParticlesModel->Parton(5);
 
   bhad->SetPxPyPzE(bhad_fit_px, bhad_fit_py, bhad_fit_pz, bhad_fit_e);
   blep->SetPxPyPzE(blep_fit_px, blep_fit_py, blep_fit_pz, blep_fit_e);
@@ -684,9 +670,6 @@ std::vector<double> LikelihoodTopLeptonJets::LogLikelihoodComponents(std::vector
   // physics constants
   double massW = fPhysicsConstants.MassW();
   double gammaW = fPhysicsConstants.GammaW();
-  // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
-  // (this will also set the correct width for the top)
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -31,9 +31,9 @@
 #include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
-// ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
-  : KLFitter::LikelihoodBase::LikelihoodBase()
+namespace KLFitter {
+LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
+  : LikelihoodBase::LikelihoodBase()
   , fFlagTopMassFixed(false)
   , fFlagGetParSigmasFromTFs(false)
   , ETmiss_x(0.)
@@ -48,10 +48,10 @@ KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
 }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets::~LikelihoodTopLeptonJets() = default;
+LikelihoodTopLeptonJets::~LikelihoodTopLeptonJets() = default;
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::SetET_miss_XY_SumET(double etx, double ety, double sumet) {
+int LikelihoodTopLeptonJets::SetET_miss_XY_SumET(double etx, double ety, double sumet) {
   // set missing ET x and y component and the SumET
   ETmiss_x = etx;
   ETmiss_y = ety;
@@ -62,7 +62,7 @@ int KLFitter::LikelihoodTopLeptonJets::SetET_miss_XY_SumET(double etx, double et
 }
 
 // ---------------------------------------------------------
-void KLFitter::LikelihoodTopLeptonJets::SetLeptonType(LeptonType leptontype) {
+void LikelihoodTopLeptonJets::SetLeptonType(LeptonType leptontype) {
   if (leptontype != kElectron && leptontype != kMuon) {
     std::cout << "KLFitter::SetLeptonTyp(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;
     fTypeLepton = kElectron;
@@ -75,7 +75,7 @@ void KLFitter::LikelihoodTopLeptonJets::SetLeptonType(LeptonType leptontype) {
 }
 
 // ---------------------------------------------------------
-void KLFitter::LikelihoodTopLeptonJets::SetLeptonType(int leptontype) {
+void LikelihoodTopLeptonJets::SetLeptonType(int leptontype) {
   if (leptontype != 1 && leptontype != 2) {
     std::cout << "KLFitter::SetLeptonTyp(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;
     leptontype = 1;
@@ -89,73 +89,59 @@ void KLFitter::LikelihoodTopLeptonJets::SetLeptonType(int leptontype) {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::DefineModelParticles() {
+int LikelihoodTopLeptonJets::DefineModelParticles() {
   // create the particles of the model
-  fParticlesModel.reset(new KLFitter::Particles{});
+  fParticlesModel.reset(new Particles{});
 
   // add model particles
   // create dummy TLorentzVector
   TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
   fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,  // type
-                               "hadronic b quark",            // name
-                               0,                             // index of corresponding particle
-                               KLFitter::Particles::kB);      // b jet (truth)
+                               Particles::kParton,  // type
+                               "hadronic b quark",  // name
+                               0,                   // index of corresponding particle
+                               Particles::kB);      // b jet (truth)
 
   fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
+                               Particles::kParton,
                                "leptonic b quark",
-                               1,                             // index of corresponding particle
-                               KLFitter::Particles::kB);      // b jet (truth)
+                               1,                   // index of corresponding particle
+                               Particles::kB);      // b jet (truth)
 
   fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
+                               Particles::kParton,
                                "light quark 1",
-                               2,                             // index of corresponding particle
-                               KLFitter::Particles::kLight);  // light jet (truth)
+                               2,                   // index of corresponding particle
+                               Particles::kLight);  // light jet (truth)
 
   fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
+                               Particles::kParton,
                                "light quark 2",
-                               3,                             // index of corresponding particle
-                               KLFitter::Particles::kLight);  // light jet (truth)
+                               3,                   // index of corresponding particle
+                               Particles::kLight);  // light jet (truth)
 
   if (fTypeLepton == kElectron) {
-    fParticlesModel->AddParticle(&dummy,
-                                 KLFitter::Particles::kElectron,
-                                 "electron");
+    fParticlesModel->AddParticle(&dummy, Particles::kElectron, "electron");
   } else if (fTypeLepton == kMuon) {
-    fParticlesModel->AddParticle(&dummy,
-                                 KLFitter::Particles::kMuon,
-                                 "muon");
+    fParticlesModel->AddParticle(&dummy, Particles::kMuon, "muon");
   }
 
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kNeutrino,
-                               "neutrino");
+  fParticlesModel->AddParticle(&dummy, Particles::kNeutrino, "neutrino");
 
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kBoson,
-                               "hadronic W");
+  fParticlesModel->AddParticle(&dummy, Particles::kBoson, "hadronic W");
 
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kBoson,
-                               "leptonic W");
+  fParticlesModel->AddParticle(&dummy, Particles::kBoson, "leptonic W");
 
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
-                               "hadronic top");
+  fParticlesModel->AddParticle(&dummy, Particles::kParton, "hadronic top");
 
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
-                               "leptonic top");
+  fParticlesModel->AddParticle(&dummy, Particles::kParton, "leptonic top");
 
   // no error
   return 1;
 }
 
 // ---------------------------------------------------------
-void KLFitter::LikelihoodTopLeptonJets::DefineParameters() {
+void LikelihoodTopLeptonJets::DefineParameters() {
   // add parameters of model
   AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
   AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
@@ -169,7 +155,7 @@ void KLFitter::LikelihoodTopLeptonJets::DefineParameters() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::CalculateLorentzVectors(std::vector <double> const& parameters) {
+int LikelihoodTopLeptonJets::CalculateLorentzVectors(std::vector <double> const& parameters) {
   double scale;
   double thad_fit_e;
   double thad_fit_px;
@@ -254,19 +240,19 @@ int KLFitter::LikelihoodTopLeptonJets::CalculateLorentzVectors(std::vector <doub
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
+int LikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
   // error code
   int err = 1;
 
   // remove the permutation from the second and the third jet
-  KLFitter::Particles::ParticleType ptype = KLFitter::Particles::kParton;
+  Particles::ParticleType ptype = Particles::kParton;
   std::vector<int> indexVector_Jets;
   indexVector_Jets.push_back(2);
   indexVector_Jets.push_back(3);
   err *= (*fPermutations)->InvariantParticlePermutations(ptype, indexVector_Jets);
 
   // remove invariant jet permutations of notevent jets
-  KLFitter::Particles* particles = (*fPermutations)->Particles();
+  Particles* particles = (*fPermutations)->Particles();
   indexVector_Jets.clear();
   for (int iPartons = 4; iPartons < particles->NPartons(); iPartons++) {
     indexVector_Jets.push_back(iPartons);
@@ -275,14 +261,14 @@ int KLFitter::LikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
 
   // remove the permutation from the other lepton
   if (fTypeLepton == kElectron) {
-    ptype = KLFitter::Particles::kMuon;
+    ptype = Particles::kMuon;
     std::vector<int> indexVector_Muons;
     for (int iMuon = 0; iMuon < particles->NMuons(); iMuon++) {
       indexVector_Muons.push_back(iMuon);
     }
     err *= (*fPermutations)->InvariantParticlePermutations(ptype, indexVector_Muons);
   } else if (fTypeLepton == kMuon) {
-    ptype = KLFitter::Particles::kElectron;
+    ptype = Particles::kElectron;
     std::vector<int> indexVector_Electrons;
     for (int iElectron = 0; iElectron < particles->NElectrons(); iElectron++) {
       indexVector_Electrons.push_back(iElectron);
@@ -295,7 +281,7 @@ int KLFitter::LikelihoodTopLeptonJets::RemoveInvariantParticlePermutations() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::AdjustParameterRanges() {
+int LikelihoodTopLeptonJets::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet    = fFlagGetParSigmasFromTFs ? 10 : 7;
   double nsigmas_lepton = fFlagGetParSigmasFromTFs ? 10 : 2;
@@ -367,7 +353,7 @@ int KLFitter::LikelihoodTopLeptonJets::AdjustParameterRanges() {
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJets::LogLikelihood(const std::vector<double> & parameters) {
+double LikelihoodTopLeptonJets::LogLikelihood(const std::vector<double> & parameters) {
   // calculate 4-vectors
   CalculateLorentzVectors(parameters);
 
@@ -430,7 +416,7 @@ double KLFitter::LikelihoodTopLeptonJets::LogLikelihood(const std::vector<double
 }
 
 // ---------------------------------------------------------
-std::vector<double> KLFitter::LikelihoodTopLeptonJets::GetInitialParameters() {
+std::vector<double> LikelihoodTopLeptonJets::GetInitialParameters() {
   std::vector<double> values(GetInitialParametersWoNeutrinoPz());
 
   // check second neutrino solution
@@ -452,7 +438,7 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets::GetInitialParameters() {
 }
 
 // ---------------------------------------------------------
-std::vector<double> KLFitter::LikelihoodTopLeptonJets::GetInitialParametersWoNeutrinoPz() {
+std::vector<double> LikelihoodTopLeptonJets::GetInitialParametersWoNeutrinoPz() {
   std::vector<double> values(GetNParameters());
 
   // energies of the quarks
@@ -489,15 +475,15 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets::GetInitialParametersWoNeu
 }
 
 // ---------------------------------------------------------
-std::vector<double> KLFitter::LikelihoodTopLeptonJets::GetNeutrinoPzSolutions() {
+std::vector<double> LikelihoodTopLeptonJets::GetNeutrinoPzSolutions() {
   return CalculateNeutrinoPzSolutions();
 }
 
 // ---------------------------------------------------------
-std::vector<double> KLFitter::LikelihoodTopLeptonJets::CalculateNeutrinoPzSolutions(TLorentzVector* additionalParticle) {
+std::vector<double> LikelihoodTopLeptonJets::CalculateNeutrinoPzSolutions(TLorentzVector* additionalParticle) {
   std::vector<double> pz;
 
-  KLFitter::PhysicsConstants constants;
+  class PhysicsConstants constants;
   // electron mass
   double mE = 0.;
 
@@ -552,9 +538,9 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets::CalculateNeutrinoPzSoluti
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::SavePermutedParticles() {
+int LikelihoodTopLeptonJets::SavePermutedParticles() {
   bhad_meas_e      = (*fParticlesPermuted)->Parton(0)->E();
-  bhad_meas_deteta = (*fParticlesPermuted)->DetEta(0, KLFitter::Particles::kParton);
+  bhad_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kParton);
   bhad_meas_px     = (*fParticlesPermuted)->Parton(0)->Px();
   bhad_meas_py     = (*fParticlesPermuted)->Parton(0)->Py();
   bhad_meas_pz     = (*fParticlesPermuted)->Parton(0)->Pz();
@@ -562,7 +548,7 @@ int KLFitter::LikelihoodTopLeptonJets::SavePermutedParticles() {
   bhad_meas_p      = sqrt(bhad_meas_e*bhad_meas_e - bhad_meas_m*bhad_meas_m);
 
   blep_meas_e      = (*fParticlesPermuted)->Parton(1)->E();
-  blep_meas_deteta = (*fParticlesPermuted)->DetEta(1, KLFitter::Particles::kParton);
+  blep_meas_deteta = (*fParticlesPermuted)->DetEta(1, Particles::kParton);
   blep_meas_px     = (*fParticlesPermuted)->Parton(1)->Px();
   blep_meas_py     = (*fParticlesPermuted)->Parton(1)->Py();
   blep_meas_pz     = (*fParticlesPermuted)->Parton(1)->Pz();
@@ -570,7 +556,7 @@ int KLFitter::LikelihoodTopLeptonJets::SavePermutedParticles() {
   blep_meas_p      = sqrt(blep_meas_e*blep_meas_e - blep_meas_m*blep_meas_m);
 
   lq1_meas_e      = (*fParticlesPermuted)->Parton(2)->E();
-  lq1_meas_deteta = (*fParticlesPermuted)->DetEta(2, KLFitter::Particles::kParton);
+  lq1_meas_deteta = (*fParticlesPermuted)->DetEta(2, Particles::kParton);
   lq1_meas_px     = (*fParticlesPermuted)->Parton(2)->Px();
   lq1_meas_py     = (*fParticlesPermuted)->Parton(2)->Py();
   lq1_meas_pz     = (*fParticlesPermuted)->Parton(2)->Pz();
@@ -578,7 +564,7 @@ int KLFitter::LikelihoodTopLeptonJets::SavePermutedParticles() {
   lq1_meas_p      = sqrt(lq1_meas_e*lq1_meas_e - lq1_meas_m*lq1_meas_m);
 
   lq2_meas_e      = (*fParticlesPermuted)->Parton(3)->E();
-  lq2_meas_deteta = (*fParticlesPermuted)->DetEta(3, KLFitter::Particles::kParton);
+  lq2_meas_deteta = (*fParticlesPermuted)->DetEta(3, Particles::kParton);
   lq2_meas_px     = (*fParticlesPermuted)->Parton(3)->Px();
   lq2_meas_py     = (*fParticlesPermuted)->Parton(3)->Py();
   lq2_meas_pz     = (*fParticlesPermuted)->Parton(3)->Pz();
@@ -588,10 +574,10 @@ int KLFitter::LikelihoodTopLeptonJets::SavePermutedParticles() {
   TLorentzVector * lepton(0);
   if (fTypeLepton == kElectron) {
     lepton = (*fParticlesPermuted)->Electron(0);
-    lep_meas_deteta = (*fParticlesPermuted)->DetEta(0, KLFitter::Particles::kElectron);
+    lep_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kElectron);
   } else {
     lepton = (*fParticlesPermuted)->Muon(0);
-    lep_meas_deteta = (*fParticlesPermuted)->DetEta(0, KLFitter::Particles::kMuon);
+    lep_meas_deteta = (*fParticlesPermuted)->DetEta(0, Particles::kMuon);
   }
   lep_meas_e        = lepton->E();
   lep_meas_sintheta = sin(lepton->Theta());
@@ -605,7 +591,7 @@ int KLFitter::LikelihoodTopLeptonJets::SavePermutedParticles() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::SaveResolutionFunctions() {
+int LikelihoodTopLeptonJets::SaveResolutionFunctions() {
   fResEnergyBhad = (*fDetector)->ResEnergyBJet(bhad_meas_deteta);
   fResEnergyBlep = (*fDetector)->ResEnergyBJet(blep_meas_deteta);
   fResEnergyLQ1  = (*fDetector)->ResEnergyLightJet(lq1_meas_deteta);
@@ -622,7 +608,7 @@ int KLFitter::LikelihoodTopLeptonJets::SaveResolutionFunctions() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets::BuildModelParticles() {
+int LikelihoodTopLeptonJets::BuildModelParticles() {
   if (GetBestFitParameters().size() > 0) CalculateLorentzVectors(GetBestFitParameters());
 
   TLorentzVector * bhad = fParticlesModel->Parton(0);
@@ -658,7 +644,7 @@ int KLFitter::LikelihoodTopLeptonJets::BuildModelParticles() {
 }
 
 // ---------------------------------------------------------
-std::vector<double> KLFitter::LikelihoodTopLeptonJets::LogLikelihoodComponents(std::vector<double> parameters) {
+std::vector<double> LikelihoodTopLeptonJets::LogLikelihoodComponents(std::vector<double> parameters) {
   std::vector<double> vecci;
 
   // calculate 4-vectors
@@ -718,3 +704,4 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets::LogLikelihoodComponents(s
   // return log of likelihood
   return vecci;
 }
+}  // namespace KLFitter

--- a/src/LikelihoodTopLeptonJetsUDSep.cxx
+++ b/src/LikelihoodTopLeptonJetsUDSep.cxx
@@ -79,11 +79,11 @@ int KLFitter::LikelihoodTopLeptonJetsUDSep::DefineModelParticles() {
                                3,                                 // index of corresponding particle
                                KLFitter::Particles::kLightDown);  // light down type jet (truth)
 
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kElectron,
                                  "electron");
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     fParticlesModel->AddParticle(&dummy,
                                  KLFitter::Particles::kMuon,
                                  "muon");
@@ -136,14 +136,14 @@ int KLFitter::LikelihoodTopLeptonJetsUDSep::RemoveInvariantParticlePermutations(
   err *= (*fPermutations)->InvariantParticlePermutations(ptype, indexVector_Jets);
 
   // remove the permutation from the other lepton
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     ptype = KLFitter::Particles::kMuon;
     std::vector<int> indexVector_Muons;
     for (int iMuon = 0; iMuon < particles->NMuons(); iMuon++) {
       indexVector_Muons.push_back(iMuon);
     }
     err *= (*fPermutations)->InvariantParticlePermutations(ptype, indexVector_Muons);
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     ptype = KLFitter::Particles::kElectron;
     std::vector<int> indexVector_Electrons;
     for (int iElectron = 0; iElectron < particles->NElectrons(); iElectron++) {

--- a/src/LikelihoodTopLeptonJetsUDSep.cxx
+++ b/src/LikelihoodTopLeptonJetsUDSep.cxx
@@ -37,7 +37,7 @@ namespace KLFitter {
 // ---------------------------------------------------------
 LikelihoodTopLeptonJetsUDSep::LikelihoodTopLeptonJetsUDSep()
   : LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
-  , fLJetSeparationMethod(LikelihoodTopLeptonJetsUDSep::kNone) {
+  , m_ljet_separation_method(LikelihoodTopLeptonJetsUDSep::kNone) {
   // define model particles
   this->DefineModelParticles();
 
@@ -148,7 +148,7 @@ double LikelihoodTopLeptonJetsUDSep::LogEventProbability() {
     if (logprobbtag <= -1e99) return -1e99;
     logprob += logprobbtag;
   }
-  if (fLJetSeparationMethod != kNone) {
+  if (m_ljet_separation_method != kNone) {
     double logprobljetweight = LogEventProbabilityLJetReweight();
     if (logprobljetweight <= -1e99) return -1e99;
     logprob += logprobljetweight;
@@ -166,10 +166,10 @@ double LikelihoodTopLeptonJetsUDSep::LogEventProbability() {
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight() {
   double logprob = 0;
-  switch (fLJetSeparationMethod) {
+  switch (m_ljet_separation_method) {
   case kPermReweight:
 
-    if (!(fUpJetPtHisto && fDownJetPtHisto&& fBJetPtHisto && fUpJetTagWeightHisto && fDownJetTagWeightHisto && fBJetTagWeightHisto)) {
+    if (!(m_up_jet_pt_histo && m_down_jet_pt_histo&& m_bjet_pt_histo && m_up_jet_tag_weight_histo && m_down_jet_tag_weight_histo && m_bjet_tag_weight_histo)) {
       std::cout <<  " KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight() : Histograms were not set properly! " << std::endl;
       return -1e99;
     }
@@ -204,7 +204,7 @@ double LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight() {
     break;
 
   case kPermReweight2D:
-    if (!(fUpJet2DWeightHisto && fDownJet2DWeightHisto && fBJet2DWeightHisto)) {
+    if (!(m_up_jet_2d_weight_histo && m_down_jet_2d_weight_histo && m_bjet_2d_weight_histo)) {
       std::cout <<  " KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight() : 2D Histograms were not set properly! " << std::endl;
       return -1e99;
     }
@@ -302,47 +302,47 @@ double LikelihoodTopLeptonJetsUDSep::LogEventProbabilityBTag() {
 
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::UpJetPt(double pt) {
-  return fUpJetPtHisto->GetBinContent(fUpJetPtHisto->GetXaxis()->FindBin(pt));
+  return m_up_jet_pt_histo->GetBinContent(m_up_jet_pt_histo->GetXaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::DownJetPt(double pt) {
-  return fDownJetPtHisto->GetBinContent(fDownJetPtHisto->GetXaxis()->FindBin(pt));
+  return m_down_jet_pt_histo->GetBinContent(m_down_jet_pt_histo->GetXaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::BJetPt(double pt) {
-  return fBJetPtHisto->GetBinContent(fBJetPtHisto->GetXaxis()->FindBin(pt));
+  return m_bjet_pt_histo->GetBinContent(m_bjet_pt_histo->GetXaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::UpJetTagWeight(double tagweight) {
-  return fUpJetTagWeightHisto->GetBinContent(fUpJetTagWeightHisto->GetXaxis()->FindBin(tagweight));
+  return m_up_jet_tag_weight_histo->GetBinContent(m_up_jet_tag_weight_histo->GetXaxis()->FindBin(tagweight));
 }
 
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::DownJetTagWeight(double tagweight) {
-  return fDownJetTagWeightHisto->GetBinContent(fDownJetTagWeightHisto->GetXaxis()->FindBin(tagweight));
+  return m_down_jet_tag_weight_histo->GetBinContent(m_down_jet_tag_weight_histo->GetXaxis()->FindBin(tagweight));
 }
 
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::BJetTagWeight(double tagweight) {
-  return fBJetTagWeightHisto->GetBinContent(fBJetTagWeightHisto->GetXaxis()->FindBin(tagweight));
+  return m_bjet_tag_weight_histo->GetBinContent(m_bjet_tag_weight_histo->GetXaxis()->FindBin(tagweight));
 }
 
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::UpJetProb(double tagweight, double pt) {
-  return fUpJet2DWeightHisto->GetBinContent(fUpJet2DWeightHisto->GetXaxis()->FindBin(tagweight), fUpJet2DWeightHisto->GetYaxis()->FindBin(pt));
+  return m_up_jet_2d_weight_histo->GetBinContent(m_up_jet_2d_weight_histo->GetXaxis()->FindBin(tagweight), m_up_jet_2d_weight_histo->GetYaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::DownJetProb(double tagweight, double pt) {
-  return fDownJet2DWeightHisto->GetBinContent(fDownJet2DWeightHisto->GetXaxis()->FindBin(tagweight), fDownJet2DWeightHisto->GetYaxis()->FindBin(pt));
+  return m_down_jet_2d_weight_histo->GetBinContent(m_down_jet_2d_weight_histo->GetXaxis()->FindBin(tagweight), m_down_jet_2d_weight_histo->GetYaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::BJetProb(double tagweight, double pt) {
-  return fBJet2DWeightHisto->GetBinContent(fBJet2DWeightHisto->GetXaxis()->FindBin(tagweight), fBJet2DWeightHisto->GetYaxis()->FindBin(pt));
+  return m_bjet_2d_weight_histo->GetBinContent(m_bjet_2d_weight_histo->GetXaxis()->FindBin(tagweight), m_bjet_2d_weight_histo->GetYaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------

--- a/src/LikelihoodTopLeptonJetsUDSep.cxx
+++ b/src/LikelihoodTopLeptonJetsUDSep.cxx
@@ -33,10 +33,11 @@
 #include "TH2F.h"
 #include "TLorentzVector.h"
 
+namespace KLFitter {
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJetsUDSep::LikelihoodTopLeptonJetsUDSep()
-  : KLFitter::LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
-  , fLJetSeparationMethod(KLFitter::LikelihoodTopLeptonJetsUDSep::kNone) {
+LikelihoodTopLeptonJetsUDSep::LikelihoodTopLeptonJetsUDSep()
+  : LikelihoodTopLeptonJets::LikelihoodTopLeptonJets()
+  , fLJetSeparationMethod(LikelihoodTopLeptonJetsUDSep::kNone) {
   // define model particles
   this->DefineModelParticles();
 
@@ -45,90 +46,73 @@ KLFitter::LikelihoodTopLeptonJetsUDSep::LikelihoodTopLeptonJetsUDSep()
   }
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJetsUDSep::~LikelihoodTopLeptonJetsUDSep() = default;
+LikelihoodTopLeptonJetsUDSep::~LikelihoodTopLeptonJetsUDSep() = default;
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJetsUDSep::DefineModelParticles() {
+int LikelihoodTopLeptonJetsUDSep::DefineModelParticles() {
   // create the particles of the model
-  fParticlesModel.reset(new KLFitter::Particles{});
+  fParticlesModel.reset(new Particles{});
 
   // add model particles
-  // create dummy TLorentzVector
-  TLorentzVector dummy{0, 0, 0, 0};  // 4-vector
+  TLorentzVector dummy{0, 0, 0, 0};
   fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,      // type
-                               "hadronic b quark",                // name
-                               0,                                 // index of corresponding particle
-                               KLFitter::Particles::kB);          // b jet (truth)
+                               Particles::kParton,  // type
+                               "hadronic b quark",  // name
+                               0,                   // index of corresponding particle
+                               Particles::kB);      // b jet (truth)
 
   fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
+                               Particles::kParton,
                                "leptonic b quark",
-                               1,                                 // index of corresponding particle
-                               KLFitter::Particles::kB);          // b jet (truth)
+                               1,                   // index of corresponding particle
+                               Particles::kB);      // b jet (truth)
 
   fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
+                               Particles::kParton,
                                "light up type quark",
-                               2,                                 // index of corresponding particle
-                               KLFitter::Particles::kLightUp);    // light up type jet (truth)
+                               2,                      // index of corresponding particle
+                               Particles::kLightUp);   // light up type jet (truth)
 
   fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
+                               Particles::kParton,
                                "light down type quark",
-                               3,                                 // index of corresponding particle
-                               KLFitter::Particles::kLightDown);  // light down type jet (truth)
+                               3,                        // index of corresponding particle
+                               Particles::kLightDown);   // light down type jet (truth)
 
   if (m_lepton_type == kElectron) {
-    fParticlesModel->AddParticle(&dummy,
-                                 KLFitter::Particles::kElectron,
-                                 "electron");
+    fParticlesModel->AddParticle(&dummy, Particles::kElectron, "electron");
   } else if (m_lepton_type == kMuon) {
-    fParticlesModel->AddParticle(&dummy,
-                                 KLFitter::Particles::kMuon,
-                                 "muon");
+    fParticlesModel->AddParticle(&dummy, Particles::kMuon, "muon");
   }
 
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kNeutrino,
-                               "neutrino");
+  fParticlesModel->AddParticle(&dummy, Particles::kNeutrino, "neutrino");
 
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kBoson,
-                               "hadronic W");
+  fParticlesModel->AddParticle(&dummy, Particles::kBoson, "hadronic W");
+  fParticlesModel->AddParticle(&dummy, Particles::kBoson, "leptonic W");
 
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kBoson,
-                               "leptonic W");
-
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
-                               "hadronic top");
-
-  fParticlesModel->AddParticle(&dummy,
-                               KLFitter::Particles::kParton,
-                               "leptonic top");
+  fParticlesModel->AddParticle(&dummy, Particles::kParton, "hadronic top");
+  fParticlesModel->AddParticle(&dummy, Particles::kParton, "leptonic top");
 
   // no error
   return 1;
 }
 
 // ---------------------------------------------------------
-void KLFitter::LikelihoodTopLeptonJetsUDSep::DefineParameters() {
+void LikelihoodTopLeptonJetsUDSep::DefineParameters() {
   // rename light quark parameters
   this->GetParameter("energy light quark 1")->SetName("energy light up type quark");
   this->GetParameter("energy light quark 2")->SetName("energy light down type quark");
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJetsUDSep::RemoveInvariantParticlePermutations() {
+int LikelihoodTopLeptonJetsUDSep::RemoveInvariantParticlePermutations() {
   // error code
   int err = 1;
 
-  KLFitter::Particles::ParticleType ptype = KLFitter::Particles::kParton;
+  Particles::ParticleType ptype = Particles::kParton;
   std::vector<int> indexVector_Jets;
-  // remove invariant jet permutations of notevent jets
-  KLFitter::Particles* particles = (*fPermutations)->Particles();
+  // remove invariant jet permutations of all jets not considered
+  Particles* particles = (*fPermutations)->Particles();
   indexVector_Jets.clear();
   for (int iPartons = 4; iPartons < particles->NPartons(); iPartons++) {
     indexVector_Jets.push_back(iPartons);
@@ -137,14 +121,14 @@ int KLFitter::LikelihoodTopLeptonJetsUDSep::RemoveInvariantParticlePermutations(
 
   // remove the permutation from the other lepton
   if (m_lepton_type == kElectron) {
-    ptype = KLFitter::Particles::kMuon;
+    ptype = Particles::kMuon;
     std::vector<int> indexVector_Muons;
     for (int iMuon = 0; iMuon < particles->NMuons(); iMuon++) {
       indexVector_Muons.push_back(iMuon);
     }
     err *= (*fPermutations)->InvariantParticlePermutations(ptype, indexVector_Muons);
   } else if (m_lepton_type == kMuon) {
-    ptype = KLFitter::Particles::kElectron;
+    ptype = Particles::kElectron;
     std::vector<int> indexVector_Electrons;
     for (int iElectron = 0; iElectron < particles->NElectrons(); iElectron++) {
       indexVector_Electrons.push_back(iElectron);
@@ -157,7 +141,7 @@ int KLFitter::LikelihoodTopLeptonJetsUDSep::RemoveInvariantParticlePermutations(
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbability() {
+double LikelihoodTopLeptonJetsUDSep::LogEventProbability() {
   double logprob = 0;
   if (fBTagMethod != kNotag) {
     double logprobbtag = LogEventProbabilityBTag();
@@ -180,8 +164,7 @@ double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbability() {
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight() {
-  //    std::cout <<  " KDEBUG! Extraweight " << std::endl;
+double LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight() {
   double logprob = 0;
   switch (fLJetSeparationMethod) {
   case kPermReweight:
@@ -203,16 +186,16 @@ double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight()
         std::cout <<  " KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight() : bTag weight for particle was not set ! " << std::endl;
         return -1e99;
       }
-      KLFitter::Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(i);
-      if (trueFlavor == KLFitter::Particles::kB) {
+      Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(i);
+      if (trueFlavor == Particles::kB) {
         logprob += log(BJetPt((*fParticlesPermuted)->Parton(index)->Pt()));
         logprob += log(BJetTagWeight((*fParticlesPermuted)->BTagWeight(index)));
       }
-      if (trueFlavor == KLFitter::Particles::kLightUp) {
+      if (trueFlavor == Particles::kLightUp) {
         logprob += log(UpJetPt((*fParticlesPermuted)->Parton(index)->Pt()));
         logprob += log(UpJetTagWeight((*fParticlesPermuted)->BTagWeight(index)));
       }
-      if (trueFlavor == KLFitter::Particles::kLightDown) {
+      if (trueFlavor == Particles::kLightDown) {
         logprob += log(DownJetPt((*fParticlesPermuted)->Parton(index)->Pt()));
         logprob += log(DownJetTagWeight((*fParticlesPermuted)->BTagWeight(index)));
       }
@@ -238,14 +221,14 @@ double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight()
         std::cout <<  " KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight() : bTag weight for particle was not set ! " << std::endl;
         return -1e99;
       }
-      KLFitter::Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(i);
-      if (trueFlavor == KLFitter::Particles::kB) {
+      Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(i);
+      if (trueFlavor == Particles::kB) {
         logprob += log(BJetProb((*fParticlesPermuted)->BTagWeight(index), (*fParticlesPermuted)->Parton(index)->Pt()));
       }
-      if (trueFlavor == KLFitter::Particles::kLightUp) {
+      if (trueFlavor == Particles::kLightUp) {
         logprob += log(UpJetProb((*fParticlesPermuted)->BTagWeight(index), (*fParticlesPermuted)->Parton(index)->Pt()));
       }
-      if (trueFlavor == KLFitter::Particles::kLightDown) {
+      if (trueFlavor == Particles::kLightDown) {
         logprob += log(DownJetProb((*fParticlesPermuted)->BTagWeight(index), (*fParticlesPermuted)->Parton(index)->Pt()));
       }
     }
@@ -259,7 +242,7 @@ double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityLJetReweight()
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityBTag() {
+double LikelihoodTopLeptonJetsUDSep::LogEventProbabilityBTag() {
   double logprob = 0;
 
   double probbtag = 1;
@@ -273,9 +256,9 @@ double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityBTag() {
       if (index < 0)
         continue;
 
-      KLFitter::Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(i);
+      Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(i);
       bool isBTagged = fParticlesModel->IsBTagged(i);
-      if (((trueFlavor == KLFitter::Particles::kLightUp) || (trueFlavor == KLFitter::Particles::kLightDown)) && isBTagged == true)
+      if (((trueFlavor == Particles::kLightUp) || (trueFlavor == Particles::kLightDown)) && isBTagged == true)
         probbtag = 0.;
     }
 
@@ -291,25 +274,25 @@ double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityBTag() {
       if (index < 0)
         continue;
 
-      KLFitter::Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(i);
+      Particles::TrueFlavorType trueFlavor = fParticlesModel->TrueFlavor(i);
       bool isBTagged = fParticlesModel->IsBTagged(i);
       double efficiency = fParticlesModel->BTaggingEfficiency(i);
       double rejection = fParticlesModel->BTaggingRejection(i);
       if (rejection < 0 || efficiency < 0) {
-        std::cout <<  " KLFitter::LikelihoodBase::LogEventProbability() : Your working points are not set properly! Returning 0 probability " << std::endl;
+        std::cout <<  " KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbability() : Your working points are not set properly! Returning 0 probability " << std::endl;
         return -1e99;
       }
 
-      if (((trueFlavor == KLFitter::Particles::kLightUp) || (trueFlavor == KLFitter::Particles::kLightDown)) && isBTagged) {
+      if (((trueFlavor == Particles::kLightUp) || (trueFlavor == Particles::kLightDown)) && isBTagged) {
         logprob += log(1./rejection);
-      } else if (((trueFlavor == KLFitter::Particles::kLightUp) || (trueFlavor == KLFitter::Particles::kLightDown)) && !isBTagged) {
+      } else if (((trueFlavor == Particles::kLightUp) || (trueFlavor == Particles::kLightDown)) && !isBTagged) {
         logprob += log(1 - 1./rejection);
-      } else if (trueFlavor == KLFitter::Particles::kB && isBTagged) {
+      } else if (trueFlavor == Particles::kB && isBTagged) {
         logprob += log(efficiency);
-      } else if (trueFlavor == KLFitter::Particles::kB && !isBTagged) {
+      } else if (trueFlavor == Particles::kB && !isBTagged) {
         logprob += log(1 - efficiency);
       } else {
-        std::cout << " KLFitter::LikelihoodBase::LogEventProbability() : b-tagging association failed! " << std::endl;
+        std::cout << " KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbability() : b-tagging association failed! " << std::endl;
       }
     }
   }
@@ -318,68 +301,68 @@ double KLFitter::LikelihoodTopLeptonJetsUDSep::LogEventProbabilityBTag() {
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::UpJetPt(double pt) {
+double LikelihoodTopLeptonJetsUDSep::UpJetPt(double pt) {
   return fUpJetPtHisto->GetBinContent(fUpJetPtHisto->GetXaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::DownJetPt(double pt) {
+double LikelihoodTopLeptonJetsUDSep::DownJetPt(double pt) {
   return fDownJetPtHisto->GetBinContent(fDownJetPtHisto->GetXaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::BJetPt(double pt) {
+double LikelihoodTopLeptonJetsUDSep::BJetPt(double pt) {
   return fBJetPtHisto->GetBinContent(fBJetPtHisto->GetXaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::UpJetTagWeight(double tagweight) {
+double LikelihoodTopLeptonJetsUDSep::UpJetTagWeight(double tagweight) {
   return fUpJetTagWeightHisto->GetBinContent(fUpJetTagWeightHisto->GetXaxis()->FindBin(tagweight));
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::DownJetTagWeight(double tagweight) {
+double LikelihoodTopLeptonJetsUDSep::DownJetTagWeight(double tagweight) {
   return fDownJetTagWeightHisto->GetBinContent(fDownJetTagWeightHisto->GetXaxis()->FindBin(tagweight));
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::BJetTagWeight(double tagweight) {
+double LikelihoodTopLeptonJetsUDSep::BJetTagWeight(double tagweight) {
   return fBJetTagWeightHisto->GetBinContent(fBJetTagWeightHisto->GetXaxis()->FindBin(tagweight));
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::UpJetProb(double tagweight, double pt) {
+double LikelihoodTopLeptonJetsUDSep::UpJetProb(double tagweight, double pt) {
   return fUpJet2DWeightHisto->GetBinContent(fUpJet2DWeightHisto->GetXaxis()->FindBin(tagweight), fUpJet2DWeightHisto->GetYaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::DownJetProb(double tagweight, double pt) {
+double LikelihoodTopLeptonJetsUDSep::DownJetProb(double tagweight, double pt) {
   return fDownJet2DWeightHisto->GetBinContent(fDownJet2DWeightHisto->GetXaxis()->FindBin(tagweight), fDownJet2DWeightHisto->GetYaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJetsUDSep::BJetProb(double tagweight, double pt) {
+double LikelihoodTopLeptonJetsUDSep::BJetProb(double tagweight, double pt) {
   return fBJet2DWeightHisto->GetBinContent(fBJet2DWeightHisto->GetXaxis()->FindBin(tagweight), fBJet2DWeightHisto->GetYaxis()->FindBin(pt));
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJetsUDSep::LHInvariantPermutationPartner(int iperm, int nperms, int *switchpar1, int *switchpar2) {
+int LikelihoodTopLeptonJetsUDSep::LHInvariantPermutationPartner(int iperm, int nperms, int *switchpar1, int *switchpar2) {
   int partnerid = -1;
-  int cache = iperm%6;
+  int cache = iperm % 6;
   switch (nperms) {
   case 24:
-    if ((iperm)%2) {
-      partnerid = (iperm -1);
+    if (iperm % 2) {
+      partnerid = iperm - 1;
     } else {
-      partnerid = (iperm+1);
+      partnerid = iperm + 1;
     }
     break;
 
   case 120:
     if (cache > 2) {
-      partnerid = (iperm -3);
+      partnerid = iperm - 3;
     } else {
-      partnerid = (iperm+3);
+      partnerid = iperm + 3;
     }
     break;
 
@@ -389,3 +372,4 @@ int KLFitter::LikelihoodTopLeptonJetsUDSep::LHInvariantPermutationPartner(int ip
   *switchpar2 = 3;
   return partnerid;
 }
+}  // namespace KLFitter

--- a/src/LikelihoodTopLeptonJetsUDSep.cxx
+++ b/src/LikelihoodTopLeptonJetsUDSep.cxx
@@ -143,6 +143,7 @@ int LikelihoodTopLeptonJetsUDSep::RemoveInvariantParticlePermutations() {
 // ---------------------------------------------------------
 double LikelihoodTopLeptonJetsUDSep::LogEventProbability() {
   double logprob = 0;
+
   if (fBTagMethod != kNotag) {
     double logprobbtag = LogEventProbabilityBTag();
     if (logprobbtag <= -1e99) return -1e99;
@@ -160,6 +161,7 @@ double LikelihoodTopLeptonJetsUDSep::LogEventProbability() {
   } else {
     logprob += LogLikelihood(GetBestFitParameters());
   }
+
   return logprob;
 }
 
@@ -268,6 +270,8 @@ double LikelihoodTopLeptonJetsUDSep::LogEventProbabilityBTag() {
       return -1e99;
     }
   } else if (fBTagMethod == kWorkingPoint) {
+    // loop over all model particles.  calculate the overall b-tagging
+    // probability which is the product of all probabilities.
     for (int i = 0; i < fParticlesModel->NPartons(); ++i) {
       // get index of corresponding measured particle.
       int index = fParticlesModel->JetIndex(i);

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -44,53 +44,47 @@ int LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
   double m = fPhysicsConstants.MassBottom();
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
-  double Emin = std::max(m, E - nsigmas_jet* sqrt(E));
-  double Emax  = E + nsigmas_jet* sqrt(E);
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
+  double Emin = std::max(m, E - nsigmas_jet * sqrt(E));
+  double Emax = E + nsigmas_jet * sqrt(E);
   SetParameterRange(parBhadE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
   m = fPhysicsConstants.MassBottom();
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
-  Emin = std::max(m, E - nsigmas_jet* sqrt(E));
-  Emax  = E + nsigmas_jet* sqrt(E);
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
+  Emin = std::max(m, E - nsigmas_jet * sqrt(E));
+  Emax = E + nsigmas_jet * sqrt(E);
   SetParameterRange(parBlepE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(2)->E();
   m = 0.001;
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(2)->M());
-  Emin = std::max(m, E - nsigmas_jet* sqrt(E));
-  Emax  = E + nsigmas_jet* sqrt(E);
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(2)->M());
+  Emin = std::max(m, E - nsigmas_jet * sqrt(E));
+  Emax = E + nsigmas_jet * sqrt(E);
   SetParameterRange(parLQ1E, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(3)->E();
   m = 0.001;
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(3)->M());
-  Emin = std::max(m, E - nsigmas_jet* sqrt(E));
-  Emax  = E + nsigmas_jet* sqrt(E);
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(3)->M());
+  Emin = std::max(m, E - nsigmas_jet * sqrt(E));
+  Emax = E + nsigmas_jet * sqrt(E);
   SetParameterRange(parLQ2E, Emin, Emax);
 
   if (fTypeLepton == kElectron) {
     E = (*fParticlesPermuted)->Electron(0)->E();
-    Emin = std::max(0.001, E - nsigmas_lepton* sqrt(E));
-    Emax  = E + nsigmas_lepton* sqrt(E);
+    Emin = std::max(0.001, E - nsigmas_lepton * sqrt(E));
+    Emax = E + nsigmas_lepton * sqrt(E);
   } else if (fTypeLepton == kMuon) {
     E = (*fParticlesPermuted)->Muon(0)->E();
     double sintheta = sin((*fParticlesPermuted)->Muon(0)->Theta());
-    double sigrange = nsigmas_lepton* (E*E*sintheta);
-    Emin = std::max(0.001, E -sigrange);
-    Emax = E +sigrange;
+    double sigrange = nsigmas_lepton * (E * E * sintheta);
+    Emin = std::max(0.001, E - sigrange);
+    Emax = E + sigrange;
   }
   SetParameterRange(parLepE, Emin, Emax);
 
-  // note: this is hard-coded in the momement
-
-  SetParameterRange(parNuPx, ETmiss_x-100.0, ETmiss_x+100);
-  SetParameterRange(parNuPy, ETmiss_y-100.0, ETmiss_y+100);
+  SetParameterRange(parNuPx, ETmiss_x - 100.0, ETmiss_x + 100);
+  SetParameterRange(parNuPy, ETmiss_y - 100.0, ETmiss_y + 100);
 
   if (fFlagTopMassFixed)
     SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
@@ -127,7 +121,7 @@ double LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vector<double> 
   if (fTypeLepton == kElectron) {
     logprob += log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp));
   } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
+    logprob += log(fResLepton->p(lep_fit_e * lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
   }
   if (!TFgoodTmp) fTFgood = false;
 
@@ -141,9 +135,6 @@ double LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vector<double> 
   // physics constants
   double massW = fPhysicsConstants.MassW();
   double gammaW = fPhysicsConstants.GammaW();
-  // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
-  // (this will also set the correct width for the top)
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
@@ -163,11 +154,11 @@ double LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vector<double> 
   // create 4-vector for leptonically decaying W boson, charge lepton and corresponding b quark
   TLorentzVector Wlep(wlep_fit_px, wlep_fit_py, wlep_fit_pz, wlep_fit_e);
   TLorentzVector Whad(whad_fit_px, whad_fit_py, whad_fit_pz, whad_fit_e);
-  TLorentzVector lep(lep_fit_px,  lep_fit_py,  lep_fit_pz,  lep_fit_e);
+  TLorentzVector lep(lep_fit_px,   lep_fit_py,  lep_fit_pz,  lep_fit_e);
   TLorentzVector blep(blep_fit_px, blep_fit_py, blep_fit_pz, blep_fit_e);
   TLorentzVector bhad(bhad_fit_px, bhad_fit_py, bhad_fit_pz, bhad_fit_e);
-  TLorentzVector lq1(lq1_fit_px, lq1_fit_py, lq1_fit_pz, lq1_fit_e);
-  TLorentzVector lq2(lq2_fit_px, lq2_fit_py, lq2_fit_pz, lq2_fit_e);
+  TLorentzVector lq1(lq1_fit_px,   lq1_fit_py,  lq1_fit_pz,  lq1_fit_e);
+  TLorentzVector lq2(lq2_fit_px,   lq2_fit_py,  lq2_fit_pz,  lq2_fit_e);
 
   // get boost vectors
   TVector3  Wlep_bo(0.0, 0.0, 0.0);
@@ -207,12 +198,12 @@ double LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vector<double> 
   double FR = 0.0017;
 
   // calculate probability
-  double p_angular_lep = (3./4.*(1.-cos_theta*cos_theta) * F0 +
-                           3./8.*(1.-cos_theta)*(1.-cos_theta) * FL +
-                           3./8.*(1.+cos_theta)*(1.+cos_theta) * FR);
+  double p_angular_lep = (3. / 4. * (1. - cos_theta * cos_theta) * F0 +
+                          3. / 8. * (1. - cos_theta) * (1. - cos_theta) * FL +
+                          3. / 8. * (1. + cos_theta) * (1. + cos_theta) * FR);
 
-  double p_angular_had = (3./4.*(1.-cos_theta_had*cos_theta_had) * F0 +
-                           3./8.*(1.+cos_theta_had*cos_theta_had) * (FL + FR));
+  double p_angular_had = (3. / 4. * (1. - cos_theta_had * cos_theta_had) * F0 +
+                          3. / 8. * (1. + cos_theta_had * cos_theta_had) * (FL + FR));
 
   logprob += log(p_angular_lep);
   logprob += log(p_angular_had);

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -23,22 +23,21 @@
 #include <iostream>
 
 #include "BAT/BCMath.h"
-#include "BAT/BCParameter.h"
-#include "KLFitter/DetectorBase.h"
 #include "KLFitter/Particles.h"
 #include "KLFitter/Permutations.h"
 #include "KLFitter/PhysicsConstants.h"
 #include "KLFitter/ResolutionBase.h"
 #include "TLorentzVector.h"
 
+namespace KLFitter {
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets_Angular::LikelihoodTopLeptonJets_Angular() = default;
+LikelihoodTopLeptonJets_Angular::LikelihoodTopLeptonJets_Angular() = default;
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets_Angular::~LikelihoodTopLeptonJets_Angular() = default;
+LikelihoodTopLeptonJets_Angular::~LikelihoodTopLeptonJets_Angular() = default;
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
+int LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet = 7.0;
   double nsigmas_lepton = 2.0;
@@ -101,7 +100,7 @@ int KLFitter::LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vector<double> & parameters) {
+double LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vector<double> & parameters) {
   // calculate 4-vectors
   CalculateLorentzVectors(parameters);
 
@@ -221,3 +220,4 @@ double KLFitter::LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vecto
   // return log of likelihood
   return logprob;
 }
+}  // namespace KLFitter

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -70,11 +70,11 @@ int LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
   Emax = E + nsigmas_jet * sqrt(E);
   SetParameterRange(parLQ2E, Emin, Emax);
 
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     E = (*fParticlesPermuted)->Electron(0)->E();
     Emin = std::max(0.001, E - nsigmas_lepton * sqrt(E));
     Emax = E + nsigmas_lepton * sqrt(E);
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     E = (*fParticlesPermuted)->Muon(0)->E();
     double sintheta = sin((*fParticlesPermuted)->Muon(0)->Theta());
     double sigrange = nsigmas_lepton * (E * E * sintheta);
@@ -83,10 +83,10 @@ int LikelihoodTopLeptonJets_Angular::AdjustParameterRanges() {
   }
   SetParameterRange(parLepE, Emin, Emax);
 
-  SetParameterRange(parNuPx, ETmiss_x - 100.0, ETmiss_x + 100);
-  SetParameterRange(parNuPy, ETmiss_y - 100.0, ETmiss_y + 100);
+  SetParameterRange(parNuPx, m_et_miss_x - 100.0, m_et_miss_x + 100);
+  SetParameterRange(parNuPy, m_et_miss_y - 100.0, m_et_miss_y + 100);
 
-  if (fFlagTopMassFixed)
+  if (m_flag_top_mass_fixed)
     SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
   // no error
@@ -105,31 +105,31 @@ double LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vector<double> 
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
-  if (fTypeLepton == kElectron) {
-    logprob += log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp));
-  } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLepton->p(lep_fit_e * lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
+  if (m_lepton_type == kElectron) {
+    logprob += log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp));
+  } else if (m_lepton_type == kMuon) {
+    logprob += log(m_res_lepton->p(m_lep_fit_e * m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp));
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));
+  logprob += log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));
+  logprob += log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum));
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -138,27 +138,27 @@ double LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vector<double> 
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
-  logprob += BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW);
+  logprob += BCMath::LogBreitWignerRel(m_whad_fit_m, massW, gammaW);
 
   // Breit-Wigner of leptonically decaying W-boson
-  logprob += BCMath::LogBreitWignerRel(wlep_fit_m, massW, gammaW);
+  logprob += BCMath::LogBreitWignerRel(m_wlep_fit_m, massW, gammaW);
 
   // Breit-Wigner of hadronically decaying top quark
-  logprob += BCMath::LogBreitWignerRel(thad_fit_m, parameters[parTopM], gammaTop);
+  logprob += BCMath::LogBreitWignerRel(m_thad_fit_m, parameters[parTopM], gammaTop);
 
   // Breit-Wigner of leptonically decaying top quark
-  logprob += BCMath::LogBreitWignerRel(tlep_fit_m, parameters[parTopM], gammaTop);
+  logprob += BCMath::LogBreitWignerRel(m_tlep_fit_m, parameters[parTopM], gammaTop);
 
   // angular information of leptonic decay
 
   // create 4-vector for leptonically decaying W boson, charge lepton and corresponding b quark
-  TLorentzVector Wlep(wlep_fit_px, wlep_fit_py, wlep_fit_pz, wlep_fit_e);
-  TLorentzVector Whad(whad_fit_px, whad_fit_py, whad_fit_pz, whad_fit_e);
-  TLorentzVector lep(lep_fit_px,   lep_fit_py,  lep_fit_pz,  lep_fit_e);
-  TLorentzVector blep(blep_fit_px, blep_fit_py, blep_fit_pz, blep_fit_e);
-  TLorentzVector bhad(bhad_fit_px, bhad_fit_py, bhad_fit_pz, bhad_fit_e);
-  TLorentzVector lq1(lq1_fit_px,   lq1_fit_py,  lq1_fit_pz,  lq1_fit_e);
-  TLorentzVector lq2(lq2_fit_px,   lq2_fit_py,  lq2_fit_pz,  lq2_fit_e);
+  TLorentzVector Wlep(m_wlep_fit_px, m_wlep_fit_py, m_wlep_fit_pz, m_wlep_fit_e);
+  TLorentzVector Whad(m_whad_fit_px, m_whad_fit_py, m_whad_fit_pz, m_whad_fit_e);
+  TLorentzVector lep(m_lep_fit_px,   m_lep_fit_py,  m_lep_fit_pz,  m_lep_fit_e);
+  TLorentzVector blep(m_blep_fit_px, m_blep_fit_py, m_blep_fit_pz, m_blep_fit_e);
+  TLorentzVector bhad(m_bhad_fit_px, m_bhad_fit_py, m_bhad_fit_pz, m_bhad_fit_e);
+  TLorentzVector lq1(m_lq1_fit_px,   m_lq1_fit_py,  m_lq1_fit_pz,  m_lq1_fit_e);
+  TLorentzVector lq2(m_lq2_fit_px,   m_lq2_fit_py,  m_lq2_fit_pz,  m_lq2_fit_e);
 
   // get boost vectors
   TVector3  Wlep_bo(0.0, 0.0, 0.0);

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -55,23 +55,23 @@ LikelihoodTopLeptonJets_JetAngles::~LikelihoodTopLeptonJets_JetAngles() = defaul
 // ---------------------------------------------------------
 void LikelihoodTopLeptonJets_JetAngles::DefineParameters() {
   // add parameters of model
-  AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
-  AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
-  AddParameter("energy light quark 1",    0.0, 1000.0);                              // parLQ1E
-  AddParameter("energy light quark 2",    0.0, 1000.0);                              // parLQ2E
-  AddParameter("energy lepton",           0.0, 1000.0);                              // parLepE
-  AddParameter("p_x neutrino",        -1000.0, 1000.0);                              // parNuPx
-  AddParameter("p_y neutrino",        -1000.0, 1000.0);                              // parNuPy
-  AddParameter("p_z neutrino",        -1000.0, 1000.0);                              // parNuPz
-  AddParameter("eta hadronic b",       -2.5, 2.5);                                   // parBhadEta
-  AddParameter("eta leptonic b",       -2.5, 2.5);                                   // parBlepEta
-  AddParameter("eta light quark 1",    -2.5, 2.5);                                   // parLQ1Eta
-  AddParameter("eta light quark 2",    -2.5, 2.5);                                   // parLQ2Eta
-  AddParameter("phi hadronic b",       -TMath::Pi(), TMath::Pi());                   // parBhadPhi
-  AddParameter("phi leptonic b",       -TMath::Pi(), TMath::Pi());                   // parBlepPhi
-  AddParameter("phi light quark 1",    -TMath::Pi(), TMath::Pi());                   // parLQ1Phi
-  AddParameter("phi light quark 2",    -TMath::Pi(), TMath::Pi());                   // parLQ2Phi
-  AddParameter("top mass",              100.0, 1000.0);                              // parTopM
+  AddParameter("energy hadronic b", fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
+  AddParameter("energy leptonic b", fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
+  AddParameter("energy light quark 1", 0.0, 1000.0);                          // parLQ1E
+  AddParameter("energy light quark 2", 0.0, 1000.0);                          // parLQ2E
+  AddParameter("energy lepton", 0.0, 1000.0);                                 // parLepE
+  AddParameter("p_x neutrino", -1000.0, 1000.0);                              // parNuPx
+  AddParameter("p_y neutrino", -1000.0, 1000.0);                              // parNuPy
+  AddParameter("p_z neutrino", -1000.0, 1000.0);                              // parNuPz
+  AddParameter("eta hadronic b", -2.5, 2.5);                                  // parBhadEta
+  AddParameter("eta leptonic b", -2.5, 2.5);                                  // parBlepEta
+  AddParameter("eta light quark 1", -2.5, 2.5);                               // parLQ1Eta
+  AddParameter("eta light quark 2", -2.5, 2.5);                               // parLQ2Eta
+  AddParameter("phi hadronic b", -TMath::Pi(), TMath::Pi());                  // parBhadPhi
+  AddParameter("phi leptonic b", -TMath::Pi(), TMath::Pi());                  // parBlepPhi
+  AddParameter("phi light quark 1", -TMath::Pi(), TMath::Pi());               // parLQ1Phi
+  AddParameter("phi light quark 2", -TMath::Pi(), TMath::Pi());               // parLQ2Phi
+  AddParameter("top mass", 100.0, 1000.0);                                    // parTopM
 }
 
 // ---------------------------------------------------------
@@ -89,28 +89,40 @@ int LikelihoodTopLeptonJets_JetAngles::CalculateLorentzVectors(std::vector <doub
   TLorentzVector v;
 
   // hadronic b quark
-  v.SetPtEtaPhiE(sqrt(parameters[parBhadE]*parameters[parBhadE]-bhad_meas_m*bhad_meas_m)/cosh(parameters[parBhadEta]), parameters[parBhadEta], parameters[parBhadPhi], parameters[parBhadE]);
+  v.SetPtEtaPhiE(sqrt(parameters[parBhadE] * parameters[parBhadE] - bhad_meas_m * bhad_meas_m) / cosh(parameters[parBhadEta]),
+                 parameters[parBhadEta],
+                 parameters[parBhadPhi],
+                 parameters[parBhadE]);
   bhad_fit_e = v.E();
   bhad_fit_px = v.Px();
   bhad_fit_py = v.Py();
   bhad_fit_pz = v.Pz();
 
   // leptonic b quark
-  v.SetPtEtaPhiE(sqrt(parameters[parBlepE]*parameters[parBlepE]-blep_meas_m*blep_meas_m)/cosh(parameters[parBlepEta]), parameters[parBlepEta], parameters[parBlepPhi], parameters[parBlepE]);
+  v.SetPtEtaPhiE(sqrt(parameters[parBlepE] * parameters[parBlepE] - blep_meas_m * blep_meas_m) / cosh(parameters[parBlepEta]),
+                 parameters[parBlepEta],
+                 parameters[parBlepPhi],
+                 parameters[parBlepE]);
   blep_fit_e = v.E();
   blep_fit_px = v.Px();
   blep_fit_py = v.Py();
   blep_fit_pz = v.Pz();
 
   // light quark 1
-  v.SetPtEtaPhiE(sqrt(parameters[parLQ1E]*parameters[parLQ1E]-lq1_meas_m*lq1_meas_m)/cosh(parameters[parLQ1Eta]), parameters[parLQ1Eta], parameters[parLQ1Phi], parameters[parLQ1E]);
+  v.SetPtEtaPhiE(sqrt(parameters[parLQ1E] * parameters[parLQ1E] - lq1_meas_m * lq1_meas_m) / cosh(parameters[parLQ1Eta]),
+                 parameters[parLQ1Eta],
+                 parameters[parLQ1Phi],
+                 parameters[parLQ1E]);
   lq1_fit_e = v.E();
   lq1_fit_px = v.Px();
   lq1_fit_py = v.Py();
   lq1_fit_pz = v.Pz();
 
   // light quark 2
-  v.SetPtEtaPhiE(sqrt(parameters[parLQ2E]*parameters[parLQ2E]-lq2_meas_m*lq2_meas_m)/cosh(parameters[parLQ2Eta]), parameters[parLQ2Eta], parameters[parLQ2Phi], parameters[parLQ2E]);
+  v.SetPtEtaPhiE(sqrt(parameters[parLQ2E] * parameters[parLQ2E] - lq2_meas_m * lq2_meas_m) / cosh(parameters[parLQ2Eta]),
+                 parameters[parLQ2Eta],
+                 parameters[parLQ2Phi],
+                 parameters[parLQ2E]);
   lq2_fit_e = v.E();
   lq2_fit_px = v.Px();
   lq2_fit_py = v.Py();
@@ -127,35 +139,35 @@ int LikelihoodTopLeptonJets_JetAngles::CalculateLorentzVectors(std::vector <doub
   nu_fit_px = parameters[parNuPx];
   nu_fit_py = parameters[parNuPy];
   nu_fit_pz = parameters[parNuPz];
-  nu_fit_e  = sqrt(nu_fit_px*nu_fit_px + nu_fit_py*nu_fit_py + nu_fit_pz*nu_fit_pz);
+  nu_fit_e  = sqrt(nu_fit_px * nu_fit_px + nu_fit_py * nu_fit_py + nu_fit_pz * nu_fit_pz);
 
   // hadronic W
-  whad_fit_e  = lq1_fit_e +lq2_fit_e;
-  whad_fit_px = lq1_fit_px+lq2_fit_px;
-  whad_fit_py = lq1_fit_py+lq2_fit_py;
-  whad_fit_pz = lq1_fit_pz+lq2_fit_pz;
-  whad_fit_m = sqrt(whad_fit_e*whad_fit_e - (whad_fit_px*whad_fit_px + whad_fit_py*whad_fit_py + whad_fit_pz*whad_fit_pz));
+  whad_fit_e  = lq1_fit_e + lq2_fit_e;
+  whad_fit_px = lq1_fit_px + lq2_fit_px;
+  whad_fit_py = lq1_fit_py + lq2_fit_py;
+  whad_fit_pz = lq1_fit_pz + lq2_fit_pz;
+  whad_fit_m = sqrt(whad_fit_e * whad_fit_e - (whad_fit_px * whad_fit_px + whad_fit_py * whad_fit_py + whad_fit_pz * whad_fit_pz));
 
   // leptonic W
-  wlep_fit_e  = lep_fit_e +nu_fit_e;
-  wlep_fit_px = lep_fit_px+nu_fit_px;
-  wlep_fit_py = lep_fit_py+nu_fit_py;
-  wlep_fit_pz = lep_fit_pz+nu_fit_pz;
-  wlep_fit_m = sqrt(wlep_fit_e*wlep_fit_e - (wlep_fit_px*wlep_fit_px + wlep_fit_py*wlep_fit_py + wlep_fit_pz*wlep_fit_pz));
+  wlep_fit_e  = lep_fit_e + nu_fit_e;
+  wlep_fit_px = lep_fit_px + nu_fit_px;
+  wlep_fit_py = lep_fit_py + nu_fit_py;
+  wlep_fit_pz = lep_fit_pz + nu_fit_pz;
+  wlep_fit_m = sqrt(wlep_fit_e * wlep_fit_e - (wlep_fit_px * wlep_fit_px + wlep_fit_py * wlep_fit_py + wlep_fit_pz * wlep_fit_pz));
 
   // hadronic top
-  thad_fit_e = whad_fit_e+bhad_fit_e;
-  thad_fit_px = whad_fit_px+bhad_fit_px;
-  thad_fit_py = whad_fit_py+bhad_fit_py;
-  thad_fit_pz = whad_fit_pz+bhad_fit_pz;
-  thad_fit_m = sqrt(thad_fit_e*thad_fit_e - (thad_fit_px*thad_fit_px + thad_fit_py*thad_fit_py + thad_fit_pz*thad_fit_pz));
+  thad_fit_e = whad_fit_e + bhad_fit_e;
+  thad_fit_px = whad_fit_px + bhad_fit_px;
+  thad_fit_py = whad_fit_py + bhad_fit_py;
+  thad_fit_pz = whad_fit_pz + bhad_fit_pz;
+  thad_fit_m = sqrt(thad_fit_e * thad_fit_e - (thad_fit_px * thad_fit_px + thad_fit_py * thad_fit_py + thad_fit_pz * thad_fit_pz));
 
   // leptonic top
-  tlep_fit_e = wlep_fit_e+blep_fit_e;
-  tlep_fit_px = wlep_fit_px+blep_fit_px;
-  tlep_fit_py = wlep_fit_py+blep_fit_py;
-  tlep_fit_pz = wlep_fit_pz+blep_fit_pz;
-  tlep_fit_m = sqrt(tlep_fit_e*tlep_fit_e - (tlep_fit_px*tlep_fit_px + tlep_fit_py*tlep_fit_py + tlep_fit_pz*tlep_fit_pz));
+  tlep_fit_e = wlep_fit_e + blep_fit_e;
+  tlep_fit_px = wlep_fit_px + blep_fit_px;
+  tlep_fit_py = wlep_fit_py + blep_fit_py;
+  tlep_fit_pz = wlep_fit_pz + blep_fit_pz;
+  tlep_fit_m = sqrt(tlep_fit_e * tlep_fit_e - (tlep_fit_px * tlep_fit_px + tlep_fit_py * tlep_fit_py + tlep_fit_pz * tlep_fit_pz));
 
   // no error
   return 1;
@@ -170,45 +182,41 @@ int LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
   double m = fPhysicsConstants.MassBottom();
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
   double sigma = fFlagGetParSigmasFromTFs ? fResEnergyBhad->GetSigma(E) : sqrt(E);
   double Emin = std::max(m, E - nsigmas_jet* sigma);
-  double Emax  = E + nsigmas_jet* sigma;
+  double Emax = E + nsigmas_jet* sigma;
   SetParameterRange(parBhadE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(1)->E();
   m = fPhysicsConstants.MassBottom();
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyBlep->GetSigma(E) : sqrt(E);
   Emin = std::max(m, E - nsigmas_jet* sigma);
-  Emax  = E + nsigmas_jet* sigma;
+  Emax = E + nsigmas_jet* sigma;
   SetParameterRange(parBlepE, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(2)->E();
   m = 0.001;
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(2)->M());
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(2)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyLQ1->GetSigma(E) : sqrt(E);
   Emin = std::max(m, E - nsigmas_jet* sigma);
-  Emax  = E + nsigmas_jet* sigma;
+  Emax = E + nsigmas_jet* sigma;
   SetParameterRange(parLQ1E, Emin, Emax);
 
   E = (*fParticlesPermuted)->Parton(3)->E();
   m = 0.001;
-  if (fFlagUseJetMass)
-    m = std::max(0.0, (*fParticlesPermuted)->Parton(3)->M());
+  if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(3)->M());
   sigma = fFlagGetParSigmasFromTFs ? fResEnergyLQ2->GetSigma(E) : sqrt(E);
   Emin = std::max(m, E - nsigmas_jet* sigma);
-  Emax  = E + nsigmas_jet* sigma;
+  Emax = E + nsigmas_jet* sigma;
   SetParameterRange(parLQ2E, Emin, Emax);
 
   if (fTypeLepton == kElectron) {
     E = (*fParticlesPermuted)->Electron(0)->E();
     sigma = fFlagGetParSigmasFromTFs ? fResLepton->GetSigma(E) : sqrt(E);
     Emin = std::max(0.001, E - nsigmas_lepton* sigma);
-    Emax  = E + nsigmas_lepton* sigma;
+    Emax = E + nsigmas_lepton* sigma;
   } else if (fTypeLepton == kMuon) {
     E = (*fParticlesPermuted)->Muon(0)->E();
     double sintheta = sin((*fParticlesPermuted)->Muon(0)->Theta());
@@ -219,12 +227,10 @@ int LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   }
   SetParameterRange(parLepE, Emin, Emax);
 
-  // note: this is hard-coded in the momement
-
   sigma = fFlagGetParSigmasFromTFs ? fResMET->GetSigma(SumET) : 100;
-  double sigrange = nsigmas_met*sigma;
-  SetParameterRange(parNuPx, ETmiss_x-sigrange, ETmiss_x+sigrange);
-  SetParameterRange(parNuPy, ETmiss_y-sigrange, ETmiss_y+sigrange);
+  double sigrange = nsigmas_met * sigma;
+  SetParameterRange(parNuPx, ETmiss_x - sigrange, ETmiss_x + sigrange);
+  SetParameterRange(parNuPy, ETmiss_y - sigrange, ETmiss_y + sigrange);
 
   // eta
   double eta = (*fParticlesPermuted)->Parton(0)->Eta();
@@ -339,9 +345,6 @@ double LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vector<double
   // physics constants
   double massW = fPhysicsConstants.MassW();
   double gammaW = fPhysicsConstants.GammaW();
-  // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
-  // (this will also set the correct width for the top)
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
@@ -470,9 +473,6 @@ std::vector<double> LikelihoodTopLeptonJets_JetAngles::LogLikelihoodComponents(s
   // physics constants
   double massW = fPhysicsConstants.MassW();
   double gammaW = fPhysicsConstants.GammaW();
-  // note: top mass width should be made DEPENDENT on the top mass at a certain point
-  //    fPhysicsConstants.SetMassTop(parameters[parTopM]);
-  // (this will also set the correct width for the top)
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -89,85 +89,85 @@ int LikelihoodTopLeptonJets_JetAngles::CalculateLorentzVectors(std::vector <doub
   TLorentzVector v;
 
   // hadronic b quark
-  v.SetPtEtaPhiE(sqrt(parameters[parBhadE] * parameters[parBhadE] - bhad_meas_m * bhad_meas_m) / cosh(parameters[parBhadEta]),
+  v.SetPtEtaPhiE(sqrt(parameters[parBhadE] * parameters[parBhadE] - m_bhad_meas_m * m_bhad_meas_m) / cosh(parameters[parBhadEta]),
                  parameters[parBhadEta],
                  parameters[parBhadPhi],
                  parameters[parBhadE]);
-  bhad_fit_e = v.E();
-  bhad_fit_px = v.Px();
-  bhad_fit_py = v.Py();
-  bhad_fit_pz = v.Pz();
+  m_bhad_fit_e = v.E();
+  m_bhad_fit_px = v.Px();
+  m_bhad_fit_py = v.Py();
+  m_bhad_fit_pz = v.Pz();
 
   // leptonic b quark
-  v.SetPtEtaPhiE(sqrt(parameters[parBlepE] * parameters[parBlepE] - blep_meas_m * blep_meas_m) / cosh(parameters[parBlepEta]),
+  v.SetPtEtaPhiE(sqrt(parameters[parBlepE] * parameters[parBlepE] - m_blep_meas_m * m_blep_meas_m) / cosh(parameters[parBlepEta]),
                  parameters[parBlepEta],
                  parameters[parBlepPhi],
                  parameters[parBlepE]);
-  blep_fit_e = v.E();
-  blep_fit_px = v.Px();
-  blep_fit_py = v.Py();
-  blep_fit_pz = v.Pz();
+  m_blep_fit_e = v.E();
+  m_blep_fit_px = v.Px();
+  m_blep_fit_py = v.Py();
+  m_blep_fit_pz = v.Pz();
 
   // light quark 1
-  v.SetPtEtaPhiE(sqrt(parameters[parLQ1E] * parameters[parLQ1E] - lq1_meas_m * lq1_meas_m) / cosh(parameters[parLQ1Eta]),
+  v.SetPtEtaPhiE(sqrt(parameters[parLQ1E] * parameters[parLQ1E] - m_lq1_meas_m * m_lq1_meas_m) / cosh(parameters[parLQ1Eta]),
                  parameters[parLQ1Eta],
                  parameters[parLQ1Phi],
                  parameters[parLQ1E]);
-  lq1_fit_e = v.E();
-  lq1_fit_px = v.Px();
-  lq1_fit_py = v.Py();
-  lq1_fit_pz = v.Pz();
+  m_lq1_fit_e = v.E();
+  m_lq1_fit_px = v.Px();
+  m_lq1_fit_py = v.Py();
+  m_lq1_fit_pz = v.Pz();
 
   // light quark 2
-  v.SetPtEtaPhiE(sqrt(parameters[parLQ2E] * parameters[parLQ2E] - lq2_meas_m * lq2_meas_m) / cosh(parameters[parLQ2Eta]),
+  v.SetPtEtaPhiE(sqrt(parameters[parLQ2E] * parameters[parLQ2E] - m_lq2_meas_m * m_lq2_meas_m) / cosh(parameters[parLQ2Eta]),
                  parameters[parLQ2Eta],
                  parameters[parLQ2Phi],
                  parameters[parLQ2E]);
-  lq2_fit_e = v.E();
-  lq2_fit_px = v.Px();
-  lq2_fit_py = v.Py();
-  lq2_fit_pz = v.Pz();
+  m_lq2_fit_e = v.E();
+  m_lq2_fit_px = v.Px();
+  m_lq2_fit_py = v.Py();
+  m_lq2_fit_pz = v.Pz();
 
   // lepton
-  lep_fit_e = parameters[parLepE];
-  scale = lep_fit_e / lep_meas_e;
-  lep_fit_px = scale * lep_meas_px;
-  lep_fit_py = scale * lep_meas_py;
-  lep_fit_pz = scale * lep_meas_pz;
+  m_lep_fit_e = parameters[parLepE];
+  scale = m_lep_fit_e / m_lep_meas_e;
+  m_lep_fit_px = scale * m_lep_meas_px;
+  m_lep_fit_py = scale * m_lep_meas_py;
+  m_lep_fit_pz = scale * m_lep_meas_pz;
 
   // neutrino
-  nu_fit_px = parameters[parNuPx];
-  nu_fit_py = parameters[parNuPy];
-  nu_fit_pz = parameters[parNuPz];
-  nu_fit_e  = sqrt(nu_fit_px * nu_fit_px + nu_fit_py * nu_fit_py + nu_fit_pz * nu_fit_pz);
+  m_nu_fit_px = parameters[parNuPx];
+  m_nu_fit_py = parameters[parNuPy];
+  m_nu_fit_pz = parameters[parNuPz];
+  m_nu_fit_e  = sqrt(m_nu_fit_px * m_nu_fit_px + m_nu_fit_py * m_nu_fit_py + m_nu_fit_pz * m_nu_fit_pz);
 
   // hadronic W
-  whad_fit_e  = lq1_fit_e + lq2_fit_e;
-  whad_fit_px = lq1_fit_px + lq2_fit_px;
-  whad_fit_py = lq1_fit_py + lq2_fit_py;
-  whad_fit_pz = lq1_fit_pz + lq2_fit_pz;
-  whad_fit_m = sqrt(whad_fit_e * whad_fit_e - (whad_fit_px * whad_fit_px + whad_fit_py * whad_fit_py + whad_fit_pz * whad_fit_pz));
+  m_whad_fit_e  = m_lq1_fit_e + m_lq2_fit_e;
+  m_whad_fit_px = m_lq1_fit_px + m_lq2_fit_px;
+  m_whad_fit_py = m_lq1_fit_py + m_lq2_fit_py;
+  m_whad_fit_pz = m_lq1_fit_pz + m_lq2_fit_pz;
+  m_whad_fit_m = sqrt(m_whad_fit_e * m_whad_fit_e - (m_whad_fit_px * m_whad_fit_px + m_whad_fit_py * m_whad_fit_py + m_whad_fit_pz * m_whad_fit_pz));
 
   // leptonic W
-  wlep_fit_e  = lep_fit_e + nu_fit_e;
-  wlep_fit_px = lep_fit_px + nu_fit_px;
-  wlep_fit_py = lep_fit_py + nu_fit_py;
-  wlep_fit_pz = lep_fit_pz + nu_fit_pz;
-  wlep_fit_m = sqrt(wlep_fit_e * wlep_fit_e - (wlep_fit_px * wlep_fit_px + wlep_fit_py * wlep_fit_py + wlep_fit_pz * wlep_fit_pz));
+  m_wlep_fit_e  = m_lep_fit_e + m_nu_fit_e;
+  m_wlep_fit_px = m_lep_fit_px + m_nu_fit_px;
+  m_wlep_fit_py = m_lep_fit_py + m_nu_fit_py;
+  m_wlep_fit_pz = m_lep_fit_pz + m_nu_fit_pz;
+  m_wlep_fit_m = sqrt(m_wlep_fit_e * m_wlep_fit_e - (m_wlep_fit_px * m_wlep_fit_px + m_wlep_fit_py * m_wlep_fit_py + m_wlep_fit_pz * m_wlep_fit_pz));
 
   // hadronic top
-  thad_fit_e = whad_fit_e + bhad_fit_e;
-  thad_fit_px = whad_fit_px + bhad_fit_px;
-  thad_fit_py = whad_fit_py + bhad_fit_py;
-  thad_fit_pz = whad_fit_pz + bhad_fit_pz;
-  thad_fit_m = sqrt(thad_fit_e * thad_fit_e - (thad_fit_px * thad_fit_px + thad_fit_py * thad_fit_py + thad_fit_pz * thad_fit_pz));
+  thad_fit_e = m_whad_fit_e + m_bhad_fit_e;
+  thad_fit_px = m_whad_fit_px + m_bhad_fit_px;
+  thad_fit_py = m_whad_fit_py + m_bhad_fit_py;
+  thad_fit_pz = m_whad_fit_pz + m_bhad_fit_pz;
+  m_thad_fit_m = sqrt(thad_fit_e * thad_fit_e - (thad_fit_px * thad_fit_px + thad_fit_py * thad_fit_py + thad_fit_pz * thad_fit_pz));
 
   // leptonic top
-  tlep_fit_e = wlep_fit_e + blep_fit_e;
-  tlep_fit_px = wlep_fit_px + blep_fit_px;
-  tlep_fit_py = wlep_fit_py + blep_fit_py;
-  tlep_fit_pz = wlep_fit_pz + blep_fit_pz;
-  tlep_fit_m = sqrt(tlep_fit_e * tlep_fit_e - (tlep_fit_px * tlep_fit_px + tlep_fit_py * tlep_fit_py + tlep_fit_pz * tlep_fit_pz));
+  tlep_fit_e = m_wlep_fit_e + m_blep_fit_e;
+  tlep_fit_px = m_wlep_fit_px + m_blep_fit_px;
+  tlep_fit_py = m_wlep_fit_py + m_blep_fit_py;
+  tlep_fit_pz = m_wlep_fit_pz + m_blep_fit_pz;
+  m_tlep_fit_m = sqrt(tlep_fit_e * tlep_fit_e - (tlep_fit_px * tlep_fit_px + tlep_fit_py * tlep_fit_py + tlep_fit_pz * tlep_fit_pz));
 
   // no error
   return 1;
@@ -176,14 +176,14 @@ int LikelihoodTopLeptonJets_JetAngles::CalculateLorentzVectors(std::vector <doub
 // ---------------------------------------------------------
 int LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   // adjust limits
-  double nsigmas_jet    = fFlagGetParSigmasFromTFs ? 10 : 7;
-  double nsigmas_lepton = fFlagGetParSigmasFromTFs ? 10 : 2;
-  double nsigmas_met    = fFlagGetParSigmasFromTFs ? 10 : 1;
+  double nsigmas_jet    = m_flag_get_par_sigmas_from_TFs ? 10 : 7;
+  double nsigmas_lepton = m_flag_get_par_sigmas_from_TFs ? 10 : 2;
+  double nsigmas_met    = m_flag_get_par_sigmas_from_TFs ? 10 : 1;
 
   double E = (*fParticlesPermuted)->Parton(0)->E();
   double m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(0)->M());
-  double sigma = fFlagGetParSigmasFromTFs ? fResEnergyBhad->GetSigma(E) : sqrt(E);
+  double sigma = m_flag_get_par_sigmas_from_TFs ? m_res_energy_bhad->GetSigma(E) : sqrt(E);
   double Emin = std::max(m, E - nsigmas_jet* sigma);
   double Emax = E + nsigmas_jet* sigma;
   SetParameterRange(parBhadE, Emin, Emax);
@@ -191,7 +191,7 @@ int LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   E = (*fParticlesPermuted)->Parton(1)->E();
   m = fPhysicsConstants.MassBottom();
   if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(1)->M());
-  sigma = fFlagGetParSigmasFromTFs ? fResEnergyBlep->GetSigma(E) : sqrt(E);
+  sigma = m_flag_get_par_sigmas_from_TFs ? m_res_energy_blep->GetSigma(E) : sqrt(E);
   Emin = std::max(m, E - nsigmas_jet* sigma);
   Emax = E + nsigmas_jet* sigma;
   SetParameterRange(parBlepE, Emin, Emax);
@@ -199,7 +199,7 @@ int LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   E = (*fParticlesPermuted)->Parton(2)->E();
   m = 0.001;
   if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(2)->M());
-  sigma = fFlagGetParSigmasFromTFs ? fResEnergyLQ1->GetSigma(E) : sqrt(E);
+  sigma = m_flag_get_par_sigmas_from_TFs ? m_res_energy_lq1->GetSigma(E) : sqrt(E);
   Emin = std::max(m, E - nsigmas_jet* sigma);
   Emax = E + nsigmas_jet* sigma;
   SetParameterRange(parLQ1E, Emin, Emax);
@@ -207,30 +207,30 @@ int LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   E = (*fParticlesPermuted)->Parton(3)->E();
   m = 0.001;
   if (fFlagUseJetMass) m = std::max(0.0, (*fParticlesPermuted)->Parton(3)->M());
-  sigma = fFlagGetParSigmasFromTFs ? fResEnergyLQ2->GetSigma(E) : sqrt(E);
+  sigma = m_flag_get_par_sigmas_from_TFs ? m_res_energy_lq2->GetSigma(E) : sqrt(E);
   Emin = std::max(m, E - nsigmas_jet* sigma);
   Emax = E + nsigmas_jet* sigma;
   SetParameterRange(parLQ2E, Emin, Emax);
 
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     E = (*fParticlesPermuted)->Electron(0)->E();
-    sigma = fFlagGetParSigmasFromTFs ? fResLepton->GetSigma(E) : sqrt(E);
+    sigma = m_flag_get_par_sigmas_from_TFs ? m_res_lepton->GetSigma(E) : sqrt(E);
     Emin = std::max(0.001, E - nsigmas_lepton* sigma);
     Emax = E + nsigmas_lepton* sigma;
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     E = (*fParticlesPermuted)->Muon(0)->E();
     double sintheta = sin((*fParticlesPermuted)->Muon(0)->Theta());
-    sigma = fFlagGetParSigmasFromTFs ? fResLepton->GetSigma(E*sintheta)/sintheta : E*E*sintheta;
+    sigma = m_flag_get_par_sigmas_from_TFs ? m_res_lepton->GetSigma(E*sintheta)/sintheta : E*E*sintheta;
     double sigrange = nsigmas_lepton* sigma;
     Emin = std::max(0.001, E -sigrange);
     Emax = E +sigrange;
   }
   SetParameterRange(parLepE, Emin, Emax);
 
-  sigma = fFlagGetParSigmasFromTFs ? fResMET->GetSigma(SumET) : 100;
+  sigma = m_flag_get_par_sigmas_from_TFs ? m_res_met->GetSigma(m_et_miss_sum) : 100;
   double sigrange = nsigmas_met * sigma;
-  SetParameterRange(parNuPx, ETmiss_x - sigrange, ETmiss_x + sigrange);
-  SetParameterRange(parNuPy, ETmiss_y - sigrange, ETmiss_y + sigrange);
+  SetParameterRange(parNuPx, m_et_miss_x - sigrange, m_et_miss_x + sigrange);
+  SetParameterRange(parNuPy, m_et_miss_y - sigrange, m_et_miss_y + sigrange);
 
   // eta
   double eta = (*fParticlesPermuted)->Parton(0)->Eta();
@@ -274,7 +274,7 @@ int LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   phimax = phi + 0.1;
   SetParameterRange(parLQ2Phi, phimin, phimax);
 
-  if (fFlagTopMassFixed)
+  if (m_flag_top_mass_fixed)
     SetParameterRange(parTopM, fPhysicsConstants.MassTop(), fPhysicsConstants.MassTop());
 
   // no error
@@ -293,31 +293,31 @@ double LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vector<double
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp));
+  logprob += log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
-  if (fTypeLepton == kElectron) {
-    logprob += log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp));
-  } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
+  if (m_lepton_type == kElectron) {
+    logprob += log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp));
+  } else if (m_lepton_type == kMuon) {
+    logprob += log(m_res_lepton->p(m_lep_fit_e* m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp));
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));
+  logprob += log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum));
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));
+  logprob += log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum));
   if (!TFgoodTmp) fTFgood = false;
 
   // eta resolution
@@ -348,16 +348,16 @@ double LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vector<double
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
-  logprob += BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW);
+  logprob += BCMath::LogBreitWignerRel(m_whad_fit_m, massW, gammaW);
 
   // Breit-Wigner of leptonically decaying W-boson
-  logprob += BCMath::LogBreitWignerRel(wlep_fit_m, massW, gammaW);
+  logprob += BCMath::LogBreitWignerRel(m_wlep_fit_m, massW, gammaW);
 
   // Breit-Wigner of hadronically decaying top quark
-  logprob += BCMath::LogBreitWignerRel(thad_fit_m, parameters[parTopM], gammaTop);
+  logprob += BCMath::LogBreitWignerRel(m_thad_fit_m, parameters[parTopM], gammaTop);
 
   // Breit-Wigner of leptonically decaying top quark
-  logprob += BCMath::LogBreitWignerRel(tlep_fit_m, parameters[parTopM], gammaTop);
+  logprob += BCMath::LogBreitWignerRel(m_tlep_fit_m, parameters[parTopM], gammaTop);
 
   // return log of likelihood
   return logprob;
@@ -368,33 +368,33 @@ std::vector<double> LikelihoodTopLeptonJets_JetAngles::GetInitialParametersWoNeu
   std::vector<double> values(GetNParameters());
 
   // energies of the quarks
-  values[parBhadE] = bhad_meas_e;
-  values[parBlepE] = blep_meas_e;
-  values[parLQ1E]  = lq1_meas_e;
-  values[parLQ2E]  = lq2_meas_e;
+  values[parBhadE] = m_bhad_meas_e;
+  values[parBlepE] = m_blep_meas_e;
+  values[parLQ1E]  = m_lq1_meas_e;
+  values[parLQ2E]  = m_lq2_meas_e;
 
   // energy of the lepton
-  if (fTypeLepton == kElectron) {
+  if (m_lepton_type == kElectron) {
     values[parLepE] = (*fParticlesPermuted)->Electron(0)->E();
-  } else if (fTypeLepton == kMuon) {
+  } else if (m_lepton_type == kMuon) {
     values[parLepE] = (*fParticlesPermuted)->Muon(0)->E();
   }
 
   // missing px and py
-  values[parNuPx] = ETmiss_x;
-  values[parNuPy] = ETmiss_y;
+  values[parNuPx] = m_et_miss_x;
+  values[parNuPy] = m_et_miss_y;
 
   // eta of the quarks
-  values[parBhadEta] = bhad_meas_eta;
-  values[parBlepEta] = blep_meas_eta;
-  values[parLQ1Eta]  = lq1_meas_eta;
-  values[parLQ2Eta]  = lq2_meas_eta;
+  values[parBhadEta] = m_bhad_meas_eta;
+  values[parBlepEta] = m_blep_meas_eta;
+  values[parLQ1Eta]  = m_lq1_meas_eta;
+  values[parLQ2Eta]  = m_lq2_meas_eta;
 
   // phi of the quarks
-  values[parBhadPhi] = bhad_meas_phi;
-  values[parBlepPhi] = blep_meas_phi;
-  values[parLQ1Phi]  = lq1_meas_phi;
-  values[parLQ2Phi]  = lq2_meas_phi;
+  values[parBhadPhi] = m_bhad_meas_phi;
+  values[parBlepPhi] = m_blep_meas_phi;
+  values[parLQ1Phi]  = m_lq1_meas_phi;
+  values[parLQ2Phi]  = m_lq2_meas_phi;
 
   // pz of the neutrino
   values[parNuPz] = 0.;
@@ -423,31 +423,31 @@ std::vector<double> LikelihoodTopLeptonJets_JetAngles::LogLikelihoodComponents(s
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  vecci.push_back(log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp)));  // comp0
+  vecci.push_back(log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp)));  // comp0
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp)));  // comp1
+  vecci.push_back(log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp)));  // comp1
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp)));  // comp2
+  vecci.push_back(log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp)));  // comp2
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp)));  // comp3
+  vecci.push_back(log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp)));  // comp3
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
-  if (fTypeLepton == kElectron) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp)));  // comp4
-  } else if (fTypeLepton == kMuon) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp)));  // comp4
+  if (m_lepton_type == kElectron) {
+    vecci.push_back(log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp)));  // comp4
+  } else if (m_lepton_type == kMuon) {
+    vecci.push_back(log(m_res_lepton->p(m_lep_fit_e* m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp)));  // comp4
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  vecci.push_back(log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET)));  // comp5
+  vecci.push_back(log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum)));  // comp5
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET)));  // comp6
+  vecci.push_back(log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum)));  // comp6
   if (!TFgoodTmp) fTFgood = false;
 
   // jet eta resolution terms
@@ -476,16 +476,16 @@ std::vector<double> LikelihoodTopLeptonJets_JetAngles::LogLikelihoodComponents(s
   double gammaTop = fPhysicsConstants.GammaTop();
 
   // Breit-Wigner of hadronically decaying W-boson
-  vecci.push_back(BCMath::LogBreitWignerRel(whad_fit_m, massW, gammaW));  // comp7
+  vecci.push_back(BCMath::LogBreitWignerRel(m_whad_fit_m, massW, gammaW));  // comp7
 
   // Breit-Wigner of leptonically decaying W-boson
-  vecci.push_back(BCMath::LogBreitWignerRel(wlep_fit_m, massW, gammaW));  // comp8
+  vecci.push_back(BCMath::LogBreitWignerRel(m_wlep_fit_m, massW, gammaW));  // comp8
 
   // Breit-Wigner of hadronically decaying top quark
-  vecci.push_back(BCMath::LogBreitWignerRel(thad_fit_m, parameters[parTopM], gammaTop));  // comp9
+  vecci.push_back(BCMath::LogBreitWignerRel(m_thad_fit_m, parameters[parTopM], gammaTop));  // comp9
 
   // Breit-Wigner of leptonically decaying top quark
-  vecci.push_back(BCMath::LogBreitWignerRel(tlep_fit_m, parameters[parTopM], gammaTop));  // comp10
+  vecci.push_back(BCMath::LogBreitWignerRel(m_tlep_fit_m, parameters[parTopM], gammaTop));  // comp10
 
   // return log of likelihood
   return vecci;

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -42,16 +42,18 @@ double diffPhi(double phi1, double phi2) {
   }
   return delta;
 }
-}
+}  // namespace
+
+
+namespace KLFitter {
+// ---------------------------------------------------------
+LikelihoodTopLeptonJets_JetAngles::LikelihoodTopLeptonJets_JetAngles() = default;
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets_JetAngles::LikelihoodTopLeptonJets_JetAngles() = default;
+LikelihoodTopLeptonJets_JetAngles::~LikelihoodTopLeptonJets_JetAngles() = default;
 
 // ---------------------------------------------------------
-KLFitter::LikelihoodTopLeptonJets_JetAngles::~LikelihoodTopLeptonJets_JetAngles() = default;
-
-// ---------------------------------------------------------
-void KLFitter::LikelihoodTopLeptonJets_JetAngles::DefineParameters() {
+void LikelihoodTopLeptonJets_JetAngles::DefineParameters() {
   // add parameters of model
   AddParameter("energy hadronic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBhadE
   AddParameter("energy leptonic b",       fPhysicsConstants.MassBottom(), 1000.0);  // parBlepE
@@ -73,7 +75,7 @@ void KLFitter::LikelihoodTopLeptonJets_JetAngles::DefineParameters() {
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets_JetAngles::CalculateLorentzVectors(std::vector <double> const& parameters) {
+int LikelihoodTopLeptonJets_JetAngles::CalculateLorentzVectors(std::vector <double> const& parameters) {
   double scale;
   double thad_fit_e;
   double thad_fit_px;
@@ -160,7 +162,7 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::CalculateLorentzVectors(std::ve
 }
 
 // ---------------------------------------------------------
-int KLFitter::LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
+int LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
   // adjust limits
   double nsigmas_jet    = fFlagGetParSigmasFromTFs ? 10 : 7;
   double nsigmas_lepton = fFlagGetParSigmasFromTFs ? 10 : 2;
@@ -274,7 +276,7 @@ int KLFitter::LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vector<double> & parameters) {
+double LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vector<double> & parameters) {
   // calculate 4-vectors
   CalculateLorentzVectors(parameters);
 
@@ -313,25 +315,25 @@ double KLFitter::LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vec
   if (!TFgoodTmp) fTFgood = false;
 
   // eta resolution
-  logprob += log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(0, KLFitter::Particles::kParton))->p(parameters[parBhadEta], (*fParticlesPermuted)->Parton(0)->Eta(), &TFgoodTmp));
+  logprob += log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->p(parameters[parBhadEta], (*fParticlesPermuted)->Parton(0)->Eta(), &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(1, KLFitter::Particles::kParton))->p(parameters[parBlepEta], (*fParticlesPermuted)->Parton(1)->Eta(), &TFgoodTmp));
+  logprob += log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->p(parameters[parBlepEta], (*fParticlesPermuted)->Parton(1)->Eta(), &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(2, KLFitter::Particles::kParton))->p(parameters[parLQ1Eta], (*fParticlesPermuted)->Parton(2)->Eta(), &TFgoodTmp));
+  logprob += log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->p(parameters[parLQ1Eta], (*fParticlesPermuted)->Parton(2)->Eta(), &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(3, KLFitter::Particles::kParton))->p(parameters[parLQ2Eta], (*fParticlesPermuted)->Parton(3)->Eta(), &TFgoodTmp));
+  logprob += log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->p(parameters[parLQ2Eta], (*fParticlesPermuted)->Parton(3)->Eta(), &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
   // transform all phi values, so that they are centered around zero, and not around the measured phi
 
   // phi resolution
-  logprob += log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(0, KLFitter::Particles::kParton))->p(diffPhi(parameters[parBhadPhi], (*fParticlesPermuted)->Parton(0)->Phi()), 0., &TFgoodTmp));
+  logprob += log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->p(diffPhi(parameters[parBhadPhi], (*fParticlesPermuted)->Parton(0)->Phi()), 0., &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(1, KLFitter::Particles::kParton))->p(diffPhi(parameters[parBlepPhi], (*fParticlesPermuted)->Parton(1)->Phi()), 0., &TFgoodTmp));
+  logprob += log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->p(diffPhi(parameters[parBlepPhi], (*fParticlesPermuted)->Parton(1)->Phi()), 0., &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(2, KLFitter::Particles::kParton))->p(diffPhi(parameters[parLQ1Phi], (*fParticlesPermuted)->Parton(2)->Phi()), 0., &TFgoodTmp));
+  logprob += log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->p(diffPhi(parameters[parLQ1Phi], (*fParticlesPermuted)->Parton(2)->Phi()), 0., &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(3, KLFitter::Particles::kParton))->p(diffPhi(parameters[parLQ2Phi], (*fParticlesPermuted)->Parton(3)->Phi()), 0., &TFgoodTmp));
+  logprob += log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->p(diffPhi(parameters[parLQ2Phi], (*fParticlesPermuted)->Parton(3)->Phi()), 0., &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -359,7 +361,7 @@ double KLFitter::LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vec
 }
 
 // ---------------------------------------------------------
-std::vector<double> KLFitter::LikelihoodTopLeptonJets_JetAngles::GetInitialParametersWoNeutrinoPz() {
+std::vector<double> LikelihoodTopLeptonJets_JetAngles::GetInitialParametersWoNeutrinoPz() {
   std::vector<double> values(GetNParameters());
 
   // energies of the quarks
@@ -408,7 +410,7 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets_JetAngles::GetInitialParam
 }
 
 // ---------------------------------------------------------
-std::vector<double> KLFitter::LikelihoodTopLeptonJets_JetAngles::LogLikelihoodComponents(std::vector<double> parameters) {
+std::vector<double> LikelihoodTopLeptonJets_JetAngles::LogLikelihoodComponents(std::vector<double> parameters) {
   std::vector<double> vecci;
 
   // calculate 4-vectors
@@ -446,23 +448,23 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets_JetAngles::LogLikelihoodCo
   if (!TFgoodTmp) fTFgood = false;
 
   // jet eta resolution terms
-  vecci.push_back(log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(0, KLFitter::Particles::kParton))->p(parameters[parBhadEta], (*fParticlesPermuted)->Parton(0)->Eta(), &TFgoodTmp)));
+  vecci.push_back(log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->p(parameters[parBhadEta], (*fParticlesPermuted)->Parton(0)->Eta(), &TFgoodTmp)));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(1, KLFitter::Particles::kParton))->p(parameters[parBlepEta], (*fParticlesPermuted)->Parton(1)->Eta(), &TFgoodTmp)));
+  vecci.push_back(log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->p(parameters[parBlepEta], (*fParticlesPermuted)->Parton(1)->Eta(), &TFgoodTmp)));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(2, KLFitter::Particles::kParton))->p(parameters[parLQ1Eta], (*fParticlesPermuted)->Parton(2)->Eta(), &TFgoodTmp)));
+  vecci.push_back(log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->p(parameters[parLQ1Eta], (*fParticlesPermuted)->Parton(2)->Eta(), &TFgoodTmp)));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(3, KLFitter::Particles::kParton))->p(parameters[parLQ2Eta], (*fParticlesPermuted)->Parton(3)->Eta(), &TFgoodTmp)));
+  vecci.push_back(log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->p(parameters[parLQ2Eta], (*fParticlesPermuted)->Parton(3)->Eta(), &TFgoodTmp)));
   if (!TFgoodTmp) fTFgood = false;
 
   // jet phi resolution terms
-  vecci.push_back(log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(0, KLFitter::Particles::kParton))->p(diffPhi(parameters[parBhadPhi], (*fParticlesPermuted)->Parton(0)->Phi()), 0., &TFgoodTmp)));
+  vecci.push_back(log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->p(diffPhi(parameters[parBhadPhi], (*fParticlesPermuted)->Parton(0)->Phi()), 0., &TFgoodTmp)));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(1, KLFitter::Particles::kParton))->p(diffPhi(parameters[parBlepPhi], (*fParticlesPermuted)->Parton(1)->Phi()), 0., &TFgoodTmp)));
+  vecci.push_back(log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->p(diffPhi(parameters[parBlepPhi], (*fParticlesPermuted)->Parton(1)->Phi()), 0., &TFgoodTmp)));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(2, KLFitter::Particles::kParton))->p(diffPhi(parameters[parLQ1Phi], (*fParticlesPermuted)->Parton(2)->Phi()), 0., &TFgoodTmp)));
+  vecci.push_back(log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->p(diffPhi(parameters[parLQ1Phi], (*fParticlesPermuted)->Parton(2)->Phi()), 0., &TFgoodTmp)));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(3, KLFitter::Particles::kParton))->p(diffPhi(parameters[parLQ2Phi], (*fParticlesPermuted)->Parton(3)->Phi()), 0., &TFgoodTmp)));
+  vecci.push_back(log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->p(diffPhi(parameters[parLQ2Phi], (*fParticlesPermuted)->Parton(3)->Phi()), 0., &TFgoodTmp)));
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -488,3 +490,4 @@ std::vector<double> KLFitter::LikelihoodTopLeptonJets_JetAngles::LogLikelihoodCo
   // return log of likelihood
   return vecci;
 }
+}  // namespace KLFitter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Although the list of changes is long, they are purely cosmetical:
1. Name all protected/private class member variables starting with an `m_`. This convention should be introduced in all classes eventually. It helps to see which variables are defined locally, and which are stored as members of a class instance.
2. Updated header file documentations to be more descriptive. The documentation was partially reformatted to be optimised for Doxygen output, and a lot of more specific details were pointed out, e.g. differences with respect to parent class implementations.
3. Some formatting inconsistencies in the implementation files were fixed (spacing etc.).
4. All implementation files are now consistently wrapped into the KLFitter namespace, i.e. using `KLFitter::` in the implementations became obsolete.
5. Obsolete include commands were removed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
