### PR TITLE
Revert "Delete unused LikelihoodBase::LogAPrioriProbability function"

### DIFF
--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -300,7 +300,7 @@ class LikelihoodBase : public BCModel {
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+  virtual double LogAPrioriProbability(const std::vector <double> & parameters) override { return 0; }
 
   /**
     * The posterior probability definition, overloaded from BCModel.

--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -296,6 +296,13 @@ class LikelihoodBase : public BCModel {
   virtual void DefineParameters() = 0;
 
   /**
+    * The prior probability definition, overloaded from BCModel.
+    * @param parameters A vector of parameters (double values).
+    * @return The logarithm of the prior probability.
+    */
+  virtual double LogAPrioriProbability(const std::vector <double> & parameters) { return 0; }
+
+  /**
     * The posterior probability definition, overloaded from BCModel.
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.


### PR DESCRIPTION
This reverts commit 568d5045ed616bb3fc2587a914b55fde7a0b8303.

The function is not unused, it overrides function from BAT and it leads to slightly different results

## Description
If we want to be 100% compatible with previous version we should keep this function in the code

## How Has This Been Tested?
Tested with master version with a custom file with ATLAS TFs. Gives identical results as version v1.0.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
