### PR TITLE
Extending supported eta range for jets to 4.5

### DIFF
--- a/include/KLFitter/DetectorAtlas_CrystalBall.h
+++ b/include/KLFitter/DetectorAtlas_CrystalBall.h
@@ -129,12 +129,14 @@ class DetectorAtlas_CrystalBall : public DetectorBase {
   std::unique_ptr<ResolutionBase> m_res_energy_light_jet_eta2;
   std::unique_ptr<ResolutionBase> m_res_energy_light_jet_eta3;
   std::unique_ptr<ResolutionBase> m_res_energy_light_jet_eta4;
+  std::unique_ptr<ResolutionBase> m_res_energy_light_jet_eta5;
 
   /// The energy resolution of b jets for different eta regions.
   std::unique_ptr<ResolutionBase> m_res_energy_bjet_eta1;
   std::unique_ptr<ResolutionBase> m_res_energy_bjet_eta2;
   std::unique_ptr<ResolutionBase> m_res_energy_bjet_eta3;
   std::unique_ptr<ResolutionBase> m_res_energy_bjet_eta4;
+  std::unique_ptr<ResolutionBase> m_res_energy_bjet_eta5;
 
   /// The energy resolution of gluon jets for different eta regions.
   std::unique_ptr<ResolutionBase> m_res_energy_gluon_jet_eta1;
@@ -190,7 +192,8 @@ class DetectorAtlas_CrystalBall : public DetectorBase {
   const double m_jet_eta_bin_1{0.8};
   const double m_jet_eta_bin_2{1.37};
   const double m_jet_eta_bin_3{1.52};
-  const double m_jet_eta_bin_4{2.50001};
+  const double m_jet_eta_bin_4{2.5};
+  const double m_jet_eta_bin_5{4.50001};
 
   /// The eta binning for electrons
   const double m_electron_eta_bin_1{0.8};

--- a/src/DetectorAtlas_CrystalBall.cxx
+++ b/src/DetectorAtlas_CrystalBall.cxx
@@ -39,11 +39,13 @@ DetectorAtlas_CrystalBall::DetectorAtlas_CrystalBall(std::string folder) : Detec
   m_res_energy_light_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_lJets_eta2.txt", folder.c_str())});
   m_res_energy_light_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_lJets_eta3.txt", folder.c_str())});
   m_res_energy_light_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_lJets_eta4.txt", folder.c_str())});
+  m_res_energy_light_jet_eta5 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_lJets_eta5.txt", folder.c_str())});
 
   m_res_energy_bjet_eta1     = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_bJets_eta1.txt", folder.c_str())});
   m_res_energy_bjet_eta2     = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_bJets_eta2.txt", folder.c_str())});
   m_res_energy_bjet_eta3     = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_bJets_eta3.txt", folder.c_str())});
   m_res_energy_bjet_eta4     = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_bJets_eta4.txt", folder.c_str())});
+  m_res_energy_bjet_eta5     = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_bJets_eta5.txt", folder.c_str())});
 
   m_res_energy_gluon_jet_eta1 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_gluon_eta1.txt", folder.c_str())});
   m_res_energy_gluon_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_gluon_eta2.txt", folder.c_str())});
@@ -102,6 +104,8 @@ ResolutionBase* DetectorAtlas_CrystalBall::ResEnergyLightJet(double eta) {
     return m_res_energy_light_jet_eta3.get();
   } else if (fabs(eta) <= m_jet_eta_bin_4) {
     return m_res_energy_light_jet_eta4.get();
+  } else if (fabs(eta) <= m_jet_eta_bin_5) {
+    return m_res_energy_light_jet_eta5.get();
   } else {
     std::cout << "DetectorAtlas_CrystalBall::ResEnergyLightJet(). Eta range exceeded." << std::endl;
     return nullptr;
@@ -118,6 +122,8 @@ ResolutionBase* DetectorAtlas_CrystalBall::ResEnergyBJet(double eta) {
     return m_res_energy_bjet_eta3.get();
   } else if (fabs(eta) <= m_jet_eta_bin_4) {
     return m_res_energy_bjet_eta4.get();
+  } else if (fabs(eta) <= m_jet_eta_bin_5) {
+    return m_res_energy_bjet_eta5.get();
   } else {
     std::cout << "DetectorAtlas_CrystalBall::ResEnergyBJet(). Eta range exceeded." << std::endl;
     return nullptr;


### PR DESCRIPTION
We plan to have support for TF for jets to up to eta 4.5. Adjusting the detector class so it can use them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
