### PR TITLE
Remove constexpr specifier from expressions with std library

### DIFF
--- a/include/KLFitter/ResSingleGaussBase.h
+++ b/include/KLFitter/ResSingleGaussBase.h
@@ -64,7 +64,7 @@ class ResSingleGaussBase : public ResolutionBase {
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma(double x) = 0;
+  virtual double GetSigma(double x) override = 0;
 
   /**
     * Return the probability of the true value of x given the

--- a/include/KLFitter/ResSingleGaussLinearBase.h
+++ b/include/KLFitter/ResSingleGaussLinearBase.h
@@ -77,7 +77,7 @@ class ResSingleGaussLinearBase : public ResolutionBase {
     * @param x The value of x.
     * @return The width.
     */
-  virtual double GetSigma(double x) = 0;
+  virtual double GetSigma(double x) override = 0;
 
   /**
     * Return the probability of the true value of x given the

--- a/src/ResCrystalBallBase.cxx
+++ b/src/ResCrystalBallBase.cxx
@@ -47,8 +47,8 @@ KLFitter::ResCrystalBallBase::~ResCrystalBallBase() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResCrystalBallBase::logp(double x, double xmeas, bool *good, double /*par*/) {
-  static constexpr double overSqrt2 = 1./std::sqrt(2.);
-  static constexpr double sqrtPiHalf = std::sqrt(M_PI/2.);
+  static const double overSqrt2 = 1./std::sqrt(2.);
+  static const double sqrtPiHalf = std::sqrt(M_PI/2.);
 
   double alpha = GetAlpha(x);
   double n = GetN(x);

--- a/src/ResGauss.cxx
+++ b/src/ResGauss.cxx
@@ -45,7 +45,7 @@ double KLFitter::ResGauss::GetSigma(double /*par*/) {
 
 // ---------------------------------------------------------
 double KLFitter::ResGauss::logp(double x, double xmeas, bool *good, double /*par*/) {
-  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
+  static const double logSqrtTwoPi = 0.5*std::log(2*M_PI);
 
   const double sigma = GetSigma(x);
   *good = true;

--- a/src/ResGaussE.cxx
+++ b/src/ResGaussE.cxx
@@ -45,7 +45,7 @@ double KLFitter::ResGaussE::GetSigma(double par) {
 
 // ---------------------------------------------------------
 double KLFitter::ResGaussE::logp(double x, double xmeas, bool *good, double /*par*/) {
-  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
+  static const double logSqrtTwoPi = 0.5*std::log(2*M_PI);
 
   *good = true;
   double sigma = GetSigma(x);

--- a/src/ResGaussPt.cxx
+++ b/src/ResGaussPt.cxx
@@ -48,7 +48,7 @@ double KLFitter::ResGaussPt::GetSigma(double par) {
 
 // ---------------------------------------------------------
 double KLFitter::ResGaussPt::logp(double x, double xmeas, bool *good, double /*par*/) {
-  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
+  static const double logSqrtTwoPi = 0.5*std::log(2*M_PI);
 
   *good = true;
   double sigma = GetSigma(x);

--- a/src/ResGauss_MET.cxx
+++ b/src/ResGauss_MET.cxx
@@ -48,7 +48,7 @@ double KLFitter::ResGauss_MET::GetSigma(double sumet) {
 
 // ---------------------------------------------------------
 double KLFitter::ResGauss_MET::logp(double x, double xmeas, bool *good, double sumet) {
-  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
+  static const double logSqrtTwoPi = 0.5*std::log(2*M_PI);
 
   *good = true;
   // calculate MET TF with 4 parameters (MC10b or later)

--- a/src/ResSingleGaussBase.cxx
+++ b/src/ResSingleGaussBase.cxx
@@ -44,7 +44,7 @@ KLFitter::ResSingleGaussBase::~ResSingleGaussBase() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResSingleGaussBase::logp(double x, double xmeas, bool *good, double /*par*/) {
-  static constexpr double logSquareTwoPi = 0.5*std::log(2*M_PI);
+  static const double logSquareTwoPi = 0.5*std::log(2*M_PI);
 
   double mean = GetMean(x);
   double sigma = GetSigma(x);

--- a/src/ResSingleGaussLinearBase.cxx
+++ b/src/ResSingleGaussLinearBase.cxx
@@ -44,7 +44,7 @@ KLFitter::ResSingleGaussLinearBase::~ResSingleGaussLinearBase() = default;
 
 // ---------------------------------------------------------
 double KLFitter::ResSingleGaussLinearBase::logp(double x, double xmeas, bool *good, double /*par*/) {
-  static constexpr double logSqrtTwoPi = 0.5*std::log(2*M_PI);
+  static const double logSqrtTwoPi = 0.5*std::log(2*M_PI);
 
   double sigma = GetSigma(x);
   // sanity checks for p2, p3 and p5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For some reason, these expressions never caused problems on machines that we
built KLFitter on. But when using clang on mac, the compiler gives errors for
these expressions as functions, such as std::sqrt(), are not const expressinos
themselves. To follow c++ standards, we now converted all of these expressions
into `const` only.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
KLFitter build failed on mac/clang systems, because the code did not follow ISO c++.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
