### PR TITLE
Add counter of removed group permutations and decrement index

### DIFF
--- a/src/Permutations.cxx
+++ b/src/Permutations.cxx
@@ -437,6 +437,10 @@ int KLFitter::Permutations::InvariantParticleGroupPermutations(KLFitter::Particl
     // get permutation
     const std::vector<int> permutation1 = fPermutationTable[iperm1];
 
+    // Count numbers of removed permutations to adjust the index for the
+    // for-loop over permutation 1.
+    unsigned int removed_perms = 0;
+
     for (int iperm2 = iperm1-1; iperm2 >= 0; --iperm2) {
       // get second permutation
       const std::vector<int> permutation2 = fPermutationTable[iperm2];
@@ -457,8 +461,14 @@ int KLFitter::Permutations::InvariantParticleGroupPermutations(KLFitter::Particl
         fPermutationTable.erase(fPermutationTable.begin() + iperm2);
 
         fParticlesTable.erase(fParticlesTable.begin() + iperm2);
+
+        removed_perms++;
       }
     }  // second permutation
+
+    // Decrement the first permutation index by the number of removed
+    // permutations, otherwise we might go out of scope..
+    iperm1 -= removed_perms;
   }  // first permutation
 
   // return error code


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes a bug with the removal of group permutations, where more than one
removal candidates are found for one permutation. In this case, the index of the
reference permutation needs to be decremented accordingly, otherwise it goes out
of scope.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug related to the group removal of permutations – unfortunately this never showed up until someone started using the all-hadronic likelihood with two or more extra jets.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
