### PR TITLE
Addressing/Suppressing compilation warnings

### DIFF
--- a/include/KLFitter/DetectorBase.h
+++ b/include/KLFitter/DetectorBase.h
@@ -74,76 +74,76 @@ class DetectorBase {
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResEnergyLightJet(double eta = 0.) { return fResEnergyLightJet; }
+  virtual ResolutionBase* ResEnergyLightJet(double /*eta*/) { return fResEnergyLightJet; }
 
   /**
     * Return the energy resolution of b jets.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResEnergyBJet(double eta = 0.) { return fResEnergyBJet; }
+  virtual ResolutionBase* ResEnergyBJet(double /*eta*/) { return fResEnergyBJet; }
 
   /**
     * Return the energy resolution of gluon jets.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResEnergyGluonJet(double eta = 0.) { return fResEnergyGluonJet; }
+  virtual ResolutionBase* ResEnergyGluonJet(double /*eta*/) { return fResEnergyGluonJet; }
 
   /**
     * Return the energy resolution of electrons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResEnergyElectron(double eta = 0.) { return fResEnergyElectron; }
+  virtual ResolutionBase* ResEnergyElectron(double /*eta*/) { return fResEnergyElectron; }
 
   /**
     * Return the energy resolution of muons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResEnergyMuon(double eta = 0.) { return fResEnergyMuon; }
+  virtual ResolutionBase* ResEnergyMuon(double /*eta*/) { return fResEnergyMuon; }
 
   /**
     * Return the energy resolution of photons.
     * @param eta The eta of the particle.
     * @return A pointer to the energy resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResEnergyPhoton(double eta = 0.) { return fResEnergyPhoton; }
+  virtual ResolutionBase* ResEnergyPhoton(double /*eta*/) { return fResEnergyPhoton; }
 
   /**
     * Return the missing ET resolution.
     * @return A pointer to the missing ET resolution.
     */
-  virtual KLFitter::ResolutionBase * ResMissingET() { return fResMissingET; }
+  virtual ResolutionBase* ResMissingET() { return fResMissingET; }
 
   /**
     * Return the eta resolution of light jets.
     * @param eta The eta of the particle.
     * @return A pointer to the eta resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResEtaLightJet(double eta = 0.) { return fResEtaLightJet; }
+  virtual ResolutionBase* ResEtaLightJet(double /*eta*/) { return fResEtaLightJet; }
 
   /**
     * Return the eta resolution of b jets.
     * @param eta The eta of the particle.
     * @return A pointer to the eta resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResEtaBJet(double eta = 0.) { return fResEtaBJet; }
+  virtual ResolutionBase* ResEtaBJet(double /*eta*/) { return fResEtaBJet; }
 
   /**
     * Return the phi resolution of light jets.
     * @param eta The phi of the particle.
     * @return A pointer to the phi resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResPhiLightJet(double eta = 0.) { return fResPhiLightJet; }
+  virtual ResolutionBase* ResPhiLightJet(double /*eta*/) { return fResPhiLightJet; }
 
   /**
     * Return the phi resolution of b jets.
     * @param eta The phi of the particle.
     * @return A pointer to the phi resolution object.
     */
