### PR TITLE
Using constexp to speed up computation

### DIFF
--- a/src/ResCrystalBallBase.cxx
+++ b/src/ResCrystalBallBase.cxx
@@ -48,6 +48,9 @@ KLFitter::ResCrystalBallBase::~ResCrystalBallBase() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResCrystalBallBase::p(double x, double xmeas, bool *good, double /*par*/) {
+  constexpr double sqrt2 = std::sqrt(2.);
+  constexpr double sqrtPiHalf = std::sqrt(M_PI/2.);
+
   double alpha = GetAlpha(x);
   double n = GetN(x);
   double sigma = GetSigma(x);
@@ -60,7 +63,7 @@ double KLFitter::ResCrystalBallBase::p(double x, double xmeas, bool *good, doubl
 
   // Needed for normalization
   const double C = n/std::fabs(alpha) * 1./(n-1.) * std::exp(-alpha*alpha/2.);
-  const double D = std::sqrt(M_PI/2.)*(1.+ROOT::Math::erf(std::fabs(alpha)/std::sqrt(2.)));
+  const double D = sqrtPiHalf*(1.+ROOT::Math::erf(std::fabs(alpha)/sqrt2));
   const double N = 1./(sigma*(C+D));
 
   return N*CrystalBallFunction(dx, alpha, n, sigma, mean);


### PR DESCRIPTION
Use constexpr for mathematical constants to speed up the computation even when no optimization is used during compilation

## Motivation and Context
CrystalBall normalization is computationally difficult and thus we need to optimize it

## Types of changes
Improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
