### PR TITLE
fixing crash with allhad LH

### DIFF
--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -435,11 +435,11 @@ int KLFitter::Permutations::InvariantParticleGroupPermutations(KLFitter::Particl
       offset += (*fParticles)->NParticles(itype);
 
     // get permutation
-    const std::vector<int>& permutation1 = fPermutationTable[iperm1];
+    const std::vector<int> permutation1 = fPermutationTable[iperm1];
 
     for (int iperm2 = iperm1-1; iperm2 >= 0; --iperm2) {
       // get second permutation
-      const std::vector<int>& permutation2 = fPermutationTable[iperm2];
+      const std::vector<int> permutation2 = fPermutationTable[iperm2];
 
       // loop over index vectors
       unsigned int numberOfInvariantMatches(0);


### PR DESCRIPTION
Fixed a crash in Allhadronic LH that was introduced by recent changes

## Description
Problem was that we used const reference to an element of permutation table that could be deleted and thus we were left with hanging reference. Now we simply make a copy of that element

## Related Issue
Fixes #65 

## How Has This Been Tested?
Tested with privately produced sample with ~150 events no crash and LL looks reasonable (tested with Atlas TFs)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
