### PR TITLE
Add missing include for ROOT 6.24 compatibility

### DIFF
--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -22,6 +22,7 @@
 #include <iostream>
 
 #include "TLorentzVector.h"
+#include "TString.h"
 
 namespace KLFitter {
 // ---------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
KLFitter doesn't compile (probably due to cleaned up includes?) with the latest ROOT version 6.24. Missing includes in the KLFitter code were now added that fix the problem.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As discovered in https://gitlab.cern.ch/atlas/atlasexternals/-/merge_requests/839.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
