### PR TITLE
Always set the higgs mass as a parameter

### DIFF
--- a/src/LikelihoodTTHLeptonJets.cxx
+++ b/src/LikelihoodTTHLeptonJets.cxx
@@ -193,7 +193,7 @@ void KLFitter::LikelihoodTTHLeptonJets::DefineParameters() {
   AddParameter("top mass",              100.0, 1000.0);                              // parTopM
   AddParameter("energy Higgs b quark 1",  fPhysicsConstants.MassBottom(), 1000.0);  // parBHiggs1E
   AddParameter("energy Higgs b quark 2",  fPhysicsConstants.MassBottom(), 1000.0);  // parBHiggs2E
-  if (fFlagHiggsMassFixed)  AddParameter("Higgs mass",              100.0, 1000.0);  // parHiggsM
+  AddParameter("Higgs mass",              100.0, 1000.0);  // parHiggsM
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
We need to always set the parameter as the if condition never succeed…s because the flag is setonly after the method is called

## Description

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
