### PR TITLE
Added missing override in LikelihoodBase class

### DIFF
--- a/include/KLFitter/LikelihoodBase.h
+++ b/include/KLFitter/LikelihoodBase.h
@@ -307,7 +307,7 @@ class LikelihoodBase : public BCModel {
     * @param parameters A vector of parameters (double values).
     * @return The logarithm of the prior probability.
     */
-  virtual double LogLikelihood(const std::vector <double> & parameters) = 0;
+  virtual double LogLikelihood(const std::vector <double> & parameters) override = 0;
 
   /**
     * The posterior probability definition, overloaded from BCModel. Split up into several subcomponents


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a missing `override` keyword that was missing in the LikelihoodBase class. On some systems the compiler complained about inconsistencies with `override` which should be fixed with this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
