### PR TITLE
Added eta>2.5 for eta and phi resolution

### DIFF
--- a/include/KLFitter/DetectorAtlas_CrystalBall.h
+++ b/include/KLFitter/DetectorAtlas_CrystalBall.h
@@ -143,6 +143,7 @@ class DetectorAtlas_CrystalBall : public DetectorBase {
   std::unique_ptr<ResolutionBase> m_res_energy_gluon_jet_eta2;
   std::unique_ptr<ResolutionBase> m_res_energy_gluon_jet_eta3;
   std::unique_ptr<ResolutionBase> m_res_energy_gluon_jet_eta4;
+  std::unique_ptr<ResolutionBase> m_res_energy_gluon_jet_eta5;
 
   /// The energy resolution of electrons for different eta regions.
   std::unique_ptr<ResolutionBase> m_res_energy_electron_eta1;
@@ -166,24 +167,28 @@ class DetectorAtlas_CrystalBall : public DetectorBase {
   std::unique_ptr<ResolutionBase> m_res_eta_light_jet_eta2;
   std::unique_ptr<ResolutionBase> m_res_eta_light_jet_eta3;
   std::unique_ptr<ResolutionBase> m_res_eta_light_jet_eta4;
+  std::unique_ptr<ResolutionBase> m_res_eta_light_jet_eta5;
 
   /// The eta resolution of b jets for different eta regions.
   std::unique_ptr<ResolutionBase> m_res_eta_bjet_eta1;
   std::unique_ptr<ResolutionBase> m_res_eta_bjet_eta2;
   std::unique_ptr<ResolutionBase> m_res_eta_bjet_eta3;
   std::unique_ptr<ResolutionBase> m_res_eta_bjet_eta4;
+  std::unique_ptr<ResolutionBase> m_res_eta_bjet_eta5;
 
   /// The phi resolution of light jets for different eta regions.
   std::unique_ptr<ResolutionBase> m_res_phi_light_jet_eta1;
   std::unique_ptr<ResolutionBase> m_res_phi_light_jet_eta2;
   std::unique_ptr<ResolutionBase> m_res_phi_light_jet_eta3;
   std::unique_ptr<ResolutionBase> m_res_phi_light_jet_eta4;
+  std::unique_ptr<ResolutionBase> m_res_phi_light_jet_eta5;
 
   /// The phi resolution of b jets for different eta regions.
   std::unique_ptr<ResolutionBase> m_res_phi_bjet_eta1;
   std::unique_ptr<ResolutionBase> m_res_phi_bjet_eta2;
   std::unique_ptr<ResolutionBase> m_res_phi_bjet_eta3;
   std::unique_ptr<ResolutionBase> m_res_phi_bjet_eta4;
+  std::unique_ptr<ResolutionBase> m_res_phi_bjet_eta5;
 
   /// Missing ET resolution in x and y
   std::unique_ptr<ResolutionBase> m_res_missing_ET;

--- a/src/DetectorAtlas_CrystalBall.cxx
+++ b/src/DetectorAtlas_CrystalBall.cxx
@@ -51,6 +51,7 @@ DetectorAtlas_CrystalBall::DetectorAtlas_CrystalBall(std::string folder) : Detec
   m_res_energy_gluon_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_gluon_eta2.txt", folder.c_str())});
   m_res_energy_gluon_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_gluon_eta3.txt", folder.c_str())});
   m_res_energy_gluon_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_gluon_eta4.txt", folder.c_str())});
+  m_res_energy_gluon_jet_eta5 = std::unique_ptr<ResolutionBase>(new ResCrystalBallJets{Form("%s/par_energy_gluon_eta5.txt", folder.c_str())});
 
   m_res_energy_electron_eta1 = std::unique_ptr<ResolutionBase>(new ResSingleGaussE{Form("%s/par_energy_Electrons_eta1.txt", folder.c_str())});
   m_res_energy_electron_eta2 = std::unique_ptr<ResolutionBase>(new ResSingleGaussE{Form("%s/par_energy_Electrons_eta2.txt", folder.c_str())});
@@ -71,22 +72,26 @@ DetectorAtlas_CrystalBall::DetectorAtlas_CrystalBall(std::string folder) : Detec
   m_res_eta_light_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta2.txt", folder.c_str())});
   m_res_eta_light_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta3.txt", folder.c_str())});
   m_res_eta_light_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta4.txt", folder.c_str())});
+  m_res_eta_light_jet_eta5 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_lJets_eta5.txt", folder.c_str())});
 
   m_res_eta_bjet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta1.txt", folder.c_str())});
   m_res_eta_bjet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta2.txt", folder.c_str())});
   m_res_eta_bjet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta3.txt", folder.c_str())});
   m_res_eta_bjet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta4.txt", folder.c_str())});
+  m_res_eta_bjet_eta5 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_eta_bJets_eta5.txt", folder.c_str())});
 
   // phi resolution
   m_res_phi_light_jet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta1.txt", folder.c_str())});
   m_res_phi_light_jet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta2.txt", folder.c_str())});
   m_res_phi_light_jet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta3.txt", folder.c_str())});
   m_res_phi_light_jet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta4.txt", folder.c_str())});
+  m_res_phi_light_jet_eta5 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_lJets_eta5.txt", folder.c_str())});
 
   m_res_phi_bjet_eta1 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta1.txt", folder.c_str())});
   m_res_phi_bjet_eta2 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta2.txt", folder.c_str())});
   m_res_phi_bjet_eta3 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta3.txt", folder.c_str())});
   m_res_phi_bjet_eta4 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta4.txt", folder.c_str())});
+  m_res_phi_bjet_eta5 = std::unique_ptr<ResolutionBase>(new ResGauss{Form("%s/par_phi_bJets_eta5.txt", folder.c_str())});
 
   m_res_missing_ET = std::unique_ptr<ResolutionBase>(new ResSingleGaussMET{Form("%s/par_misset.txt", folder.c_str())});
 }


### PR DESCRIPTION
Now we provide eta and phi parametrization for eta > 2.5 jets
 
## Description
Added support for DetectorAtlass_CrystalBall class for eta and phi parameters for jets with eta > 2.5

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
