### PR TITLE
patching BAT 0.9.4.1 for working with c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ include( CTest )
 # Set up the "C++ version" to use.
 set( CMAKE_CXX_STANDARD_REQUIRED 11 CACHE STRING
    "Minimum C++ standard required for the build" )
-set( CMAKE_CXX_STANDARD 14 CACHE STRING
+set( CMAKE_CXX_STANDARD 17 CACHE STRING
    "C++ standard to use for the build" )
 set( CMAKE_CXX_EXTENSIONS FALSE CACHE BOOL
    "(Dis)allow using compiler extensions" )
@@ -76,6 +76,7 @@ if( BUILTIN_BAT )
     URL "https://github.com/bat/bat/releases/download/v0.9.4.1/BAT-0.9.4.1.tar.gz"
     URL_HASH SHA256=D46C6F834CB5888BBF4DB393887190380132FA48816E0804F79C4A3CC344EF87
     BUILD_IN_SOURCE 1
+    PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/cpp17_patch_v0_9_4_1.patch
     CONFIGURE_COMMAND <SOURCE_DIR>/configure --with-rootsys=${ROOTSYS} --prefix=${_buildDir} --enable-silent-rules
     BUILD_COMMAND make LIBTOOLFLAGS=--silent
     INSTALL_COMMAND make install LIBTOOLFLAGS=--silent

--- a/patches/cpp17_patch_v0_9_4_1.patch
+++ b/patches/cpp17_patch_v0_9_4_1.patch
@@ -1,0 +1,74 @@
+diff --git a/BAT/BCMath.h b/BAT/BCMath.h
+index 2b743e1..47dffa6 100644
+--- a/BAT/BCMath.h
++++ b/BAT/BCMath.h
+@@ -215,7 +215,7 @@ namespace BCMath
+ 	 * @return R-value
+ 	 */
+ 	double Rvalue(const std::vector<double> & chain_means, const std::vector<double> & chain_variances,
+-                  const unsigned & chain_length, const bool & strict = true) throw (std::invalid_argument, std::domain_error);
++                  const unsigned & chain_length, const bool & strict = true) ;//throw (std::invalid_argument, std::domain_error);
+ 
+    /** \name p value methods */
+    /** @{ */
+@@ -228,7 +228,7 @@ namespace BCMath
+ 	 * @param nobservations The number of data points.
+ 	 * @return corrected p value
+ 	 */
+-	double CorrectPValue(const double & pvalue, const unsigned & npar, const unsigned & nobservations) throw (std::domain_error);
++	double CorrectPValue(const double & pvalue, const unsigned & npar, const unsigned & nobservations) ;//throw (std::domain_error);
+ 
+ 	/**
+ 	 * Calculate the p value using fast MCMC for a histogram and the likelihood as test statistic.
+@@ -241,7 +241,7 @@ namespace BCMath
+ 	 * @return The p value
+ 	 */
+ 	double FastPValue(const std::vector<unsigned> & observed, const std::vector<double> & expected,
+-	                  unsigned nIterations = 1e5, unsigned seed = 0) throw (std::invalid_argument);
++	                  unsigned nIterations = 1e5, unsigned seed = 0) ;//throw (std::invalid_argument);
+ 
+ 	/** @} */
+ }
+diff --git a/models/mvc/BCMVCombination.cxx b/models/mvc/BCMVCombination.cxx
+index 59fb72d..b517b0b 100644
+--- a/models/mvc/BCMVCombination.cxx
++++ b/models/mvc/BCMVCombination.cxx
+@@ -18,6 +18,7 @@
+ #include "../../BAT/BCMath.h"
+ #include "../../BAT/BCParameter.h"
+ 
++#include <TString.h>
+ #include <fstream>
+ #include <iomanip>
+ #include <iostream>
+diff --git a/src/BCMath.cxx b/src/BCMath.cxx
+index 0a89f67..7afb27a 100644
+--- a/src/BCMath.cxx
++++ b/src/BCMath.cxx
+@@ -549,7 +549,7 @@ double longestRunFrequency(unsigned longestObserved, unsigned int nTrials)
+ 
+ // ---------------------------------------------------------
+ double Rvalue(const std::vector<double> & chain_means, const std::vector<double> & chain_variances,
+-              const unsigned & chain_length, const bool & strict)  throw (std::invalid_argument, std::domain_error)
++              const unsigned & chain_length, const bool & strict)  //throw (std::invalid_argument, std::domain_error)
+ {
+    if (chain_means.size() != chain_variances.size())
+       throw std::invalid_argument("BCMath::RValue: chain means and chain variances are not aligned!");
+@@ -662,7 +662,7 @@ double Rvalue(const std::vector<double> & chain_means, const std::vector<double>
+ }
+ 
+ // ---------------------------------------------------------
+-double CorrectPValue(const double & pvalue, const unsigned & npar, const unsigned & nobservations) throw (std::domain_error)
++double CorrectPValue(const double & pvalue, const unsigned & npar, const unsigned & nobservations) //throw (std::domain_error)
+ {
+    // avoid pathologies
+    if (pvalue < 0 or pvalue > 1)
+@@ -688,7 +688,7 @@ double CorrectPValue(const double & pvalue, const unsigned & npar, const unsigne
+ 
+ // ---------------------------------------------------------
+ double FastPValue(const std::vector<unsigned> & observed, const std::vector<double> & expected,
+-                  unsigned nIterations, unsigned seed) throw (std::invalid_argument)
++                  unsigned nIterations, unsigned seed) //throw (std::invalid_argument)
+ {
+    size_t nbins = observed.size();
+    if (nbins != expected.size())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This MR adds patch files to modify minor parts of the BAT 0.9.4.1 code in order to make it compatible with latest ROOT and C++17 standard. 

The changes are fairly minor, but they ensure KLFitter compiles with ROOT > 6.24. 

## Related Issue

None

## Motivation and Context

At the moment the code will fail at compile time without these patches.

Ideally one would want to migrate to use BAT > 1.0.0 to get the c++17 compatibility, but I understand this project is no longer maintained, so the patch will be sufficient. 

## How Has This Been Tested?

This was tested by simply following compilation instructions from the README.

Without the changes, the compilation will fail -- with the changes it will succeed. 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
