### PR TITLE
Fixing handling of resolution function and TF availability

### DIFF
--- a/include/KLFitter/DetectorBase.h
+++ b/include/KLFitter/DetectorBase.h
@@ -167,6 +167,14 @@ class DetectorBase {
    */
   ResolutionBase* ResolutionUndefined(const std::string& type);
 
+  /**
+   * Handle cases where the parameters for a resolution type are
+   * not available. This prints an error message and throws an
+   * exception of type std::invalid_argument.
+   * @param type The name of the resolution function
+   */
+   void ResolutionParametersUnavailable(const std::string& type);
+
   /// Requested resolutions that the detector must provide.
   std::set<ResolutionType> res_type_requested;
 };

--- a/include/KLFitter/DetectorBase.h
+++ b/include/KLFitter/DetectorBase.h
@@ -67,76 +67,76 @@ class DetectorBase {
    * @param eta The eta of the particle.
    * @return A pointer to the energy resolution object.
    */
-  virtual ResolutionBase* ResEnergyLightJet(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResEnergyLightJet(double /*eta*/) = 0;
 
   /**
    * Return the energy resolution of b jets.
    * @param eta The eta of the particle.
    * @return A pointer to the energy resolution object.
    */
-  virtual ResolutionBase* ResEnergyBJet(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResEnergyBJet(double /*eta*/) = 0;
 
   /**
    * Return the energy resolution of gluon jets.
    * @param eta The eta of the particle.
    * @return A pointer to the energy resolution object.
    */
-  virtual ResolutionBase* ResEnergyGluonJet(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResEnergyGluonJet(double /*eta*/) = 0;
 
   /**
    * Return the energy resolution of electrons.
    * @param eta The eta of the particle.
    * @return A pointer to the energy resolution object.
    */
-  virtual ResolutionBase* ResEnergyElectron(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResEnergyElectron(double /*eta*/) = 0;
 
   /**
    * Return the energy resolution of muons.
    * @param eta The eta of the particle.
    * @return A pointer to the energy resolution object.
    */
-  virtual ResolutionBase* ResEnergyMuon(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResEnergyMuon(double /*eta*/) = 0;
 
   /**
    * Return the energy resolution of photons.
    * @param eta The eta of the particle.
    * @return A pointer to the energy resolution object.
    */
-  virtual ResolutionBase* ResEnergyPhoton(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResEnergyPhoton(double /*eta*/) = 0;
 
   /**
    * Return the missing ET resolution.
    * @return A pointer to the missing ET resolution.
    */
-  virtual ResolutionBase* ResMissingET() { return nullptr; }
+  virtual ResolutionBase* ResMissingET() = 0;
 
   /**
    * Return the eta resolution of light jets.
    * @param eta The eta of the particle.
    * @return A pointer to the eta resolution object.
    */
-  virtual ResolutionBase* ResEtaLightJet(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResEtaLightJet(double /*eta*/) = 0;
 
   /**
    * Return the eta resolution of b jets.
    * @param eta The eta of the particle.
    * @return A pointer to the eta resolution object.
    */
-  virtual ResolutionBase* ResEtaBJet(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResEtaBJet(double /*eta*/) = 0;
 
   /**
    * Return the phi resolution of light jets.
    * @param eta The phi of the particle.
    * @return A pointer to the phi resolution object.
    */
-  virtual ResolutionBase* ResPhiLightJet(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResPhiLightJet(double /*eta*/) = 0;
 
   /**
    * Return the phi resolution of b jets.
    * @param eta The phi of the particle.
    * @return A pointer to the phi resolution object.
    */
-  virtual ResolutionBase* ResPhiBJet(double /*eta*/) { return nullptr; }
+  virtual ResolutionBase* ResPhiBJet(double /*eta*/) = 0;
 
   /* @} */
   /** \name Member functions (misc)  */
@@ -156,6 +156,17 @@ class DetectorBase {
   /* @} */
 
  protected:
+  /**
+   * Handle the call to a resolution object that is not defined,
+   * and throw an exception. The derived detector classes are
+   * expected to reimplement *all* resolution functions and, if
+   * not supported by the detector, return this dummy object that
+   * throws the exception accordingly.
+   * @param type The type of resolution function
+   * @return A nullptr, because an exception is thrown
+   */
+  ResolutionBase* ResolutionUndefined(const std::string& type);
+
   /// Requested resolutions that the detector must provide.
   std::set<ResolutionType> res_type_requested;
 };

--- a/include/KLFitter/DetectorBase.h
+++ b/include/KLFitter/DetectorBase.h
@@ -20,12 +20,27 @@
 #ifndef KLFITTER_DETECTORBASE_H_
 #define KLFITTER_DETECTORBASE_H_
 
+#include <set>
 #include <string>
 
 // ---------------------------------------------------------
 
 namespace KLFitter {
 class ResolutionBase;
+
+enum class ResolutionType {
+  EnergyLightJet,  ///< Energy resolution of light jets
+  EnergyBJet,      ///< Energy resolution of b-jets
+  EnergyGluonJet,  ///< Energy resolution of gluon jets
+  EnergyElectron,  ///< Energy resolution of electrons
+  EnergyMuon,      ///< Energy resolution of muons
+  EnergyPhoton,    ///< Energy resolution of photons
+  MissingET,       ///< Missing ET resolution
+  EtaLightJet,     ///< Eta resolution of light jets
+  EtaBJet,         ///< Eta resolution of b-jets
+  PhiLightJet,     ///< Phi resolution of light jets
+  PhiBJet,         ///< Phi resolution of b-jets
+};
 
 /**
  * A base class for describing detectors. This base class
@@ -129,7 +144,20 @@ class DetectorBase {
 
   int Status();
 
+  /**
+   * Request a resolution type from the detector. The likelihoods
+   * should define which resolution types are needed and make the
+   * appropriate requests to the detector class. Requested
+   * resolution types are then checked in the Status() function.
+   * @param type The ResolutionType object
+   */
+  void RequestResolutionType(const ResolutionType& type);
+
   /* @} */
+
+ protected:
+  /// Requested resolutions that the detector must provide.
+  std::set<ResolutionType> res_type_requested;
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/DetectorSnowmass.h
+++ b/include/KLFitter/DetectorSnowmass.h
@@ -84,6 +84,24 @@ class DetectorSnowmass : public DetectorBase {
 
   /* @} */
 
+  /// Resolution function for gluon jets -- not defined.
+  ResolutionBase* ResEnergyGluonJet(double) override { return ResolutionUndefined("ResEnergyGluonJet"); }
+
+  /// Resolution function for photons -- not defined.
+  ResolutionBase* ResEnergyPhoton(double) override { return ResolutionUndefined("ResEnergyPhoton"); }
+
+  /// Resolution function for light jet eta -- not defined.
+  ResolutionBase* ResEtaLightJet(double) override { return ResolutionUndefined("ResEtaLightJet"); }
+
+  /// Resolution function for b-jet eta -- not defined.
+  ResolutionBase* ResEtaBJet(double) override { return ResolutionUndefined("ResEtaBJet"); }
+
+  /// Resolution function for light jet phi -- not defined.
+  ResolutionBase* ResPhiLightJet(double) override { return ResolutionUndefined("ResPhiLightJet"); }
+
+  /// Resolution function for b-jet phi -- not defined.
+  ResolutionBase* ResPhiBJet(double) override { return ResolutionUndefined("ResPhiBJet"); }
+
  private:
   /// The energy resolution of light jets for different eta regions.
   std::unique_ptr<ResolutionBase> m_res_jet_energy_eta1;

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -155,7 +155,7 @@ class LikelihoodBase : public BCModel {
     * @param detector A pointer to a pointer of the detector.
     * @return An error flag
     */
-  int SetDetector(KLFitter::DetectorBase** detector);
+  virtual int SetDetector(KLFitter::DetectorBase** detector);
 
   /**
     * Set the measured particles.
@@ -280,6 +280,11 @@ class LikelihoodBase : public BCModel {
     */
   void PropagateBTaggingInformation();
 
+  /**
+   * Request necessary resolution functions from the detector.
+   * @return An error code.
+   */
+  virtual void RequestResolutionFunctions() = 0;
 
   /* @} */
   /** \name Member functions (BAT)  */

--- a/include/KLFitter/LikelihoodSgTopWtLJ.h
+++ b/include/KLFitter/LikelihoodSgTopWtLJ.h
@@ -104,6 +104,9 @@ class LikelihoodSgTopWtLJ : public KLFitter::LikelihoodBase {
     */
   int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
+  /// Request the necessary resolution functions from the detector.
+  void RequestResolutionFunctions() override;
+
   /**
     * Associate the hadronic leg of the event to the top quark for likelihood calculation.
     */

--- a/include/KLFitter/LikelihoodTTHLeptonJets.h
+++ b/include/KLFitter/LikelihoodTTHLeptonJets.h
@@ -87,6 +87,9 @@ class LikelihoodTTHLeptonJets : public KLFitter::LikelihoodBase {
     */
   int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
+  /// Request the necessary resolution functions from the detector.
+  void RequestResolutionFunctions() override;
+
   /**
     * Set a flag. If flag is true the invariant top quark mass is
     * fixed to the pole mass.

--- a/include/KLFitter/LikelihoodTTZTrilepton.h
+++ b/include/KLFitter/LikelihoodTTZTrilepton.h
@@ -95,6 +95,9 @@ class LikelihoodTTZTrilepton : public KLFitter::LikelihoodBase {
     */
   int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
+  /// Request the necessary resolution functions from the detector.
+  void RequestResolutionFunctions() override;
+
   /**
     * Set the cut-off value of the 1/E^2 distribution.
     */

--- a/include/KLFitter/LikelihoodTopAllHadronic.h
+++ b/include/KLFitter/LikelihoodTopAllHadronic.h
@@ -78,6 +78,9 @@ class LikelihoodTopAllHadronic : public KLFitter::LikelihoodBase {
    */
   int SetET_miss_XY_SumET(double /*etx*/, double /*ety*/, double /*sumet*/) override { return 1; }
 
+  /// Request the necessary resolution functions from the detector.
+  void RequestResolutionFunctions() override;
+
   /**
     * Set a flag. If flag is true the invariant top quark mass is
     * fixed to the pole mass.

--- a/include/KLFitter/LikelihoodTopDilepton.h
+++ b/include/KLFitter/LikelihoodTopDilepton.h
@@ -93,6 +93,9 @@ class LikelihoodTopDilepton : public KLFitter::LikelihoodBase {
     */
   int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
+  /// Request the necessary resolution functions from the detector.
+  void RequestResolutionFunctions() override;
+
   /**
     * Set a flag. If flag is true the invariant top quark mass is
     * fixed to the pole mass.

--- a/include/KLFitter/LikelihoodTopLeptonJets.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets.h
@@ -166,6 +166,9 @@ class LikelihoodTopLeptonJets : public LikelihoodBase {
    */
   int SetET_miss_XY_SumET(double etx, double ety, double sumet) override;
 
+  /// Request the necessary resolution functions from the detector.
+  void RequestResolutionFunctions() override;
+
   /* @} */
 
  protected:

--- a/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
+++ b/include/KLFitter/LikelihoodTopLeptonJets_JetAngles.h
@@ -120,6 +120,9 @@ class LikelihoodTopLeptonJets_JetAngles : public KLFitter::LikelihoodTopLeptonJe
    */
   std::vector<double> LogLikelihoodComponents(std::vector <double> parameters) override;
 
+  /// Request the necessary resolution functions from the detector.
+  void RequestResolutionFunctions() override;
+
   /* @} */
 
  protected:

--- a/include/KLFitter/LikelihoodTwoTracks.h
+++ b/include/KLFitter/LikelihoodTwoTracks.h
@@ -119,6 +119,9 @@ class LikelihoodTwoTracks : public LikelihoodBase {
   /// Dummy reimplementation of the base class function.
   int SetET_miss_XY_SumET(double /*etx*/, double /*ety*/, double /*sumet*/) override { return 0; }
 
+  /// Dummy reimplementation from the base class.
+  void RequestResolutionFunctions() override { /* do nothing */ }
+
   /// Dummy reimplementation of the base class function.
   int AdjustParameterRanges() override { return 0; }
 

--- a/include/KLFitter/ResolutionBase.h
+++ b/include/KLFitter/ResolutionBase.h
@@ -124,7 +124,7 @@ class ResolutionBase {
     * Return a status code.
     * @return A status code (1: ok, 0: error).
     */
-  int Status();
+  int Status() { return fStatus; }
 
   /* @} */
 
@@ -134,6 +134,9 @@ class ResolutionBase {
 
   /// The parameter values.
   std::vector <double> fParameters;
+
+  /// The status of this class (1: ok, 0: error).
+  int fStatus;
 };
 }  // namespace KLFitter
 

--- a/src/DetectorAtlas_8TeV.cxx
+++ b/src/DetectorAtlas_8TeV.cxx
@@ -46,10 +46,10 @@ DetectorAtlas_8TeV::DetectorAtlas_8TeV(std::string folder) : DetectorBase() {
   m_res_energy_bjet_eta3     = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_4{Form("%s/par_energy_bJets_eta3.txt", folder.c_str())});
   m_res_energy_bjet_eta4     = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_4{Form("%s/par_energy_bJets_eta4.txt", folder.c_str())});
 
-  // m_res_energy_gluon_jet_eta1 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_1{Form("%s/par_energy_gluon_eta1.txt", folder.c_str())});
-  // m_res_energy_gluon_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_1{Form("%s/par_energy_gluon_eta2.txt", folder.c_str())});
-  // m_res_energy_gluon_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_1{Form("%s/par_energy_gluon_eta3.txt", folder.c_str())});
-  // m_res_energy_gluon_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_1{Form("%s/par_energy_gluon_eta4.txt", folder.c_str())});
+  m_res_energy_gluon_jet_eta1 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_1{Form("%s/par_energy_gluon_eta1.txt", folder.c_str())});
+  m_res_energy_gluon_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_1{Form("%s/par_energy_gluon_eta2.txt", folder.c_str())});
+  m_res_energy_gluon_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_1{Form("%s/par_energy_gluon_eta3.txt", folder.c_str())});
+  m_res_energy_gluon_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_1{Form("%s/par_energy_gluon_eta4.txt", folder.c_str())});
 
   m_res_energy_electron_eta1 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_5{Form("%s/par_energy_Electrons_eta1.txt", folder.c_str())});
   m_res_energy_electron_eta2 = std::unique_ptr<ResolutionBase>(new ResDoubleGaussE_5{Form("%s/par_energy_Electrons_eta2.txt", folder.c_str())});
@@ -60,32 +60,32 @@ DetectorAtlas_8TeV::DetectorAtlas_8TeV(std::string folder) : DetectorBase() {
   m_res_energy_muon_eta2     = std::unique_ptr<ResolutionBase>(new ResDoubleGaussPt{Form("%s/par_energy_Muons_eta2.txt", folder.c_str())});
   m_res_energy_muon_eta3     = std::unique_ptr<ResolutionBase>(new ResDoubleGaussPt{Form("%s/par_energy_Muons_eta3.txt", folder.c_str())});
 
-  // m_res_energy_photon_eta1   = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_energy_photon_eta1.txt", folder.c_str())});
-  // m_res_energy_photon_eta2   = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_energy_photon_eta2.txt", folder.c_str())});
-  // m_res_energy_photon_eta3   = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_energy_photon_eta3.txt", folder.c_str())});
-  // m_res_energy_photon_eta4   = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_energy_photon_eta4.txt", folder.c_str())});
+  m_res_energy_photon_eta1   = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_energy_photon_eta1.txt", folder.c_str())});
+  m_res_energy_photon_eta2   = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_energy_photon_eta2.txt", folder.c_str())});
+  m_res_energy_photon_eta3   = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_energy_photon_eta3.txt", folder.c_str())});
+  m_res_energy_photon_eta4   = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_energy_photon_eta4.txt", folder.c_str())});
 
   // eta resolution
-  // m_res_eta_light_jet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta1.txt", folder.c_str())});
-  // m_res_eta_light_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta2.txt", folder.c_str())});
-  // m_res_eta_light_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta3.txt", folder.c_str())});
-  // m_res_eta_light_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta4.txt", folder.c_str())});
+  m_res_eta_light_jet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta1.txt", folder.c_str())});
+  m_res_eta_light_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta2.txt", folder.c_str())});
+  m_res_eta_light_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta3.txt", folder.c_str())});
+  m_res_eta_light_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta4.txt", folder.c_str())});
 
-  // m_res_eta_bjet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta1.txt", folder.c_str())});
-  // m_res_eta_bjet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta2.txt", folder.c_str())});
-  // m_res_eta_bjet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta3.txt", folder.c_str())});
-  // m_res_eta_bjet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta4.txt", folder.c_str())});
+  m_res_eta_bjet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta1.txt", folder.c_str())});
+  m_res_eta_bjet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta2.txt", folder.c_str())});
+  m_res_eta_bjet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta3.txt", folder.c_str())});
+  m_res_eta_bjet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta4.txt", folder.c_str())});
 
   // phi resolution
-  // m_res_phi_light_jet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta1.txt", folder.c_str())});
-  // m_res_phi_light_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta2.txt", folder.c_str())});
-  // m_res_phi_light_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta3.txt", folder.c_str())});
-  // m_res_phi_light_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta4.txt", folder.c_str())});
+  m_res_phi_light_jet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta1.txt", folder.c_str())});
+  m_res_phi_light_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta2.txt", folder.c_str())});
+  m_res_phi_light_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta3.txt", folder.c_str())});
+  m_res_phi_light_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta4.txt", folder.c_str())});
 
-  // m_res_phi_bjet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta1.txt", folder.c_str())});
-  // m_res_phi_bjet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta2.txt", folder.c_str())});
-  // m_res_phi_bjet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta3.txt", folder.c_str())});
-  // m_res_phi_bjet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta4.txt", folder.c_str())});
+  m_res_phi_bjet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta1.txt", folder.c_str())});
+  m_res_phi_bjet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta2.txt", folder.c_str())});
+  m_res_phi_bjet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta3.txt", folder.c_str())});
+  m_res_phi_bjet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta4.txt", folder.c_str())});
 
   m_res_missing_ET = std::unique_ptr<ResolutionBase>(new ResGauss_MET{Form("%s/par_misset.txt", folder.c_str())});
 }

--- a/src/DetectorBase.cxx
+++ b/src/DetectorBase.cxx
@@ -35,57 +35,57 @@ int DetectorBase::Status() {
   try {
     if (res_type_requested.find(ResolutionType::EnergyLightJet) != res_type_requested.end()) {
       if (!ResEnergyLightJet(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResEnergyLightJet");
       }
     }
     if (res_type_requested.find(ResolutionType::EnergyBJet) != res_type_requested.end()) {
       if (!ResEnergyBJet(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResEnergyBJet");
       }
     }
     if (res_type_requested.find(ResolutionType::EnergyGluonJet) != res_type_requested.end()) {
       if (!ResEnergyGluonJet(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResEnergyGluonJet");
       }
     }
     if (res_type_requested.find(ResolutionType::EnergyElectron) != res_type_requested.end()) {
       if (!ResEnergyElectron(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResEnergyElectron");
       }
     }
     if (res_type_requested.find(ResolutionType::EnergyMuon) != res_type_requested.end()) {
       if (!ResEnergyMuon(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResEnergyMuon");
       }
     }
     if (res_type_requested.find(ResolutionType::EnergyPhoton) != res_type_requested.end()) {
       if (!ResEnergyPhoton(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResEnergyPhoton");
       }
     }
     if (res_type_requested.find(ResolutionType::MissingET) != res_type_requested.end()) {
       if (!ResMissingET()->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResMissingET");
       }
     }
     if (res_type_requested.find(ResolutionType::EtaLightJet) != res_type_requested.end()) {
       if (!ResEtaLightJet(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResEtaLightJet");
       }
     }
     if (res_type_requested.find(ResolutionType::EtaBJet) != res_type_requested.end()) {
       if (!ResEtaBJet(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResEtaBJet");
       }
     }
     if (res_type_requested.find(ResolutionType::PhiLightJet) != res_type_requested.end()) {
       if (!ResPhiLightJet(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResPhiLightJet");
       }
     }
     if (res_type_requested.find(ResolutionType::PhiBJet) != res_type_requested.end()) {
       if (!ResPhiBJet(0)->Status()) {
-        return 0;
+        ResolutionParametersUnavailable("ResPhiBJet");
       }
     }
   } catch (std::invalid_argument& excp) {
@@ -102,6 +102,14 @@ int DetectorBase::Status() {
 // ---------------------------------------------------------
 void DetectorBase::RequestResolutionType(const ResolutionType& type) {
   res_type_requested.insert(type);
+}
+
+// ---------------------------------------------------------
+void DetectorBase::ResolutionParametersUnavailable(const std::string& type) {
+  std::cerr << "KLFitter::DetectorBase: Parametrization of \"" << type;
+  std::cerr << "\" needed by chosen likelihood, but parameters could not be read.";
+  std::cerr << " Maybe the used transfer-function parameter set does not provide them?\n";
+  throw std::invalid_argument(type);
 }
 
 // ---------------------------------------------------------

--- a/src/DetectorBase.cxx
+++ b/src/DetectorBase.cxx
@@ -32,12 +32,83 @@ DetectorBase::~DetectorBase() = default;
 
 // ---------------------------------------------------------
 int DetectorBase::Status() {
-  // This function is being refactored ...
+  try {
+    if (res_type_requested.find(ResolutionType::EnergyLightJet) != res_type_requested.end()) {
+      if (!ResEnergyLightJet(0)->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::EnergyBJet) != res_type_requested.end()) {
+      if (!ResEnergyBJet(0)->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::EnergyGluonJet) != res_type_requested.end()) {
+      if (!ResEnergyGluonJet(0)->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::EnergyElectron) != res_type_requested.end()) {
+      if (!ResEnergyElectron(0)->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::EnergyMuon) != res_type_requested.end()) {
+      if (!ResEnergyMuon(0)->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::EnergyPhoton) != res_type_requested.end()) {
+      if (!ResEnergyPhoton(0)->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::MissingET) != res_type_requested.end()) {
+      if (!ResMissingET()->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::EtaLightJet) != res_type_requested.end()) {
+      if (!ResEtaLightJet(0)->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::EtaBJet) != res_type_requested.end()) {
+      if (!ResEtaBJet(0)->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::PhiLightJet) != res_type_requested.end()) {
+      if (!ResPhiLightJet(0)->Status()) {
+        return 0;
+      }
+    }
+    if (res_type_requested.find(ResolutionType::PhiBJet) != res_type_requested.end()) {
+      if (!ResPhiBJet(0)->Status()) {
+        return 0;
+      }
+    }
+  } catch (std::invalid_argument& excp) {
+    // Catch exception and exit gracefully with an error code.
+    std::cerr << "KLFitter::DetectorBase:";
+    std::cerr << " Caught std::invalid_argument: " << excp.what() << "\n";
+    return 0;
+  }
+
+  // no error
   return 1;
 }
 
 // ---------------------------------------------------------
 void DetectorBase::RequestResolutionType(const ResolutionType& type) {
   res_type_requested.insert(type);
+}
+
+// ---------------------------------------------------------
+ResolutionBase* DetectorBase::ResolutionUndefined(const std::string& type) {
+  std::cerr << "KLFitter::DetectorBase: Resolution object of type \"" << type;
+  std::cerr << "\" requested by likelihood, but not supported by the detector class.\n";
+  throw std::invalid_argument(type + " is undefined");
+  return nullptr;
 }
 }  // namespace KLFitter

--- a/src/DetectorBase.cxx
+++ b/src/DetectorBase.cxx
@@ -35,4 +35,9 @@ int DetectorBase::Status() {
   // This function is being refactored ...
   return 1;
 }
+
+// ---------------------------------------------------------
+void DetectorBase::RequestResolutionType(const ResolutionType& type) {
+  res_type_requested.insert(type);
+}
 }  // namespace KLFitter

--- a/src/Fitter.cxx
+++ b/src/Fitter.cxx
@@ -107,6 +107,9 @@ int KLFitter::Fitter::SetDetector(KLFitter::DetectorBase * detector) {
   // set detector
   fDetector = detector;
 
+  // If likelihood != nullptr, request the resolution functions now.
+  if (fLikelihood) fLikelihood->RequestResolutionFunctions();
+
   // Return the status of the detector.
   return fDetector->Status();
 }

--- a/src/Fitter.cxx
+++ b/src/Fitter.cxx
@@ -107,8 +107,8 @@ int KLFitter::Fitter::SetDetector(KLFitter::DetectorBase * detector) {
   // set detector
   fDetector = detector;
 
-  // no error
-  return 1;
+  // Return the status of the detector.
+  return fDetector->Status();
 }
 
 // ---------------------------------------------------------
@@ -128,6 +128,9 @@ int KLFitter::Fitter::SetLikelihood(KLFitter::LikelihoodBase * likelihood) {
   // remove invariant permutations if particles are defined alreday
   if (fParticles)
     fLikelihood->RemoveInvariantParticlePermutations();
+
+  // If detector != nullptr, return its status right now.
+  if (fDetector) return fDetector->Status();
 
   // no error
   return 1;

--- a/src/LikelihoodBase.cxx
+++ b/src/LikelihoodBase.cxx
@@ -120,6 +120,8 @@ int KLFitter::LikelihoodBase::SetDetector(KLFitter::DetectorBase** detector) {
   // set pointer to pointer of detector
   fDetector = detector;
 
+  if (*fDetector) RequestResolutionFunctions();
+
   // no error
   return 1;
 }

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -84,6 +84,15 @@ int KLFitter::LikelihoodSgTopWtLJ::SetET_miss_XY_SumET(double etx, double ety, d
 }
 
 // ---------------------------------------------------------
+void KLFitter::LikelihoodSgTopWtLJ::RequestResolutionFunctions() {
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyLightJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyBJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyElectron);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyMuon);
+  (*fDetector)->RequestResolutionType(ResolutionType::MissingET);
+}
+
+// ---------------------------------------------------------
 void KLFitter::LikelihoodSgTopWtLJ::SetLeptonType(int leptontype) {
   if (leptontype != kElectron && leptontype != kMuon) {
     std::cout << "KLFitter::SetLeptonType()\tWARNING\t lepton type not defined: " << leptontype << ". Set electron as lepton type." << std::endl;

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -62,6 +62,15 @@ int KLFitter::LikelihoodTTHLeptonJets::SetET_miss_XY_SumET(double etx, double et
 }
 
 // ---------------------------------------------------------
+void KLFitter::LikelihoodTTHLeptonJets::RequestResolutionFunctions() {
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyLightJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyBJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyElectron);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyMuon);
+  (*fDetector)->RequestResolutionType(ResolutionType::MissingET);
+}
+
+// ---------------------------------------------------------
 void KLFitter::LikelihoodTTHLeptonJets::SetLeptonType(LeptonType leptontype) {
   if (leptontype != kElectron && leptontype != kMuon) {
     std::cout << "KLFitter::SetLeptonTyp(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -64,6 +64,15 @@ int KLFitter::LikelihoodTTZTrilepton::SetET_miss_XY_SumET(double etx, double ety
 }
 
 // ---------------------------------------------------------
+void KLFitter::LikelihoodTTZTrilepton::RequestResolutionFunctions() {
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyLightJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyBJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyElectron);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyMuon);
+  (*fDetector)->RequestResolutionType(ResolutionType::MissingET);
+}
+
+// ---------------------------------------------------------
 void KLFitter::LikelihoodTTZTrilepton::SetLeptonType(LeptonType leptontype) {
   if (leptontype != kElectron && leptontype != kMuon) {
     std::cout << "KLFitter::SetLeptonTyp(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -324,6 +324,12 @@ int KLFitter::LikelihoodTopAllHadronic::AdjustParameterRanges() {
 }
 
 // ---------------------------------------------------------
+void KLFitter::LikelihoodTopAllHadronic::RequestResolutionFunctions() {
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyLightJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyBJet);
+}
+
+// ---------------------------------------------------------
 double KLFitter::LikelihoodTopAllHadronic::LogLikelihood(const std::vector<double> & parameters) {
   // calculate 4-vectors
   CalculateLorentzVectors(parameters);

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -84,6 +84,15 @@ int KLFitter::LikelihoodTopDilepton::SetET_miss_XY_SumET(double etx, double ety,
 }
 
 // ---------------------------------------------------------
+void KLFitter::LikelihoodTopDilepton::RequestResolutionFunctions() {
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyLightJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyBJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyElectron);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyMuon);
+  (*fDetector)->RequestResolutionType(ResolutionType::MissingET);
+}
+
+// ---------------------------------------------------------
 void KLFitter::LikelihoodTopDilepton::SetLeptonType(LeptonType leptontype_1, LeptonType leptontype_2) {
   if ((leptontype_1 != kElectron && leptontype_1 != kMuon) || (leptontype_2 != kElectron && leptontype_2 != kMuon)) {
     std::cout << "KLFitter::SetLeptonTyp(). Warning: lepton type not defined. Set electron-electron as lepton type." << std::endl;

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -63,6 +63,15 @@ int LikelihoodTopLeptonJets::SetET_miss_XY_SumET(double etx, double ety, double 
 }
 
 // ---------------------------------------------------------
+void LikelihoodTopLeptonJets::RequestResolutionFunctions() {
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyLightJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyBJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyElectron);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyMuon);
+  (*fDetector)->RequestResolutionType(ResolutionType::MissingET);
+}
+
+// ---------------------------------------------------------
 void LikelihoodTopLeptonJets::SetLeptonType(LeptonType leptontype) {
   if (leptontype != kElectron && leptontype != kMuon) {
     std::cout << "KLFitter::SetLeptonType(). Warning: lepton type not defined. Set electron as lepton type." << std::endl;

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -282,6 +282,19 @@ int LikelihoodTopLeptonJets_JetAngles::AdjustParameterRanges() {
 }
 
 // ---------------------------------------------------------
+void LikelihoodTopLeptonJets_JetAngles::RequestResolutionFunctions() {
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyLightJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyBJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyElectron);
+  (*fDetector)->RequestResolutionType(ResolutionType::EnergyMuon);
+  (*fDetector)->RequestResolutionType(ResolutionType::MissingET);
+  (*fDetector)->RequestResolutionType(ResolutionType::EtaLightJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::EtaBJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::PhiLightJet);
+  (*fDetector)->RequestResolutionType(ResolutionType::PhiBJet);
+}
+
+// ---------------------------------------------------------
 double LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vector<double> & parameters) {
   // calculate 4-vectors
   CalculateLorentzVectors(parameters);

--- a/src/ResolutionBase.cxx
+++ b/src/ResolutionBase.cxx
@@ -108,7 +108,7 @@ int KLFitter::ResolutionBase::ReadParameters(const char * filename, int nparamet
 
   // check if file is open
   if (!inputfile.is_open()) {
-    std::cout << "KLFitter::ResolutionBase::ReadParameters(). File \"" << filename << "\" not found." << std::endl;
+    fStatus = 0;
     return 0;
   }
 
@@ -124,6 +124,9 @@ int KLFitter::ResolutionBase::ReadParameters(const char * filename, int nparamet
 
   // close file
   inputfile.close();
+
+  // Switch internal status to "ok".
+  fStatus = 1;
 
   // no error
   return 1;

--- a/tests/test-ljets-lh.cxx
+++ b/tests/test-ljets-lh.cxx
@@ -109,7 +109,11 @@ int main(int argc, char* argv[]) {
   KLFitter::LikelihoodTopLeptonJets lh{};
   lh.SetLeptonType(KLFitter::LikelihoodTopLeptonJets::LeptonType::kMuon);
   lh.SetBTagging(KLFitter::LikelihoodBase::BtaggingMethod::kWorkingPoint);
-  fitter.SetLikelihood(&lh);
+
+  if (!fitter.SetLikelihood(&lh)) {
+    std::cerr << "Setting up the likelihood failed" << std::endl;
+    return -1;
+  }
 
   KLFitter::DetectorSnowmass detector{base_dir + "/data/transferfunctions/snowmass"};
   if (!fitter.SetDetector(&detector)) {


### PR DESCRIPTION
## Description

This PR adds functionality for the likelihoods to "request" specific types of resolution functions from the detector class. This request basically triggers two checks:
1. The detector class must explicitly implement the requested resolution function. To be more precise, non-explicit reimplementation will already fail at compilation level. If detectors don't support certain resolution functions, they now return `DetectorBase::ResolutionUndefined(const std::string& type)`.
2. The resolution object must have valid transfer-function parameters. These parameters are usually read in from text files (from the TF parameter sets). Only if the file exists, if it can be opened and if the parameters can be extracted, the status of the resolution object will say "all ok".

If one of the two above checks fails, the detector will return an error code when `DetectorBase::Status()` is called. This status check is done by the fitter, when the fitter "learns" about the detector with `Fitter::SetDetector(DetectorBase* det)`, i.e. this check will be done _once_ during the setup of the fit. If the error code is returned, both the example implementation and the unit test suggest to abort execution of the program.

In case the above checks pass for all requested resolution function types, there will be no warnings/errors produced for "missing" transfer-function parameter files, as we had it before.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#56 (adjust requirements for transfer function parameterisations), please check the details of the issue for motivation and context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in various setups:
1. Requests done for eta/phi parameterisations, when the detector supports it, but the TF parameter set does not contain parameterisations -> aborts correctly.
2. Request eta/phi parameterisations with the Snowmass detector, which does not support it -> aborts correctly.
3. Request eta/phi parameterisations, when fully supported -> runs smoothly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