-  virtual KLFitter::ResolutionBase * ResPhiBJet(double eta = 0.) { return fResPhiBJet; }
+  virtual ResolutionBase* ResPhiBJet(double /*eta*/) { return fResPhiBJet; }
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -395,7 +395,7 @@ class LikelihoodBase : public BCModel {
     * @param switchpar2 ???
     * @return Permutation of the invariant partner, -1 if there is no one.
     */
-  virtual int LHInvariantPermutationPartner(int iperm, int nperms, int *switchpar1, int *switchpar2) { return -1; }
+  virtual int LHInvariantPermutationPartner(int /*iperm*/, int /*nperms*/, int* /*switchpar1*/, int* /*switchpar2*/) { return -1; }
 
   /**
     * Write parameters from fCachedParametersVector.at(iperm) to fCachedParameters

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -290,13 +290,6 @@ class LikelihoodBase : public BCModel {
   virtual void DefineParameters() = 0;
 
   /**
-    * The prior probability definition, overloaded from BCModel.
-    * @param parameters A vector of parameters (double values).
-    * @return The logarithm of the prior probability.
-    */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
-
-  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -74,12 +74,9 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
    * Set the values for the missing ET x and y components and the SumET.
    * Reimplemented with dummy implementation to overwrite purely virtual
    * function in base class.
-   * @param etx missing ET x component.
-   * @param ety missing ET y component.
-   * @param sumet total scalar ET.
    * @return An error flag.
    */
-  int SetET_miss_XY_SumET(double etx, double ety, double sumet) override { return 1; }
+  int SetET_miss_XY_SumET(double /*etx*/, double /*ety*/, double /*sumet*/) override { return 1; }
 
   /**
     * Set a flag. If flag is true the invariant top quark mass is

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -210,7 +210,7 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     * including a tuning factor alpha.
     * @return A double.
     */
-  double CalculateMLepJet(const std::vector<double> & parameters);
+  double CalculateMLepJet();
 
   /**
     * Set a flag. If flag is true the sumloglikelihood

--- a/include/KLFitter/ResDoubleGaussBase.h
+++ b/include/KLFitter/ResDoubleGaussBase.h
@@ -103,10 +103,10 @@ class ResDoubleGaussBase : public ResolutionBase {
   /**
     * Return the approximate width of the TF depending on the measured value of x.
     * Used to adjust the range of the fit parameter that correspond to the TF.
-    * @param xmeas The measured value of x.
+    * @param par The measured value of x.
     * @return The width.
     */
-  double GetSigma(double xmeas) override;
+  double GetSigma(double par) override;
 
   /**
     * Return the probability of the true value of x given the

--- a/include/KLFitter/ResDoubleGaussBase.h
+++ b/include/KLFitter/ResDoubleGaussBase.h
@@ -118,17 +118,6 @@ class ResDoubleGaussBase : public ResolutionBase {
     */
   double p(double x, double xmeas, bool *good) override;
 
-  /**
-    * Return the probability of the true value of x given the
-    * measured value, xmeas.
-    * @param x The true value of x.
-    * @param xmeas The measured value of x.
-    * @param good False if problem with TF.
-    * @param par Optional additional parameter (SumET in case of MET TF).
-    * @return The probability.
-    */
-  double p(double x, double xmeas, bool *good, double par) override { *good = true; return 0; }
-
   /* @} */
 
   /**

--- a/include/KLFitter/ResDoubleGaussBase.h
+++ b/include/KLFitter/ResDoubleGaussBase.h
@@ -114,9 +114,10 @@ class ResDoubleGaussBase : public ResolutionBase {
     * @param x The true value of x.
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
+    * @param par Optional additional parameter (not used here).
     * @return The probability.
     */
-  double p(double x, double xmeas, bool *good) override;
+  double p(double x, double xmeas, bool *good, double /*par*/ = 0) override;
 
   /* @} */
 

--- a/include/KLFitter/ResGauss.h
+++ b/include/KLFitter/ResGauss.h
@@ -80,17 +80,6 @@ class ResGauss : public ResolutionBase {
     */
   double p(double x, double xmeas, bool *good) override;
 
-  /**
-    * Return the probability of the true value of x given the
-    * measured value, xmeas.
-    * @param x The true value of x.
-    * @param xmeas The measured value of x.
-    * @param good False if problem with TF.
-    * @param par Optional additional parameter (SumET in case of MET TF).
-    * @return The probability.
-    */
-  double p(double x, double xmeas, bool *good, double par) override { *good = true; return 0; }
-
   /* @} */
   /** \name Member functions (Set)  */
   /* @{ */

--- a/include/KLFitter/ResGauss.h
+++ b/include/KLFitter/ResGauss.h
@@ -65,10 +65,10 @@ class ResGauss : public ResolutionBase {
   /**
     * Return the width of the TF depending on the measured value of x.
     * Used to adjust the range of the fit parameter that correspond to the TF.
-    * @param dummy Dummy parameter. Only needed to satisfy the interface.
+    * @param par Dummy parameter. Only needed to satisfy the interface.
     * @return The width.
     */
-  double GetSigma(double dummy = 0) override;
+  double GetSigma(double par = 0) override;
 
   /**
     * Return the probability of the true value of x given the

--- a/include/KLFitter/ResGauss.h
+++ b/include/KLFitter/ResGauss.h
@@ -76,9 +76,10 @@ class ResGauss : public ResolutionBase {
     * @param x The true value of x.
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
+    * @param par Optional additional parameter (not used here).
     * @return The probability.
     */
-  double p(double x, double xmeas, bool *good) override;
+  double p(double x, double xmeas, bool *good, double par = 0) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGaussE.h
+++ b/include/KLFitter/ResGaussE.h
@@ -72,10 +72,10 @@ class ResGaussE : public ResolutionBase {
   /**
     * Return the width of the TF depending on the value of energy x.
     * Used to adjust the range of the fit parameter that correspond to the TF.
-    * @param x true energy as parameter of the TF.
+    * @param par true energy as parameter of the TF.
     * @return The width.
     */
-  double GetSigma(double x) override;
+  double GetSigma(double par) override;
 
   /**
     * Return the probability of the true value of x given the

--- a/include/KLFitter/ResGaussE.h
+++ b/include/KLFitter/ResGaussE.h
@@ -83,10 +83,10 @@ class ResGaussE : public ResolutionBase {
     * @param x The true value of x.
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
-    * @param par Optional additional parameter (SumET in case of MET TF).
+    * @param par Optional additional parameter (not used here).
     * @return The probability.
     */
-  double p(double x, double xmeas, bool *good) override;
+  double p(double x, double xmeas, bool *good, double par = 0) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGaussPt.h
+++ b/include/KLFitter/ResGaussPt.h
@@ -72,10 +72,10 @@ class ResGaussPt : public ResolutionBase {
   /**
     * Return the width of the TF depending on the value of energy x.
     * Used to adjust the range of the fit parameter that correspond to the TF.
-    * @param x true energy as parameter of the TF.
+    * @param par true energy as parameter of the TF.
     * @return The width.
     */
-  double GetSigma(double x) override;
+  double GetSigma(double par) override;
 
   /**
     * Return the probability of the true value of x given the

--- a/include/KLFitter/ResGaussPt.h
+++ b/include/KLFitter/ResGaussPt.h
@@ -83,10 +83,10 @@ class ResGaussPt : public ResolutionBase {
     * @param x The true value of x.
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
-    * @param par Optional additional parameter (SumET in case of MET TF).
+    * @param par Optional additional parameter (not used here).
     * @return The probability.
     */
-  double p(double x, double xmeas, bool *good) override;
+  double p(double x, double xmeas, bool *good, double par = 0) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGauss_MET.h
+++ b/include/KLFitter/ResGauss_MET.h
@@ -77,16 +77,6 @@ class ResGauss_MET : public ResolutionBase {
     * measured value, xmeas.
     * @param x The true value of x.
     * @param xmeas The measured value of x.
-    * @param good False if problem with TF.
-    * @return The probability.
-    */
-  double p(double x, double xmeas, bool *good) override { *good = true; return 0; }
-
-  /**
-    * Return the probability of the true value of x given the
-    * measured value, xmeas.
-    * @param x The true value of x.
-    * @param xmeas The measured value of x.
     * @param sumet SumET, as the width of the TF depends on this.
     * @param good False if problem with TF.
     * @return The probability.

--- a/include/KLFitter/ResGauss_MET.h
+++ b/include/KLFitter/ResGauss_MET.h
@@ -77,8 +77,8 @@ class ResGauss_MET : public ResolutionBase {
     * measured value, xmeas.
     * @param x The true value of x.
     * @param xmeas The measured value of x.
-    * @param sumet SumET, as the width of the TF depends on this.
     * @param good False if problem with TF.
+    * @param sumet SumET, as the width of the TF depends on this.
     * @return The probability.
     */
   double p(double x, double xmeas, bool *good, double sumet) override;

--- a/include/KLFitter/ResolutionBase.h
+++ b/include/KLFitter/ResolutionBase.h
@@ -76,20 +76,10 @@ class ResolutionBase {
     * @param x The true value of x.
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
-    * @return The probability.
-    */
-  virtual double p(double x, double xmeas, bool *good) { *good = true; return 0; }
-
-  /**
-    * Return the probability of the true value of x given the
-    * measured value, xmeas.
-    * @param x The true value of x.
-    * @param xmeas The measured value of x.
-    * @param good False if problem with TF.
     * @param par Optional additional parameter (SumET in case of MET TF).
     * @return The probability.
     */
-  virtual double p(double x, double xmeas, bool *good, double par) { *good = true; return 0; }
+  virtual double p(double /*x*/, double /*xmeas*/, bool *good, double /*par*/ = 0) { *good = true; return 0; }
 
   /**
     * Return a parameter of the parameterization.

--- a/src/DetectorBase.cxx
+++ b/src/DetectorBase.cxx
@@ -24,7 +24,7 @@
 #include "KLFitter/ResolutionBase.h"
 
 // ---------------------------------------------------------
-KLFitter::DetectorBase::DetectorBase(std::string folder)
+KLFitter::DetectorBase::DetectorBase(std::string /*folder*/)
   : fResEnergyLightJet(0)
   , fResEnergyBJet(0)
   , fResEnergyGluonJet(0)

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -520,14 +520,14 @@ double KLFitter::LikelihoodTopDilepton::LogLikelihood(const std::vector<double> 
   if (logweight + 10 == logweight) std::cout << "Gauss NuEta inf! : " << log(GaussNuEta(parameters)) << std::endl;
 
   // Sum of invariant masses (lep, jet) term
-  if (CalculateMLepJet(parameters) == 0.) {
+  if (CalculateMLepJet() == 0.) {
     logweight = log(1e-99);
     return logweight;
   } else {
-    logweight += log(CalculateMLepJet(parameters));
+    logweight += log(CalculateMLepJet());
   }
 
-  if (logweight + 10 == logweight) std::cout << "CalculateMLepJet inf! : "  << log(CalculateMLepJet(parameters)) << std::endl;
+  if (logweight + 10 == logweight) std::cout << "CalculateMLepJet inf! : "  << log(CalculateMLepJet()) << std::endl;
 
   // check if total logweight is inf
   if (logweight + 10 == logweight) std::cout << "logweight TOT = " << logweight << std::endl;
@@ -537,7 +537,7 @@ double KLFitter::LikelihoodTopDilepton::LogLikelihood(const std::vector<double> 
 }
 
 // ---------------------------------------------------------
-double KLFitter::LikelihoodTopDilepton::CalculateMLepJet(const std::vector<double> & parameters) {
+double KLFitter::LikelihoodTopDilepton::CalculateMLepJet() {
   double sumMinv = 0.;
   double norm = 1.;
 
@@ -1025,10 +1025,10 @@ std::vector<double> KLFitter::LikelihoodTopDilepton::LogLikelihoodComponents(std
   }
 
   // sum of invariant masses (lep, jet) term
-  if (CalculateMLepJet(parameters) == 0.) {
+  if (CalculateMLepJet() == 0.) {
     vecci.push_back(log(1e-99));
   } else {
-    vecci.push_back(log(CalculateMLepJet(parameters)));  // comp7
+    vecci.push_back(log(CalculateMLepJet()));  // comp7
   }
 
   // return log of likelihood

--- a/src/ResDoubleGaussBase.cxx
+++ b/src/ResDoubleGaussBase.cxx
@@ -41,15 +41,15 @@ KLFitter::ResDoubleGaussBase::ResDoubleGaussBase(std::vector<double> const& para
 KLFitter::ResDoubleGaussBase::~ResDoubleGaussBase() = default;
 
 // ---------------------------------------------------------
-double KLFitter::ResDoubleGaussBase::GetSigma(double xmeas) {
+double KLFitter::ResDoubleGaussBase::GetSigma(double par) {
   // Calculate mean width of both gaussians; weight the width of the 2nd one with its amplitude
-  double sigma1 = GetSigma1(xmeas);
-  double sigma2 = GetSigma2(xmeas);
-  double amplitude2 = GetAmplitude2(xmeas);
+  double sigma1 = GetSigma1(par);
+  double sigma2 = GetSigma2(par);
+  double amplitude2 = GetAmplitude2(par);
   double sigma = (sigma1 + amplitude2*sigma2) / (1+amplitude2);
 
   // sigma estimates the fractional resolution, but we want absolute
-  return sigma*xmeas;
+  return sigma*par;
 }
 
 // ---------------------------------------------------------

--- a/src/ResDoubleGaussBase.cxx
+++ b/src/ResDoubleGaussBase.cxx
@@ -53,7 +53,7 @@ double KLFitter::ResDoubleGaussBase::GetSigma(double xmeas) {
 }
 
 // ---------------------------------------------------------
-double KLFitter::ResDoubleGaussBase::p(double x, double xmeas, bool *good) {
+double KLFitter::ResDoubleGaussBase::p(double x, double xmeas, bool *good, double /*par*/) {
   double m1 = GetMean1(x);
   double s1 = GetSigma1(x);
   double a2 = GetAmplitude2(x);

--- a/src/ResGauss.cxx
+++ b/src/ResGauss.cxx
@@ -39,7 +39,7 @@ KLFitter::ResGauss::ResGauss(double sigma) : KLFitter::ResolutionBase(1) {
 KLFitter::ResGauss::~ResGauss() = default;
 
 // ---------------------------------------------------------
-double KLFitter::ResGauss::GetSigma(double dummy) {
+double KLFitter::ResGauss::GetSigma(double /*par*/) {
   return fParameters[0];
 }
 

--- a/src/ResGauss.cxx
+++ b/src/ResGauss.cxx
@@ -44,7 +44,7 @@ double KLFitter::ResGauss::GetSigma(double dummy) {
 }
 
 // ---------------------------------------------------------
-double KLFitter::ResGauss::p(double x, double xmeas, bool *good) {
+double KLFitter::ResGauss::p(double x, double xmeas, bool *good, double /*par*/) {
   *good = true;
   return TMath::Gaus(xmeas, x, fParameters[0], true);
 }

--- a/src/ResGaussE.cxx
+++ b/src/ResGaussE.cxx
@@ -44,7 +44,7 @@ double KLFitter::ResGaussE::GetSigma(double x) {
 }
 
 // ---------------------------------------------------------
-double KLFitter::ResGaussE::p(double x, double xmeas, bool *good) {
+double KLFitter::ResGaussE::p(double x, double xmeas, bool *good, double /*par*/) {
   *good = true;
   double sigma = GetSigma(x);
   return TMath::Gaus(xmeas, x, sigma, true);

--- a/src/ResGaussE.cxx
+++ b/src/ResGaussE.cxx
@@ -39,8 +39,8 @@ KLFitter::ResGaussE::ResGaussE(std::vector<double> const& parameters) :KLFitter:
 KLFitter::ResGaussE::~ResGaussE() = default;
 
 // ---------------------------------------------------------
-double KLFitter::ResGaussE::GetSigma(double x) {
-  return sqrt(fParameters[0]*fParameters[0]*x*x + fParameters[1]*fParameters[1]*x + fParameters[2]*fParameters[2]);
+double KLFitter::ResGaussE::GetSigma(double par) {
+  return sqrt(fParameters[0]*fParameters[0]*par*par + fParameters[1]*fParameters[1]*par + fParameters[2]*fParameters[2]);
 }
 
 // ---------------------------------------------------------

--- a/src/ResGaussPt.cxx
+++ b/src/ResGaussPt.cxx
@@ -39,8 +39,8 @@ KLFitter::ResGaussPt::ResGaussPt(std::vector<double> const& parameters) :KLFitte
 KLFitter::ResGaussPt::~ResGaussPt() = default;
 
 // ---------------------------------------------------------
-double KLFitter::ResGaussPt::GetSigma(double x) {
-  if (x <= 200.0)
+double KLFitter::ResGaussPt::GetSigma(double par) {
+  if (par <= 200.0)
     return fParameters[0];
   else
     return fParameters[1];

--- a/src/ResGaussPt.cxx
+++ b/src/ResGaussPt.cxx
@@ -47,7 +47,7 @@ double KLFitter::ResGaussPt::GetSigma(double x) {
 }
 
 // ---------------------------------------------------------
-double KLFitter::ResGaussPt::p(double x, double xmeas, bool *good) {
+double KLFitter::ResGaussPt::p(double x, double xmeas, bool *good, double /*par*/) {
   *good = true;
   double sigma = GetSigma(x);
   return TMath::Gaus(xmeas, x, sigma, true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR addresses and/or suppresses compilation warnings that show up, when the c++ flag `-Wextra` is used:
1. Unused parameters in dummy implementations are now unnamed to suppress "unused variable" warnings.
2. `LogAPrioriProbability()` function was removed as it wasn't used anywhere.
3. Unused parameter of `LikelihoodTopDilepton::CalculateMLepJet()` was removed from function definition.
4. Overloaded definition of `ResolutionBase::p()` was merged into one definition (with the last parameter being optional). This avoids a lot of confusion between the two different implementations, and when they are overwritten in some of the classes.
5. Removal of a few reimplementations of functions in derived classes, when they were identical with the base class implementation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
