### PR TITLE
Optimization

### DIFF
--- a/include/KLFitter/ResCrystalBallBase.h
+++ b/include/KLFitter/ResCrystalBallBase.h
@@ -112,6 +112,14 @@ class ResCrystalBallBase : public ResolutionBase {
    * @return CrystalBall value for X
    */
   double CrystalBallFunction(double x, double alpha, double n, double sigma, double mean);
+
+  /**
+   * An approximation of the error function needed to calculate crystal ball normalization
+   * with precision < 1e-4. Decreases computation time by about 10%.
+   * @param x
+   * @return Approximate value of the error function for x
+   */
+  double ApproxError(double x);
 };
 }  // namespace KLFitter
 

--- a/include/KLFitter/ResolutionBase.h
+++ b/include/KLFitter/ResolutionBase.h
@@ -118,7 +118,7 @@ class ResolutionBase {
     * @param nparameters The number of parameters.
     * @return An error code.
     */
-  int ReadParameters(const char * filename, int nparameters);
+  int ReadParameters(const char * filename, std::size_t nparameters);
 
   /**
     * Return a status code.

--- a/src/ResCrystalBallBase.cxx
+++ b/src/ResCrystalBallBase.cxx
@@ -21,7 +21,6 @@
 
 // Needed for CrystalBall
 #include "Math/Math.h"
-#include "Math/SpecFuncMathCore.h"
 
 #include <cmath>
 #include <iostream>
@@ -48,8 +47,8 @@ KLFitter::ResCrystalBallBase::~ResCrystalBallBase() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResCrystalBallBase::p(double x, double xmeas, bool *good, double /*par*/) {
-  constexpr double sqrt2 = std::sqrt(2.);
-  constexpr double sqrtPiHalf = std::sqrt(M_PI/2.);
+  static constexpr double sqrt2 = std::sqrt(2.);
+  static constexpr double sqrtPiHalf = std::sqrt(M_PI/2.);
 
   double alpha = GetAlpha(x);
   double n = GetN(x);
@@ -63,7 +62,7 @@ double KLFitter::ResCrystalBallBase::p(double x, double xmeas, bool *good, doubl
 
   // Needed for normalization
   const double C = n/std::fabs(alpha) * 1./(n-1.) * std::exp(-alpha*alpha/2.);
-  const double D = sqrtPiHalf*(1.+ROOT::Math::erf(std::fabs(alpha)/sqrt2));
+  const double D = sqrtPiHalf*(1.+ApproxError(std::fabs(alpha)/sqrt2));
   const double N = 1./(sigma*(C+D));
 
   return N*CrystalBallFunction(dx, alpha, n, sigma, mean);
@@ -90,4 +89,16 @@ double KLFitter::ResCrystalBallBase::CrystalBallFunction(double x, double alpha,
     double arg = nDivAlpha/(B-z);
     return AA * std::pow(arg,n);
   }
+}
+
+// ---------------------------------------------------------
+double KLFitter::ResCrystalBallBase::ApproxError(double x) {
+  static constexpr double a1 = 0.278393;
+  static constexpr double a2 = 0.230389;
+  static constexpr double a3 = 0.000972;
+  static constexpr double a4 = 0.078108;
+
+  const double denom = 1.+ a1*x + a2*x*x + a3*x*x*x + a4*x*x*x*x;
+
+  return 1. - (1./denom/denom/denom/denom);
 }

--- a/src/ResCrystalBallBase.cxx
+++ b/src/ResCrystalBallBase.cxx
@@ -47,7 +47,7 @@ KLFitter::ResCrystalBallBase::~ResCrystalBallBase() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResCrystalBallBase::p(double x, double xmeas, bool *good, double /*par*/) {
-  static constexpr double sqrt2 = std::sqrt(2.);
+  static constexpr double overSqrt2 = 1./std::sqrt(2.);
   static constexpr double sqrtPiHalf = std::sqrt(M_PI/2.);
 
   double alpha = GetAlpha(x);
@@ -61,8 +61,8 @@ double KLFitter::ResCrystalBallBase::p(double x, double xmeas, bool *good, doubl
   double dx = (x - xmeas) / x;
 
   // Needed for normalization
-  const double C = n/std::fabs(alpha) * 1./(n-1.) * std::exp(-alpha*alpha/2.);
-  const double D = sqrtPiHalf*(1.+ApproxError(std::fabs(alpha)/sqrt2));
+  const double C = n/std::fabs(alpha) * 1./(n-1.) * std::exp(-0.5*alpha*alpha);
+  const double D = sqrtPiHalf*(1.+ApproxError(std::fabs(alpha)*overSqrt2));
   const double N = 1./(sigma*(C+D));
 
   return N*CrystalBallFunction(dx, alpha, n, sigma, mean);

--- a/src/ResolutionBase.cxx
+++ b/src/ResolutionBase.cxx
@@ -99,7 +99,7 @@ int KLFitter::ResolutionBase::SetPar(std::vector <double> parameters) {
 }
 
 // ---------------------------------------------------------
-int KLFitter::ResolutionBase::ReadParameters(const char * filename, int nparameters) {
+int KLFitter::ResolutionBase::ReadParameters(const char * filename, std::size_t nparameters) {
   // define input file
   std::ifstream inputfile;
 
@@ -116,10 +116,15 @@ int KLFitter::ResolutionBase::ReadParameters(const char * filename, int nparamet
   fParameters.clear();
 
   // read parameters
-  for (int i = 0; i < nparameters; ++i) {
-    double par = 0.0;
-    inputfile >> par;
+  double par = 0.0;
+  while (inputfile >> par) {
     fParameters.push_back(par);
+  }
+
+  if (fParameters.size() != nparameters){
+    std::cout << "KLFitter::ResolutionBase::ReadParameters(). Expecting " << nparameters
+      << ", parameters for Transfer fuctions but " << fParameters.size() << " parameters found" << std::endl;
+    return 0;
   }
 
   // close file


### PR DESCRIPTION
Replacing precise and slow computation of the error function needed by crystal ball normalization with an approximation with is computationally less expensive. 

Also added test to check if the number of parameters from the list is larger than expected.

## Motivation and Context
Using crystal ball TF increases the running time significantly. This change speeds up the running time by about 10% with no significant loss of precision.

## How Has This Been Tested?
Compared output with the rigorous method and the approximation and the results were very similar. THe running time was improved by about 10%.

## Types of changes
Improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
