### PR TITLE
Log prob

### DIFF
--- a/include/KLFitter/ResCrystalBallBase.h
+++ b/include/KLFitter/ResCrystalBallBase.h
@@ -78,9 +78,9 @@ class ResCrystalBallBase : public ResolutionBase {
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
     * @param par Optional additional parameter (not used here).
-    * @return The probability.
+    * @return Logarithm of the probability.
     */
-  double p(double x, double xmeas, bool *good, double /*par*/ = 0) override;
+  double logp(double x, double xmeas, bool *good, double /*par*/ = 0) override;
 
   /**
     * Sanity check for the crystal ball parameters sigma, and n (1st sigma, scale and 2nd sigma).

--- a/include/KLFitter/ResCrystalBallBase.h
+++ b/include/KLFitter/ResCrystalBallBase.h
@@ -109,9 +109,9 @@ class ResCrystalBallBase : public ResolutionBase {
    * @param n parameter
    * @param sigma parameter
    * @param mean parameter
-   * @return CrystalBall value for X
+   * @return Logarithm of CrystalBall value for X
    */
-  double CrystalBallFunction(double x, double alpha, double n, double sigma, double mean);
+  double LogCrystalBallFunction(double x, double alpha, double n, double sigma, double mean);
 
   /**
    * An approximation of the error function needed to calculate crystal ball normalization

--- a/include/KLFitter/ResDoubleGaussBase.h
+++ b/include/KLFitter/ResDoubleGaussBase.h
@@ -117,7 +117,7 @@ class ResDoubleGaussBase : public ResolutionBase {
     * @param par Optional additional parameter (not used here).
     * @return The probability.
     */
-  double p(double x, double xmeas, bool *good, double /*par*/ = 0) override;
+  double logp(double x, double xmeas, bool *good, double /*par*/ = 0) override;
 
   /* @} */
 

--- a/include/KLFitter/ResGauss.h
+++ b/include/KLFitter/ResGauss.h
@@ -77,9 +77,9 @@ class ResGauss : public ResolutionBase {
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
     * @param par Optional additional parameter (not used here).
-    * @return The probability.
+    * @return Logarithm of the probability.
     */
-  double p(double x, double xmeas, bool *good, double par = 0) override;
+  double logp(double x, double xmeas, bool *good, double par = 0) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGaussE.h
+++ b/include/KLFitter/ResGaussE.h
@@ -84,9 +84,9 @@ class ResGaussE : public ResolutionBase {
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
     * @param par Optional additional parameter (not used here).
-    * @return The probability.
+    * @return Logarithm of the probability.
     */
-  double p(double x, double xmeas, bool *good, double par = 0) override;
+  double logp(double x, double xmeas, bool *good, double par = 0) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGaussPt.h
+++ b/include/KLFitter/ResGaussPt.h
@@ -84,9 +84,9 @@ class ResGaussPt : public ResolutionBase {
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
     * @param par Optional additional parameter (not used here).
-    * @return The probability.
+    * @return Logarithm of the probability.
     */
-  double p(double x, double xmeas, bool *good, double par = 0) override;
+  double logp(double x, double xmeas, bool *good, double par = 0) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResGauss_MET.h
+++ b/include/KLFitter/ResGauss_MET.h
@@ -79,9 +79,9 @@ class ResGauss_MET : public ResolutionBase {
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
     * @param sumet SumET, as the width of the TF depends on this.
-    * @return The probability.
+    * @return Logarithm of the probability.
     */
-  double p(double x, double xmeas, bool *good, double sumet) override;
+  double logp(double x, double xmeas, bool *good, double sumet) override;
 
   /* @} */
   /** \name Member functions (Set)  */

--- a/include/KLFitter/ResSingleGaussBase.h
+++ b/include/KLFitter/ResSingleGaussBase.h
@@ -73,9 +73,9 @@ class ResSingleGaussBase : public ResolutionBase {
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
     * @param par Optional additional parameter (not used here).
-    * @return The probability.
+    * @return Logarithm of the probability.
     */
-  double p(double x, double xmeas, bool *good, double /*par*/ = 0) override;
+  double logp(double x, double xmeas, bool *good, double /*par*/ = 0) override;
 
   /**
     * Sanity check for single gaussian parameter sigma.

--- a/include/KLFitter/ResSingleGaussLinearBase.h
+++ b/include/KLFitter/ResSingleGaussLinearBase.h
@@ -86,9 +86,9 @@ class ResSingleGaussLinearBase : public ResolutionBase {
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
     * @param par Optional additional parameter (not used here).
-    * @return The probability.
+    * @return Logarithm of the probability.
     */
-  double p(double x, double xmeas, bool *good, double /*par*/ = 0) override;
+  double logp(double x, double xmeas, bool *good, double /*par*/ = 0) override;
 
   /* @} */
 

--- a/include/KLFitter/ResolutionBase.h
+++ b/include/KLFitter/ResolutionBase.h
@@ -77,9 +77,9 @@ class ResolutionBase {
     * @param xmeas The measured value of x.
     * @param good False if problem with TF.
     * @param par Optional additional parameter (SumET in case of MET TF).
-    * @return The probability.
+    * @return Logarithm of the probability.
     */
-  virtual double p(double /*x*/, double /*xmeas*/, bool *good, double /*par*/ = 0) { *good = true; return 0; }
+  virtual double logp(double /*x*/, double /*xmeas*/, bool *good, double /*par*/ = 0) { *good = true; return 0; }
 
   /**
     * Return a parameter of the parameterization.

--- a/src/BoostedLikelihoodTopLeptonJets.cxx
+++ b/src/BoostedLikelihoodTopLeptonJets.cxx
@@ -354,28 +354,28 @@ double KLFitter::BoostedLikelihoodTopLeptonJets::LogLikelihood(const std::vector
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBhad->logp(bhad_fit_e, bhad_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBlep->logp(blep_fit_e, blep_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ->p(lq_fit_e, lq_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ->logp(lq_fit_e, lq_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (fTypeLepton == kElectron) {
-    logprob += log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp));
+    logprob += fResLepton->logp(lep_fit_e, lep_meas_e, &TFgoodTmp);
   } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
+    logprob += fResLepton->logp(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp);
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));
+  logprob += fResMET->logp(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));
+  logprob += fResMET->logp(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET);
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -624,28 +624,28 @@ std::vector<double> KLFitter::BoostedLikelihoodTopLeptonJets::LogLikelihoodCompo
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  vecci.push_back(log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp)));  // comp0
+  vecci.push_back(fResEnergyBhad->logp(bhad_fit_e, bhad_meas_e, &TFgoodTmp));  // comp0
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp)));  // comp1
+  vecci.push_back(fResEnergyBlep->logp(blep_fit_e, blep_meas_e, &TFgoodTmp));  // comp1
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ->p(lq_fit_e, lq_meas_e, &TFgoodTmp)));  // comp2
+  vecci.push_back(fResEnergyLQ->logp(lq_fit_e, lq_meas_e, &TFgoodTmp));  // comp2
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (fTypeLepton == kElectron) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp)));  // comp3
+    vecci.push_back(fResLepton->logp(lep_fit_e, lep_meas_e, &TFgoodTmp));  // comp3
   } else if (fTypeLepton == kMuon) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp)));  // comp3
+    vecci.push_back(fResLepton->logp(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));  // comp3
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  vecci.push_back(log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET)));  // comp4
+  vecci.push_back(fResMET->logp(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));  // comp4
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET)));  // comp5
+  vecci.push_back(fResMET->logp(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));  // comp5
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants

--- a/src/LikelihoodSgTopWtLJ.cxx
+++ b/src/LikelihoodSgTopWtLJ.cxx
@@ -358,25 +358,25 @@ double KLFitter::LikelihoodSgTopWtLJ::LogLikelihood(const std::vector<double> & 
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(fResEnergyB->p(b_fit_e, b_meas_e, &TFgoodTmp));
+  logprob += fResEnergyB->logp(b_fit_e, b_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ1->logp(lq1_fit_e, lq1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ2->logp(lq2_fit_e, lq2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (fTypeLepton == kElectron) {
-    logprob += log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp));
+    logprob += fResLepton->logp(lep_fit_e, lep_meas_e, &TFgoodTmp);
   } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
+    logprob += fResLepton->logp(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp);
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));
+  logprob += fResMET->logp(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET);
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));
+  logprob += fResMET->logp(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET);
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants

--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -456,37 +456,37 @@ double KLFitter::LikelihoodTTHLeptonJets::LogLikelihood(const std::vector<double
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBhad->logp(bhad_fit_e, bhad_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBlep->logp(blep_fit_e, blep_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ1->logp(lq1_fit_e, lq1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ2->logp(lq2_fit_e, lq2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyBHiggs1->p(BHiggs1_fit_e, BHiggs1_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBHiggs1->logp(BHiggs1_fit_e, BHiggs1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyBHiggs2->p(BHiggs2_fit_e, BHiggs2_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBHiggs2->logp(BHiggs2_fit_e, BHiggs2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (fTypeLepton == kElectron) {
-    logprob += log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp));
+    logprob += fResLepton->logp(lep_fit_e, lep_meas_e, &TFgoodTmp);
   } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
+    logprob += fResLepton->logp(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp);
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));
+  logprob += fResMET->logp(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));
+  logprob += fResMET->logp(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET);
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -795,37 +795,37 @@ std::vector<double> KLFitter::LikelihoodTTHLeptonJets::LogLikelihoodComponents(s
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  vecci.push_back(log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp)));  // comp0
+  vecci.push_back(fResEnergyBhad->logp(bhad_fit_e, bhad_meas_e, &TFgoodTmp));  // comp0
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp)));  // comp1
+  vecci.push_back(fResEnergyBlep->logp(blep_fit_e, blep_meas_e, &TFgoodTmp));  // comp1
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp)));  // comp2
+  vecci.push_back(fResEnergyLQ1->logp(lq1_fit_e, lq1_meas_e, &TFgoodTmp));  // comp2
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp)));  // comp3
+  vecci.push_back(fResEnergyLQ2->logp(lq2_fit_e, lq2_meas_e, &TFgoodTmp));  // comp3
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyBHiggs1->p(BHiggs1_fit_e, BHiggs1_meas_e, &TFgoodTmp)));  // comp4
+  vecci.push_back(fResEnergyBHiggs1->logp(BHiggs1_fit_e, BHiggs1_meas_e, &TFgoodTmp));  // comp4
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyBHiggs2->p(BHiggs2_fit_e, BHiggs2_meas_e, &TFgoodTmp)));  // comp5
+  vecci.push_back(fResEnergyBHiggs2->logp(BHiggs2_fit_e, BHiggs2_meas_e, &TFgoodTmp));  // comp5
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (fTypeLepton == kElectron) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp)));  // comp6
+    vecci.push_back(fResLepton->logp(lep_fit_e, lep_meas_e, &TFgoodTmp));  // comp6
   } else if (fTypeLepton == kMuon) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp)));  // comp6
+    vecci.push_back(fResLepton->logp(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));  // comp6
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  vecci.push_back(log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET)));  // comp7
+  vecci.push_back(fResMET->logp(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));  // comp7
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET)));  // comp8
+  vecci.push_back(fResMET->logp(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));  // comp8
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants

--- a/src/LikelihoodTTZTrilepton.cxx
+++ b/src/LikelihoodTTZTrilepton.cxx
@@ -511,45 +511,45 @@ double KLFitter::LikelihoodTTZTrilepton::LogLikelihood(const std::vector<double>
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBhad->logp(bhad_fit_e, bhad_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBlep->logp(blep_fit_e, blep_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ1->logp(lq1_fit_e, lq1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ2->logp(lq2_fit_e, lq2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (fTypeLepton == kElectron) {
-    logprob += log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp));
+    logprob += fResLepton->logp(lep_fit_e, lep_meas_e, &TFgoodTmp);
   } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));
+    logprob += fResLepton->logp(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp);
   }
   if (!TFgoodTmp) fTFgood = false;
 
   if (fTypeLepton == kElectron) {
-    logprob += log(fResLeptonZ1->p(lepZ1_fit_e, lepZ1_meas_e, &TFgoodTmp));
+    logprob += fResLeptonZ1->logp(lepZ1_fit_e, lepZ1_meas_e, &TFgoodTmp);
   } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLeptonZ1->p(lepZ1_fit_e* lepZ1_meas_sintheta, lepZ1_meas_pt, &TFgoodTmp));
+    logprob += fResLeptonZ1->logp(lepZ1_fit_e* lepZ1_meas_sintheta, lepZ1_meas_pt, &TFgoodTmp);
   }
   if (!TFgoodTmp) fTFgood = false;
 
   if (fTypeLepton == kElectron) {
-    logprob += log(fResLeptonZ2->p(lepZ2_fit_e, lepZ2_meas_e, &TFgoodTmp));
+    logprob += fResLeptonZ2->logp(lepZ2_fit_e, lepZ2_meas_e, &TFgoodTmp);
   } else if (fTypeLepton == kMuon) {
-    logprob += log(fResLeptonZ2->p(lepZ2_fit_e* lepZ2_meas_sintheta, lepZ2_meas_pt, &TFgoodTmp));
+    logprob += fResLeptonZ2->logp(lepZ2_fit_e* lepZ2_meas_sintheta, lepZ2_meas_pt, &TFgoodTmp);
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));
+  logprob += fResMET->logp(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));
+  logprob += fResMET->logp(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET);
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -911,45 +911,45 @@ std::vector<double> KLFitter::LikelihoodTTZTrilepton::LogLikelihoodComponents(st
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  vecci.push_back(log(fResEnergyBhad->p(bhad_fit_e, bhad_meas_e, &TFgoodTmp)));  // comp0
+  vecci.push_back(fResEnergyBhad->logp(bhad_fit_e, bhad_meas_e, &TFgoodTmp));  // comp0
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyBlep->p(blep_fit_e, blep_meas_e, &TFgoodTmp)));  // comp1
+  vecci.push_back(fResEnergyBlep->logp(blep_fit_e, blep_meas_e, &TFgoodTmp));  // comp1
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp)));  // comp2
+  vecci.push_back(fResEnergyLQ1->logp(lq1_fit_e, lq1_meas_e, &TFgoodTmp));  // comp2
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp)));  // comp3
+  vecci.push_back(fResEnergyLQ2->logp(lq2_fit_e, lq2_meas_e, &TFgoodTmp));  // comp3
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (fTypeLepton == kElectron) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e, lep_meas_e, &TFgoodTmp)));  // comp4
+    vecci.push_back(fResLepton->logp(lep_fit_e, lep_meas_e, &TFgoodTmp));  // comp4
   } else if (fTypeLepton == kMuon) {
-    vecci.push_back(log(fResLepton->p(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp)));  // comp4
+    vecci.push_back(fResLepton->logp(lep_fit_e* lep_meas_sintheta, lep_meas_pt, &TFgoodTmp));  // comp4
   }
   if (!TFgoodTmp) fTFgood = false;
 
   if (fTypeLepton == kElectron) {
-    vecci.push_back(log(fResLeptonZ1->p(lepZ1_fit_e, lepZ1_meas_e, &TFgoodTmp)));  // comp4
+    vecci.push_back(fResLeptonZ1->logp(lepZ1_fit_e, lepZ1_meas_e, &TFgoodTmp));  // comp4
   } else if (fTypeLepton == kMuon) {
-    vecci.push_back(log(fResLeptonZ1->p(lepZ1_fit_e* lepZ1_meas_sintheta, lepZ1_meas_pt, &TFgoodTmp)));  // comp4
+    vecci.push_back(fResLeptonZ1->logp(lepZ1_fit_e* lepZ1_meas_sintheta, lepZ1_meas_pt, &TFgoodTmp));  // comp4
   }
   if (!TFgoodTmp) fTFgood = false;
 
   if (fTypeLepton == kElectron) {
-    vecci.push_back(log(fResLeptonZ2->p(lepZ2_fit_e, lepZ2_meas_e, &TFgoodTmp)));  // comp4
+    vecci.push_back(fResLeptonZ2->logp(lepZ2_fit_e, lepZ2_meas_e, &TFgoodTmp));  // comp4
   } else if (fTypeLepton == kMuon) {
-    vecci.push_back(log(fResLeptonZ2->p(lepZ2_fit_e* lepZ2_meas_sintheta, lepZ2_meas_pt, &TFgoodTmp)));  // comp4
+    vecci.push_back(fResLeptonZ2->logp(lepZ2_fit_e* lepZ2_meas_sintheta, lepZ2_meas_pt, &TFgoodTmp));  // comp4
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  vecci.push_back(log(fResMET->p(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET)));  // comp5
+  vecci.push_back(fResMET->logp(nu_fit_px, ETmiss_x, &TFgoodTmp, SumET));  // comp5
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResMET->p(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET)));  // comp6
+  vecci.push_back(fResMET->logp(nu_fit_py, ETmiss_y, &TFgoodTmp, SumET));  // comp6
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants

--- a/src/LikelihoodTopAllHadronic.cxx
+++ b/src/LikelihoodTopAllHadronic.cxx
@@ -341,22 +341,22 @@ double KLFitter::LikelihoodTopAllHadronic::LogLikelihood(const std::vector<doubl
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(fResEnergyBhad1->p(bhad1_fit_e, bhad1_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBhad1->logp(bhad1_fit_e, bhad1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyBhad2->p(bhad2_fit_e, bhad2_meas_e, &TFgoodTmp));
+  logprob += fResEnergyBhad2->logp(bhad2_fit_e, bhad2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ1->logp(lq1_fit_e, lq1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ2->logp(lq2_fit_e, lq2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ3->p(lq3_fit_e, lq3_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ3->logp(lq3_fit_e, lq3_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(fResEnergyLQ4->p(lq4_fit_e, lq4_meas_e, &TFgoodTmp));
+  logprob += fResEnergyLQ4->logp(lq4_fit_e, lq4_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -519,22 +519,22 @@ std::vector<double> KLFitter::LikelihoodTopAllHadronic::LogLikelihoodComponents(
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  vecci.push_back(log(fResEnergyBhad1->p(bhad1_fit_e, bhad1_meas_e, &TFgoodTmp)));  // comp0
+  vecci.push_back(fResEnergyBhad1->logp(bhad1_fit_e, bhad1_meas_e, &TFgoodTmp));  // comp0
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyBhad2->p(bhad2_fit_e, bhad2_meas_e, &TFgoodTmp)));  // comp1
+  vecci.push_back(fResEnergyBhad2->logp(bhad2_fit_e, bhad2_meas_e, &TFgoodTmp));  // comp1
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ1->p(lq1_fit_e, lq1_meas_e, &TFgoodTmp)));  // comp2
+  vecci.push_back(fResEnergyLQ1->logp(lq1_fit_e, lq1_meas_e, &TFgoodTmp));  // comp2
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ2->p(lq2_fit_e, lq2_meas_e, &TFgoodTmp)));  // comp3
+  vecci.push_back(fResEnergyLQ2->logp(lq2_fit_e, lq2_meas_e, &TFgoodTmp));  // comp3
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ3->p(lq3_fit_e, lq3_meas_e, &TFgoodTmp)));  // comp4
+  vecci.push_back(fResEnergyLQ3->logp(lq3_fit_e, lq3_meas_e, &TFgoodTmp));  // comp4
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(fResEnergyLQ4->p(lq4_fit_e, lq4_meas_e, &TFgoodTmp)));  // comp5
+  vecci.push_back(fResEnergyLQ4->logp(lq4_fit_e, lq4_meas_e, &TFgoodTmp));  // comp5
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants

--- a/src/LikelihoodTopDilepton.cxx
+++ b/src/LikelihoodTopDilepton.cxx
@@ -432,80 +432,40 @@ double KLFitter::LikelihoodTopDilepton::LogLikelihood(const std::vector<double> 
   if (logweight + 10 == logweight) std::cout << "NUWT inf! : " << logweight << std::endl;
 
   // jet energy resolution terms
-  if (fResEnergyB1->p(b1_fit_e, b1_meas_e, &TFgoodTmp) == 0.) {
-    logweight = log(1e-99);
-    return logweight;
-  } else {
-    logweight += log(fResEnergyB1->p(b1_fit_e, b1_meas_e, &TFgoodTmp));
-  }
+  logweight += fResEnergyB1->logp(b1_fit_e, b1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  if (logweight + 10 == logweight) std::cout << "TF b1 inf! : " << log(fResEnergyB1->p(b1_fit_e, b1_meas_e, &TFgoodTmp)) << std::endl;
+  if (logweight + 10 == logweight) std::cout << "TF b1 inf! : " << fResEnergyB1->logp(b1_fit_e, b1_meas_e, &TFgoodTmp) << std::endl;
 
-  if (fResEnergyB2->p(b2_fit_e, b2_meas_e, &TFgoodTmp) == 0.) {
-    logweight = log(1e-99);
-    return logweight;
-  } else {
-    logweight += log(fResEnergyB2->p(b2_fit_e, b2_meas_e, &TFgoodTmp));
-  }
+  logweight += fResEnergyB2->logp(b2_fit_e, b2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  if (logweight + 10 == logweight) std::cout << "TF b2 inf! : " << log(fResEnergyB2->p(b2_fit_e, b2_meas_e, &TFgoodTmp)) << std::endl;
+  if (logweight + 10 == logweight) std::cout << "TF b2 inf! : " << fResEnergyB2->logp(b2_fit_e, b2_meas_e, &TFgoodTmp) << std::endl;
 
   // lepton energy resolution terms EM
   if (fTypeLepton_1 == kElectron && fTypeLepton_2 == kMuon) {
-    if (fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp) == 0.) {
-      logweight = log(1e-99);
-      return logweight;
-    } else {
-      logweight += log(fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp));
-    }
+    logweight += fResLepton1->logp(lep1_fit_e, lep1_meas_e, &TFgoodTmp);
 
-    if (fResLepton2->p(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp) == 0.) {
-      logweight = log(1e-99);
-      return logweight;
-    } else {
-      logweight += log(fResLepton2->p(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp));
-    }
+    logweight += fResLepton2->logp(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp);
     if (!TFgoodTmp) fTFgood = false;
 
-    if (logweight + 10 == logweight) std::cout << "TF lep emu inf! : "<< log(fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp)) <<" and "<< log(fResLepton2->p(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp)) <<std::endl;
+    if (logweight + 10 == logweight) std::cout << "TF lep emu inf! : "<< fResLepton1->logp(lep1_fit_e, lep1_meas_e, &TFgoodTmp) <<" and "<< fResLepton2->logp(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp) <<std::endl;
   } else if (fTypeLepton_1 == kElectron && fTypeLepton_2 == kElectron) {
     // lepton energy resolution terms EE
-    if (fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp) == 0.) {
-      logweight = log(1e-99);
-      return logweight;
-    } else {
-      logweight += log(fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp));
-    }
+    logweight += fResLepton1->logp(lep1_fit_e, lep1_meas_e, &TFgoodTmp);
 
-    if (fResLepton2->p(lep2_fit_e, lep2_meas_e, &TFgoodTmp) == 0.) {
-      logweight = log(1e-99);
-      return logweight;
-    } else {
-      logweight += log(fResLepton2->p(lep2_fit_e, lep2_meas_e, &TFgoodTmp));
-    }
+    logweight += fResLepton2->logp(lep2_fit_e, lep2_meas_e, &TFgoodTmp);
     if (!TFgoodTmp) fTFgood = false;
 
-    if (logweight + 10 == logweight) std::cout << "TF lep ee inf! : " << log(fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp)) << " and " << log(fResLepton2->p(lep2_fit_e, lep2_meas_e, &TFgoodTmp)) << std::endl;
+    if (logweight + 10 == logweight) std::cout << "TF lep ee inf! : " << fResLepton1->logp(lep1_fit_e, lep1_meas_e, &TFgoodTmp) << " and " << fResLepton2->logp(lep2_fit_e, lep2_meas_e, &TFgoodTmp) << std::endl;
   } else if (fTypeLepton_1 == kMuon && fTypeLepton_2 == kMuon) {
     // lepton energy resolution terms MM
-    if (fResLepton1->p(lep1_fit_e*lep1_meas_sintheta, lep1_meas_pt, &TFgoodTmp) == 0.) {
-      logweight = log(1e-99);
-      return logweight;
-    } else {
-      logweight += log(fResLepton1->p(lep1_fit_e*lep1_meas_sintheta, lep1_meas_pt, &TFgoodTmp));
-    }
+    logweight += fResLepton1->logp(lep1_fit_e*lep1_meas_sintheta, lep1_meas_pt, &TFgoodTmp);
 
-    if (fResLepton2->p(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp) == 0.) {
-      logweight = log(1e-99);
-      return logweight;
-    } else {
-      logweight += log(fResLepton2->p(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp));
-    }
+    logweight += fResLepton2->logp(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp);
     if (!TFgoodTmp) fTFgood = false;
 
-    if (logweight + 10 == logweight) std::cout << "TF lep mumu inf! : " << log(fResLepton1->p(lep1_fit_e*lep1_meas_sintheta, lep1_meas_pt, &TFgoodTmp)) << " and " << log(fResLepton2->p(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp)) << std::endl;
+    if (logweight + 10 == logweight) std::cout << "TF lep mumu inf! : " << fResLepton1->logp(lep1_fit_e*lep1_meas_sintheta, lep1_meas_pt, &TFgoodTmp) << " and " << fResLepton2->logp(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp) << std::endl;
   }
 
   // Antineutrino eta term
@@ -964,59 +924,27 @@ std::vector<double> KLFitter::LikelihoodTopDilepton::LogLikelihoodComponents(std
   }
 
   // jet energy resolution terms
-  if (fResEnergyB1->p(b1_fit_e, b1_meas_e, &TFgoodTmp) == 0.) {
-    vecci.push_back(log(1e-99));
-  } else {
-    vecci.push_back(log(fResEnergyB1->p(b1_fit_e, b1_meas_e, &TFgoodTmp)));  // comp1
-  }
+  vecci.push_back(fResEnergyB1->logp(b1_fit_e, b1_meas_e, &TFgoodTmp));  // comp1
   if (!TFgoodTmp) fTFgood = false;
 
-  if (fResEnergyB2->p(b2_fit_e, b2_meas_e, &TFgoodTmp) == 0.) {
-    vecci.push_back(log(1e-99));
-  } else {
-    vecci.push_back(log(fResEnergyB2->p(b2_fit_e, b2_meas_e, &TFgoodTmp)));  // comp2
-  }
+  vecci.push_back(fResEnergyB2->logp(b2_fit_e, b2_meas_e, &TFgoodTmp));  // comp2
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (fTypeLepton_1 == kElectron && fTypeLepton_2 == kMuon) {
-    if (fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp) == 0.) {
-      vecci.push_back(log(1e-99));
-    } else {
-      vecci.push_back(log(fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp)));  // comp3
-    }
+    vecci.push_back(fResLepton1->logp(lep1_fit_e, lep1_meas_e, &TFgoodTmp));  // comp3
 
-    if (fResLepton2->p(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp) == 0.) {
-      vecci.push_back(log(1e-99));
-    } else {
-      vecci.push_back(log(fResLepton2->p(lep2_fit_e* lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp)));  // comp4
-    }
+    vecci.push_back(fResLepton2->logp(lep2_fit_e* lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp));  // comp4
     if (!TFgoodTmp) fTFgood = false;
   } else if (fTypeLepton_1 == kElectron && fTypeLepton_2 == kElectron) {
-    if (fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp) == 0.) {
-      vecci.push_back(log(1e-99));
-    } else {
-      vecci.push_back(log(fResLepton1->p(lep1_fit_e, lep1_meas_e, &TFgoodTmp)));  // comp3
-    }
+    vecci.push_back(fResLepton1->logp(lep1_fit_e, lep1_meas_e, &TFgoodTmp));  // comp3
 
-    if (fResLepton2->p(lep2_fit_e, lep2_meas_e, &TFgoodTmp) == 0.) {
-      vecci.push_back(log(1e-99));
-    } else {
-      vecci.push_back(log(fResLepton2->p(lep2_fit_e, lep2_meas_e, &TFgoodTmp)));  // comp4
-    }
+    vecci.push_back(fResLepton2->logp(lep2_fit_e, lep2_meas_e, &TFgoodTmp));  // comp4
     if (!TFgoodTmp) fTFgood = false;
   } else if (fTypeLepton_1 == kMuon && fTypeLepton_2 == kMuon) {
-    if (fResLepton1->p(lep1_fit_e*lep1_meas_sintheta, lep1_meas_pt, &TFgoodTmp) == 0.) {
-      vecci.push_back(log(1e-99));
-    } else {
-      vecci.push_back(log(fResLepton1->p(lep1_fit_e* lep1_meas_sintheta, lep1_meas_pt, &TFgoodTmp)));  // comp3
-    }
+    vecci.push_back(fResLepton1->logp(lep1_fit_e* lep1_meas_sintheta, lep1_meas_pt, &TFgoodTmp));  // comp3
 
-    if (fResLepton2->p(lep2_fit_e*lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp) == 0.) {
-      vecci.push_back(log(1e-99));
-    } else {
-      vecci.push_back(log(fResLepton2->p(lep2_fit_e* lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp)));  // comp4
-    }
+    vecci.push_back(fResLepton2->logp(lep2_fit_e* lep2_meas_sintheta, lep2_meas_pt, &TFgoodTmp));  // comp4
     if (!TFgoodTmp) fTFgood = false;
   }
 

--- a/src/LikelihoodTopLeptonJets.cxx
+++ b/src/LikelihoodTopLeptonJets.cxx
@@ -365,31 +365,31 @@ double LikelihoodTopLeptonJets::LogLikelihood(const std::vector<double> & parame
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_bhad->logp(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_blep->logp(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_lq1->logp(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_lq2->logp(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (m_lepton_type == kElectron) {
-    logprob += log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp));
+    logprob += m_res_lepton->logp(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp);
   } else if (m_lepton_type == kMuon) {
-    logprob += log(m_res_lepton->p(m_lep_fit_e * m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp));
+    logprob += m_res_lepton->logp(m_lep_fit_e * m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp);
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum));
+  logprob += m_res_met->logp(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum));
+  logprob += m_res_met->logp(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum);
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -650,31 +650,31 @@ std::vector<double> LikelihoodTopLeptonJets::LogLikelihoodComponents(std::vector
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  vecci.push_back(log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp)));  // comp0
+  vecci.push_back(m_res_energy_bhad->logp(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp));  // comp0
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp)));  // comp1
+  vecci.push_back(m_res_energy_blep->logp(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp));  // comp1
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp)));  // comp2
+  vecci.push_back(m_res_energy_lq1->logp(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp));  // comp2
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp)));  // comp3
+  vecci.push_back(m_res_energy_lq2->logp(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp));  // comp3
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (m_lepton_type == kElectron) {
-    vecci.push_back(log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp)));  // comp4
+    vecci.push_back(m_res_lepton->logp(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp));  // comp4
   } else if (m_lepton_type == kMuon) {
-    vecci.push_back(log(m_res_lepton->p(m_lep_fit_e* m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp)));  // comp4
+    vecci.push_back(m_res_lepton->logp(m_lep_fit_e* m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp));  // comp4
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  vecci.push_back(log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum)));  // comp5
+  vecci.push_back(m_res_met->logp(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum));  // comp5
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum)));  // comp6
+  vecci.push_back(m_res_met->logp(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum));  // comp6
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants

--- a/src/LikelihoodTopLeptonJets_Angular.cxx
+++ b/src/LikelihoodTopLeptonJets_Angular.cxx
@@ -105,31 +105,31 @@ double LikelihoodTopLeptonJets_Angular::LogLikelihood(const std::vector<double> 
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_bhad->logp(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_blep->logp(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_lq1->logp(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_lq2->logp(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (m_lepton_type == kElectron) {
-    logprob += log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp));
+    logprob += m_res_lepton->logp(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp);
   } else if (m_lepton_type == kMuon) {
-    logprob += log(m_res_lepton->p(m_lep_fit_e * m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp));
+    logprob += m_res_lepton->logp(m_lep_fit_e * m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp);
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum));
+  logprob += m_res_met->logp(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum));
+  logprob += m_res_met->logp(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum);
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants

--- a/src/LikelihoodTopLeptonJets_JetAngles.cxx
+++ b/src/LikelihoodTopLeptonJets_JetAngles.cxx
@@ -306,53 +306,53 @@ double LikelihoodTopLeptonJets_JetAngles::LogLikelihood(const std::vector<double
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  logprob += log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_bhad->logp(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_blep->logp(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_lq1->logp(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp));
+  logprob += m_res_energy_lq2->logp(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (m_lepton_type == kElectron) {
-    logprob += log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp));
+    logprob += m_res_lepton->logp(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp);
   } else if (m_lepton_type == kMuon) {
-    logprob += log(m_res_lepton->p(m_lep_fit_e* m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp));
+    logprob += m_res_lepton->logp(m_lep_fit_e* m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp);
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  logprob += log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum));
+  logprob += m_res_met->logp(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum);
   if (!TFgoodTmp) fTFgood = false;
 
-  logprob += log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum));
+  logprob += m_res_met->logp(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum);
   if (!TFgoodTmp) fTFgood = false;
 
   // eta resolution
-  logprob += log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->p(parameters[parBhadEta], (*fParticlesPermuted)->Parton(0)->Eta(), &TFgoodTmp));
+  logprob += (*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->logp(parameters[parBhadEta], (*fParticlesPermuted)->Parton(0)->Eta(), &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->p(parameters[parBlepEta], (*fParticlesPermuted)->Parton(1)->Eta(), &TFgoodTmp));
+  logprob += (*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->logp(parameters[parBlepEta], (*fParticlesPermuted)->Parton(1)->Eta(), &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->p(parameters[parLQ1Eta], (*fParticlesPermuted)->Parton(2)->Eta(), &TFgoodTmp));
+  logprob += (*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->logp(parameters[parLQ1Eta], (*fParticlesPermuted)->Parton(2)->Eta(), &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->p(parameters[parLQ2Eta], (*fParticlesPermuted)->Parton(3)->Eta(), &TFgoodTmp));
+  logprob += (*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->logp(parameters[parLQ2Eta], (*fParticlesPermuted)->Parton(3)->Eta(), &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // transform all phi values, so that they are centered around zero, and not around the measured phi
 
   // phi resolution
-  logprob += log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->p(diffPhi(parameters[parBhadPhi], (*fParticlesPermuted)->Parton(0)->Phi()), 0., &TFgoodTmp));
+  logprob += (*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->logp(diffPhi(parameters[parBhadPhi], (*fParticlesPermuted)->Parton(0)->Phi()), 0., &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->p(diffPhi(parameters[parBlepPhi], (*fParticlesPermuted)->Parton(1)->Phi()), 0., &TFgoodTmp));
+  logprob += (*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->logp(diffPhi(parameters[parBlepPhi], (*fParticlesPermuted)->Parton(1)->Phi()), 0., &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->p(diffPhi(parameters[parLQ1Phi], (*fParticlesPermuted)->Parton(2)->Phi()), 0., &TFgoodTmp));
+  logprob += (*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->logp(diffPhi(parameters[parLQ1Phi], (*fParticlesPermuted)->Parton(2)->Phi()), 0., &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
-  logprob += log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->p(diffPhi(parameters[parLQ2Phi], (*fParticlesPermuted)->Parton(3)->Phi()), 0., &TFgoodTmp));
+  logprob += (*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->logp(diffPhi(parameters[parLQ2Phi], (*fParticlesPermuted)->Parton(3)->Phi()), 0., &TFgoodTmp);
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants
@@ -436,51 +436,51 @@ std::vector<double> LikelihoodTopLeptonJets_JetAngles::LogLikelihoodComponents(s
   bool TFgoodTmp(true);
 
   // jet energy resolution terms
-  vecci.push_back(log(m_res_energy_bhad->p(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp)));  // comp0
+  vecci.push_back(m_res_energy_bhad->logp(m_bhad_fit_e, m_bhad_meas_e, &TFgoodTmp));  // comp0
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(m_res_energy_blep->p(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp)));  // comp1
+  vecci.push_back(m_res_energy_blep->logp(m_blep_fit_e, m_blep_meas_e, &TFgoodTmp));  // comp1
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(m_res_energy_lq1->p(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp)));  // comp2
+  vecci.push_back(m_res_energy_lq1->logp(m_lq1_fit_e, m_lq1_meas_e, &TFgoodTmp));  // comp2
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(m_res_energy_lq2->p(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp)));  // comp3
+  vecci.push_back(m_res_energy_lq2->logp(m_lq2_fit_e, m_lq2_meas_e, &TFgoodTmp));  // comp3
   if (!TFgoodTmp) fTFgood = false;
 
   // lepton energy resolution terms
   if (m_lepton_type == kElectron) {
-    vecci.push_back(log(m_res_lepton->p(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp)));  // comp4
+    vecci.push_back(m_res_lepton->logp(m_lep_fit_e, m_lep_meas_e, &TFgoodTmp));  // comp4
   } else if (m_lepton_type == kMuon) {
-    vecci.push_back(log(m_res_lepton->p(m_lep_fit_e* m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp)));  // comp4
+    vecci.push_back(m_res_lepton->logp(m_lep_fit_e* m_lep_meas_sintheta, m_lep_meas_pt, &TFgoodTmp));  // comp4
   }
   if (!TFgoodTmp) fTFgood = false;
 
   // neutrino px and py
-  vecci.push_back(log(m_res_met->p(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum)));  // comp5
+  vecci.push_back(m_res_met->logp(m_nu_fit_px, m_et_miss_x, &TFgoodTmp, m_et_miss_sum));  // comp5
   if (!TFgoodTmp) fTFgood = false;
 
-  vecci.push_back(log(m_res_met->p(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum)));  // comp6
+  vecci.push_back(m_res_met->logp(m_nu_fit_py, m_et_miss_y, &TFgoodTmp, m_et_miss_sum));  // comp6
   if (!TFgoodTmp) fTFgood = false;
 
   // jet eta resolution terms
-  vecci.push_back(log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->p(parameters[parBhadEta], (*fParticlesPermuted)->Parton(0)->Eta(), &TFgoodTmp)));
+  vecci.push_back((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->logp(parameters[parBhadEta], (*fParticlesPermuted)->Parton(0)->Eta(), &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->p(parameters[parBlepEta], (*fParticlesPermuted)->Parton(1)->Eta(), &TFgoodTmp)));
+  vecci.push_back((*fDetector)->ResEtaBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->logp(parameters[parBlepEta], (*fParticlesPermuted)->Parton(1)->Eta(), &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->p(parameters[parLQ1Eta], (*fParticlesPermuted)->Parton(2)->Eta(), &TFgoodTmp)));
+  vecci.push_back((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->logp(parameters[parLQ1Eta], (*fParticlesPermuted)->Parton(2)->Eta(), &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->p(parameters[parLQ2Eta], (*fParticlesPermuted)->Parton(3)->Eta(), &TFgoodTmp)));
+  vecci.push_back((*fDetector)->ResEtaLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->logp(parameters[parLQ2Eta], (*fParticlesPermuted)->Parton(3)->Eta(), &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
   // jet phi resolution terms
-  vecci.push_back(log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->p(diffPhi(parameters[parBhadPhi], (*fParticlesPermuted)->Parton(0)->Phi()), 0., &TFgoodTmp)));
+  vecci.push_back((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(0, Particles::kParton))->logp(diffPhi(parameters[parBhadPhi], (*fParticlesPermuted)->Parton(0)->Phi()), 0., &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->p(diffPhi(parameters[parBlepPhi], (*fParticlesPermuted)->Parton(1)->Phi()), 0., &TFgoodTmp)));
+  vecci.push_back((*fDetector)->ResPhiBJet((*fParticlesPermuted)->DetEta(1, Particles::kParton))->logp(diffPhi(parameters[parBlepPhi], (*fParticlesPermuted)->Parton(1)->Phi()), 0., &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->p(diffPhi(parameters[parLQ1Phi], (*fParticlesPermuted)->Parton(2)->Phi()), 0., &TFgoodTmp)));
+  vecci.push_back((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(2, Particles::kParton))->logp(diffPhi(parameters[parLQ1Phi], (*fParticlesPermuted)->Parton(2)->Phi()), 0., &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
-  vecci.push_back(log((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->p(diffPhi(parameters[parLQ2Phi], (*fParticlesPermuted)->Parton(3)->Phi()), 0., &TFgoodTmp)));
+  vecci.push_back((*fDetector)->ResPhiLightJet((*fParticlesPermuted)->DetEta(3, Particles::kParton))->logp(diffPhi(parameters[parLQ2Phi], (*fParticlesPermuted)->Parton(3)->Phi()), 0., &TFgoodTmp));
   if (!TFgoodTmp) fTFgood = false;
 
   // physics constants

--- a/src/ResCrystalBallBase.cxx
+++ b/src/ResCrystalBallBase.cxx
@@ -47,7 +47,7 @@ KLFitter::ResCrystalBallBase::ResCrystalBallBase(std::vector<double> const& para
 KLFitter::ResCrystalBallBase::~ResCrystalBallBase() = default;
 
 // ---------------------------------------------------------
-double KLFitter::ResCrystalBallBase::p(double x, double xmeas, bool *good, double /*par*/) {
+double KLFitter::ResCrystalBallBase::logp(double x, double xmeas, bool *good, double /*par*/) {
   constexpr double sqrt2 = std::sqrt(2.);
   constexpr double sqrtPiHalf = std::sqrt(M_PI/2.);
 

--- a/src/ResCrystalBallBase.cxx
+++ b/src/ResCrystalBallBase.cxx
@@ -63,17 +63,16 @@ double KLFitter::ResCrystalBallBase::logp(double x, double xmeas, bool *good, do
   // Needed for normalization
   const double C = n/std::fabs(alpha) * 1./(n-1.) * std::exp(-0.5*alpha*alpha);
   const double D = sqrtPiHalf*(1.+ApproxError(std::fabs(alpha)*overSqrt2));
-  const double N = 1./(sigma*(C+D));
 
-  return N*CrystalBallFunction(dx, alpha, n, sigma, mean);
+  return (-std::log(sigma*(C+D))) + LogCrystalBallFunction(dx, alpha, n, sigma, mean);
 }
   
 // ---------------------------------------------------------
-double KLFitter::ResCrystalBallBase::CrystalBallFunction(double x, double alpha,
+double KLFitter::ResCrystalBallBase::LogCrystalBallFunction(double x, double alpha,
     double n, double sigma, double mean) {
 	// evaluate the crystal ball function
   if (sigma < 0.) {
-    return 0.;
+    return -9999999;
   }
   double z = (x - mean)/sigma; 
   if (alpha < 0) {
@@ -81,13 +80,13 @@ double KLFitter::ResCrystalBallBase::CrystalBallFunction(double x, double alpha,
   }
   double abs_alpha = std::abs(alpha);
   if (z  > - abs_alpha) {
-    return std::exp(- 0.5 * z * z);
+    return (- 0.5 * z * z);
   } else {
     double nDivAlpha = n/abs_alpha;
-    double AA =  std::exp(-0.5*abs_alpha*abs_alpha);
     double B = nDivAlpha -abs_alpha;
     double arg = nDivAlpha/(B-z);
-    return AA * std::pow(arg,n);
+
+    return (-0.5*abs_alpha*abs_alpha) + n*std::log(arg);
   }
 }
 

--- a/src/ResDoubleGaussBase.cxx
+++ b/src/ResDoubleGaussBase.cxx
@@ -53,7 +53,7 @@ double KLFitter::ResDoubleGaussBase::GetSigma(double par) {
 }
 
 // ---------------------------------------------------------
-double KLFitter::ResDoubleGaussBase::p(double x, double xmeas, bool *good, double /*par*/) {
+double KLFitter::ResDoubleGaussBase::logp(double x, double xmeas, bool *good, double /*par*/) {
   double m1 = GetMean1(x);
   double s1 = GetSigma1(x);
   double a2 = GetAmplitude2(x);

--- a/src/ResDoubleGaussBase.cxx
+++ b/src/ResDoubleGaussBase.cxx
@@ -66,5 +66,6 @@ double KLFitter::ResDoubleGaussBase::logp(double x, double xmeas, bool *good, do
   double dx = (x - xmeas) / x;
 
   // calculate double-Gaussian
-  return 1./sqrt(2.*M_PI) / (s1 + a2 * s2) * (exp(-(dx-m1)*(dx-m1)/(2 * s1*s1)) + a2 * exp(-(dx-m2)*(dx-m2)/(2 * s2 * s2)));
+  const double p =  1./sqrt(2.*M_PI) / (s1 + a2 * s2) * (exp(-(dx-m1)*(dx-m1)/(2 * s1*s1)) + a2 * exp(-(dx-m2)*(dx-m2)/(2 * s2 * s2)));
+  return std::log(p);
 }

--- a/src/ResGauss.cxx
+++ b/src/ResGauss.cxx
@@ -44,7 +44,7 @@ double KLFitter::ResGauss::GetSigma(double /*par*/) {
 }
 
 // ---------------------------------------------------------
-double KLFitter::ResGauss::p(double x, double xmeas, bool *good, double /*par*/) {
+double KLFitter::ResGauss::logp(double x, double xmeas, bool *good, double /*par*/) {
   *good = true;
   return TMath::Gaus(xmeas, x, fParameters[0], true);
 }

--- a/src/ResGauss.cxx
+++ b/src/ResGauss.cxx
@@ -45,6 +45,8 @@ double KLFitter::ResGauss::GetSigma(double /*par*/) {
 
 // ---------------------------------------------------------
 double KLFitter::ResGauss::logp(double x, double xmeas, bool *good, double /*par*/) {
+  const double sigma = GetSigma(x);
   *good = true;
-  return TMath::Gaus(xmeas, x, fParameters[0], true);
+
+  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
 }

--- a/src/ResGauss.cxx
+++ b/src/ResGauss.cxx
@@ -45,8 +45,10 @@ double KLFitter::ResGauss::GetSigma(double /*par*/) {
 
 // ---------------------------------------------------------
 double KLFitter::ResGauss::logp(double x, double xmeas, bool *good, double /*par*/) {
+  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
+
   const double sigma = GetSigma(x);
   *good = true;
 
-  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
+  return -logSqrtTwoPi - std::log(sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma);
 }

--- a/src/ResGaussE.cxx
+++ b/src/ResGaussE.cxx
@@ -45,7 +45,9 @@ double KLFitter::ResGaussE::GetSigma(double par) {
 
 // ---------------------------------------------------------
 double KLFitter::ResGaussE::logp(double x, double xmeas, bool *good, double /*par*/) {
+  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
+
   *good = true;
   double sigma = GetSigma(x);
-  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
+  return -logSqrtTwoPi - std::log(sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma);
 }

--- a/src/ResGaussE.cxx
+++ b/src/ResGaussE.cxx
@@ -47,5 +47,5 @@ double KLFitter::ResGaussE::GetSigma(double par) {
 double KLFitter::ResGaussE::logp(double x, double xmeas, bool *good, double /*par*/) {
   *good = true;
   double sigma = GetSigma(x);
-  return TMath::Gaus(xmeas, x, sigma, true);
+  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
 }

--- a/src/ResGaussE.cxx
+++ b/src/ResGaussE.cxx
@@ -44,7 +44,7 @@ double KLFitter::ResGaussE::GetSigma(double par) {
 }
 
 // ---------------------------------------------------------
-double KLFitter::ResGaussE::p(double x, double xmeas, bool *good, double /*par*/) {
+double KLFitter::ResGaussE::logp(double x, double xmeas, bool *good, double /*par*/) {
   *good = true;
   double sigma = GetSigma(x);
   return TMath::Gaus(xmeas, x, sigma, true);

--- a/src/ResGaussPt.cxx
+++ b/src/ResGaussPt.cxx
@@ -47,7 +47,7 @@ double KLFitter::ResGaussPt::GetSigma(double par) {
 }
 
 // ---------------------------------------------------------
-double KLFitter::ResGaussPt::p(double x, double xmeas, bool *good, double /*par*/) {
+double KLFitter::ResGaussPt::logp(double x, double xmeas, bool *good, double /*par*/) {
   *good = true;
   double sigma = GetSigma(x);
   return TMath::Gaus(xmeas, x, sigma, true);

--- a/src/ResGaussPt.cxx
+++ b/src/ResGaussPt.cxx
@@ -48,7 +48,9 @@ double KLFitter::ResGaussPt::GetSigma(double par) {
 
 // ---------------------------------------------------------
 double KLFitter::ResGaussPt::logp(double x, double xmeas, bool *good, double /*par*/) {
+  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
+
   *good = true;
   double sigma = GetSigma(x);
-  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
+  return -logSqrtTwoPi - std::log(sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma);
 }

--- a/src/ResGaussPt.cxx
+++ b/src/ResGaussPt.cxx
@@ -50,5 +50,5 @@ double KLFitter::ResGaussPt::GetSigma(double par) {
 double KLFitter::ResGaussPt::logp(double x, double xmeas, bool *good, double /*par*/) {
   *good = true;
   double sigma = GetSigma(x);
-  return TMath::Gaus(xmeas, x, sigma, true);
+  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
 }

--- a/src/ResGauss_MET.cxx
+++ b/src/ResGauss_MET.cxx
@@ -48,8 +48,10 @@ double KLFitter::ResGauss_MET::GetSigma(double sumet) {
 
 // ---------------------------------------------------------
 double KLFitter::ResGauss_MET::logp(double x, double xmeas, bool *good, double sumet) {
+  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
+
   *good = true;
   // calculate MET TF with 4 parameters (MC10b or later)
   double sigma = GetSigma(sumet);
-  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
+  return -logSqrtTwoPi - std::log(sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma);
 }

--- a/src/ResGauss_MET.cxx
+++ b/src/ResGauss_MET.cxx
@@ -47,7 +47,7 @@ double KLFitter::ResGauss_MET::GetSigma(double sumet) {
 }
 
 // ---------------------------------------------------------
-double KLFitter::ResGauss_MET::p(double x, double xmeas, bool *good, double sumet) {
+double KLFitter::ResGauss_MET::logp(double x, double xmeas, bool *good, double sumet) {
   *good = true;
   // calculate MET TF with 4 parameters (MC10b or later)
   double sigma = GetSigma(sumet);

--- a/src/ResGauss_MET.cxx
+++ b/src/ResGauss_MET.cxx
@@ -51,5 +51,5 @@ double KLFitter::ResGauss_MET::logp(double x, double xmeas, bool *good, double s
   *good = true;
   // calculate MET TF with 4 parameters (MC10b or later)
   double sigma = GetSigma(sumet);
-  return TMath::Gaus(xmeas, x, sigma, true);
+  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
 }

--- a/src/ResSingleGaussBase.cxx
+++ b/src/ResSingleGaussBase.cxx
@@ -43,7 +43,7 @@ KLFitter::ResSingleGaussBase::ResSingleGaussBase(std::vector<double> const& para
 KLFitter::ResSingleGaussBase::~ResSingleGaussBase() = default;
 
 // ---------------------------------------------------------
-double KLFitter::ResSingleGaussBase::p(double x, double xmeas, bool *good, double /*par*/) {
+double KLFitter::ResSingleGaussBase::logp(double x, double xmeas, bool *good, double /*par*/) {
   double mean = GetMean(x);
   double sigma = GetSigma(x);
 

--- a/src/ResSingleGaussBase.cxx
+++ b/src/ResSingleGaussBase.cxx
@@ -52,5 +52,5 @@ double KLFitter::ResSingleGaussBase::logp(double x, double xmeas, bool *good, do
 
   double dx = (x - xmeas) / x;
 
-  return TMath::Gaus(dx, mean, fParameters[0], true);
+  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(dx-mean)*(dx-mean)/sigma/sigma); 
 }

--- a/src/ResSingleGaussLinearBase.cxx
+++ b/src/ResSingleGaussLinearBase.cxx
@@ -44,13 +44,10 @@ KLFitter::ResSingleGaussLinearBase::~ResSingleGaussLinearBase() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResSingleGaussLinearBase::logp(double x, double xmeas, bool *good, double /*par*/) {
-  double mean = GetMean(x);
   double sigma = GetSigma(x);
 
   // sanity checks for p2, p3 and p5
   *good = CheckSingleGaussianSanity(&sigma);
 
-  double dx = (x - xmeas) / x;
-
-  return TMath::Gaus(dx, mean, fParameters[0], true);
+  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
 }

--- a/src/ResSingleGaussLinearBase.cxx
+++ b/src/ResSingleGaussLinearBase.cxx
@@ -44,10 +44,11 @@ KLFitter::ResSingleGaussLinearBase::~ResSingleGaussLinearBase() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResSingleGaussLinearBase::logp(double x, double xmeas, bool *good, double /*par*/) {
-  double sigma = GetSigma(x);
+  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
 
+  double sigma = GetSigma(x);
   // sanity checks for p2, p3 and p5
   *good = CheckSingleGaussianSanity(&sigma);
 
-  return -std::log(std::sqrt(2*M_PI)*sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma); 
+  return -logSqrtTwoPi - std::log(sigma) - (0.5*(xmeas-x)*(xmeas-x)/sigma/sigma);
 }

--- a/src/ResSingleGaussLinearBase.cxx
+++ b/src/ResSingleGaussLinearBase.cxx
@@ -43,7 +43,7 @@ KLFitter::ResSingleGaussLinearBase::ResSingleGaussLinearBase(std::vector<double>
 KLFitter::ResSingleGaussLinearBase::~ResSingleGaussLinearBase() = default;
 
 // ---------------------------------------------------------
-double KLFitter::ResSingleGaussLinearBase::p(double x, double xmeas, bool *good, double /*par*/) {
+double KLFitter::ResSingleGaussLinearBase::logp(double x, double xmeas, bool *good, double /*par*/) {
   double mean = GetMean(x);
   double sigma = GetSigma(x);
 


### PR DESCRIPTION
TFs return logprobability instead of probability and then likelihoods do not apply additional log

## Description
For some functions CPU was wasted to calculate exponential and then logarithm. This is now improved. It helps significantly with the CrystalBall running time

## Motivation and Context
CB TFs used lot of CPU

## How Has This Been Tested?
Double gauss implementation leads to the same results as before. Unfortunately a bug in CB was discovered so it makes it impossible to compare with the previous CB results

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
