### PR TITLE
Correctly using electron cluster eta

### DIFF
--- a/util/example-top-ljets.cxx
+++ b/util/example-top-ljets.cxx
@@ -249,7 +249,7 @@ int main(int argc, char *argv[]) {
     lepton.SetPtEtaPhiE(event.lepton_pt, event.lepton_eta, event.lepton_phi, event.lepton_e);
     if (event.lepton_is_e) {
       likelihood.SetLeptonType(KLFitter::LikelihoodTopLeptonJets::kElectron);
-      particles.AddParticle(lepton, event.lepton_eta, KLFitter::Particles::kElectron);
+      particles.AddParticle(lepton, event.lepton_cl_eta, KLFitter::Particles::kElectron);
     } else if (event.lepton_is_mu) {
       likelihood.SetLeptonType(KLFitter::LikelihoodTopLeptonJets::kMuon);
       particles.AddParticle(lepton, event.lepton_eta, KLFitter::Particles::kMuon);


### PR DESCRIPTION
Correctly using electron cluster eta

## Description
Previous version did not use electron cluster eta properly (used only lepton track eta).

## Motivation and Context
TF are generally derived from calorimeter energy response that is split by cluster eta rather then by track eta

## How Has This Been Tested?
Ran the standard example 

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
