### PR TITLE
Added protection when number of TF parameters is larger than expected

### DIFF
--- a/include/KLFitter/ResolutionBase.h
+++ b/include/KLFitter/ResolutionBase.h
@@ -118,7 +118,7 @@ class ResolutionBase {
     * @param nparameters The number of parameters.
     * @return An error code.
     */
-  int ReadParameters(const char * filename, int nparameters);
+  int ReadParameters(const char * filename, std::size_t nparameters);
 
   /**
     * Return a status code.

--- a/src/ResolutionBase.cxx
+++ b/src/ResolutionBase.cxx
@@ -99,7 +99,7 @@ int KLFitter::ResolutionBase::SetPar(std::vector <double> parameters) {
 }
 
 // ---------------------------------------------------------
-int KLFitter::ResolutionBase::ReadParameters(const char * filename, int nparameters) {
+int KLFitter::ResolutionBase::ReadParameters(const char * filename, std::size_t nparameters) {
   // define input file
   std::ifstream inputfile;
 
@@ -116,10 +116,15 @@ int KLFitter::ResolutionBase::ReadParameters(const char * filename, int nparamet
   fParameters.clear();
 
   // read parameters
-  for (int i = 0; i < nparameters; ++i) {
-    double par = 0.0;
-    inputfile >> par;
+  double par = 0.0;
+  while (inputfile >> par) {
     fParameters.push_back(par);
+  }
+
+  if (fParameters.size() != nparameters){
+    std::cout << "KLFitter::ResolutionBase::ReadParameters(). Expecting " << nparameters
+      << ", parameters for Transfer fuctions but " << fParameters.size() << " parameters found" << std::endl;
+    return 0;
   }
 
   // close file


### PR DESCRIPTION
Previously the code printed an error only when number of parameters for TFs was smaller than expected. Now we also exit when number of parameters is larger - this points to using a wrong TF set

## Description
Now we read all parameters and only then compare if the number of read parameters matches our expectation.

## How Has This Been Tested?
Testes with using various combination of TFs and their parametrization

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
